### PR TITLE
OCMUI-2650: rename trunk references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ specially used CLI options, the user-flow, and so on -->
 
 # Review process
 
-Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).
+Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).
 
 ## QE Reviewer
 

--- a/.github/workflows/check_api_pipeline.yml
+++ b/.github/workflows/check_api_pipeline.yml
@@ -15,7 +15,7 @@ on:
 env:
   NODE_VERSION: ${{ github.event.inputs.node-version || '22.x' }}
   SWAP_BRANCH_NAME: ${{ github.event.inputs.swap-branch-name || 'openapi' }}
-  BASE_BRANCH_NAME: ${{ github.ref_name || 'master' }}
+  BASE_BRANCH_NAME: ${{ github.ref_name || 'main' }}
 
 jobs:
   check_api:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   install:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   install:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,13 +22,13 @@ variables:
 stages:
   - sync
 
-📦 Sync master branch:
+📦 Sync main branch:
   <<: *sync-default
   stage: sync
   rules:
     - if: $JOB_ID == "sync"
   script:
-    - git clone -b master https://$GITHUB_TOKEN@github.com/RedHatInsights/uhc-portal uhc-portal
+    - git clone -b main https://$GITHUB_TOKEN@github.com/RedHatInsights/uhc-portal uhc-portal
     - cd uhc-portal
     - git remote add gitlab https://GITLAB_SYNC_TOKEN:$GITLAB_SYNC_TOKEN@gitlab.cee.redhat.com/service/uhc-portal
     - git push gitlab master --force

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ By default, UI run Assisted Installer without standalone mode. To run with Assis
 
 | uhc-portal branch            | deployed env                                            | insights-chrome | default backend |
 |------------------------------| ------------------------------------------------------- | --------------- | --------------- |
-| `master`                     | https://console.dev.redhat.com/openshift                | stable version  | staging         |
-| `master` (specific revision) | https://console.redhat.com/openshift                    | stable version  | production      |
+| `main`                       | https://console.dev.redhat.com/openshift                | stable version  | staging         |
+| `main` (specific revision) | https://console.redhat.com/openshift                    | stable version  | production      |
 
 
 ## Issues/Troubleshooting

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -17,7 +17,7 @@
 
 # -----------------------------------------------------------------
 # This script is executed by a Jenkins job upon merge to any of the
-# long-lived deployment branches (i.e. master).
+# long-lived deployment branches (i.e. 'main').
 # If it doesn't succeed the change won't be deployed.
 # -----------------------------------------------------------------
 

--- a/docs/pull-request-process.md
+++ b/docs/pull-request-process.md
@@ -45,7 +45,7 @@ Here is the process to move a PR from draft to merged:
 
 1. :notebook: QE reviewer approves the PR once they feel the PR is production-ready
 
-1. :pencil2: Author pulls in changes from master if needed and waits for all checks/tests to pass
+1. :pencil2: Author pulls in changes from 'main' if needed and waits for all checks/tests to pass
 
 1. :pencil2: Author merges the PR using the "squash commits" button once there are 3 approvals (2 developer and 1 QE)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,8 @@
 # :cookie: Release to Production
 
-1. #### Pick the latest commit hash that can be released to Prod from master
+1. #### Pick the latest commit hash that can be released to Prod from 'main'
 
-   Go to https://github.com/RedHatInsights/uhc-portal/commits/master/
+   Go to https://github.com/RedHatInsights/uhc-portal/commits/main/
 
    Look at commits and pick the last commit that has all pipelines passed. Click on the "copy full SHA" for the commit you chose, and save it for later use.
 

--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -251,7 +251,7 @@ Ideally, tests will be written and coded before making changes to the actual app
 it.todo('displays “Hello Kim” when “Kim” is sent as a prop on initial render');
 ```
 
-These todo tests should be checked into git if there is a need to merge the code to master before the tests are done.
+These todo tests should be checked into git if there is a need to merge the code to 'main' before the tests are done.
 
 ## Skip tests that are producing unexpected results
 

--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "prettier:fix": "prettier --write '{src,cypress,scripts}/**/*.{js,ts,mjs,jsx,tsx}' 'run/*js'",
     "test-no-coverage": "TZ=America/New_York LC_ALL=en_US.utf8 node --no-compilation-cache --expose-gc ./node_modules/.bin/jest --logHeapUsage  ",
     "test": "yarn test-no-coverage --coverage ",
-    "test-changes": "yarn test --changedSince=master",
+    "test-changes": "yarn test --changedSince=main",
     "test-changes-with-enforcement": "yarn test-changes --coverageThreshold='{\"global\":{\"statements\":\"80\"}}'",
     "test-local": "yarn test --maxWorkers=50%",
     "test-no-cache": "yarn test --no-cache",


### PR DESCRIPTION
# Summary

update any occurrences of 'master' branch in the source code to 'main', before renaming the repository default-branch.

# Jira

addresses [OCMUI-2650][2]

# Additional information

these changes are depended upon for updating build & deployment config' @ app-interface (see [!151786][1]).

after this PR is merged, the default-branch can be renamed via GH web UI, and then the app-interface MR will pass validation and could be merged, too.

at this stage there are no active contributors yet, so no disruption will be caused by this rename.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).



[1]: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/151786
[2]: https://issues.redhat.com/browse/OCMUI-2650