### PR TITLE
OCMUI-3476: fix delete-cluster dialog not showing operation-ID on errors

### DIFF
--- a/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.test.tsx
+++ b/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.test.tsx
@@ -6,13 +6,10 @@ import { checkAccessibility, screen, withState } from '~/testUtils';
 
 import DeleteClusterDialog from './DeleteClusterDialog';
 
-jest.mock('react-redux', () => {
-  const config = {
-    __esModule: true,
-    ...jest.requireActual('react-redux'),
-  };
-  return config;
-});
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-redux'),
+}));
 
 const mockedUseDeleteCluster = jest.spyOn(useDeleteCluster, 'useDeleteCluster');
 
@@ -113,7 +110,7 @@ describe('<DeleteClusterDialog />', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).not.toHaveAttribute('aria-disabled');
   });
 
-  it('closes the modal on success', async () => {
+  it('closes the modal on success', () => {
     const newUseDeleteClusterResponse = { ...defaultUseDeleteClusterResponse, isSuccess: true };
 
     mockedUseDeleteCluster.mockReturnValue(newUseDeleteClusterResponse);
@@ -127,18 +124,33 @@ describe('<DeleteClusterDialog />', () => {
     expect(onClose).toHaveBeenCalledWith(true);
   });
 
-  it('displays an error', async () => {
+  it('displays an error', () => {
     const newUseDeleteClusterResponse = {
       ...defaultUseDeleteClusterResponse,
       isError: true,
       error: { errorMessage: 'Mocked error message' },
     };
 
-    // @ts-ignore
     mockedUseDeleteCluster.mockReturnValue(newUseDeleteClusterResponse);
-    checkForNoCalls();
     withState(defaultReduxState).render(<DeleteClusterDialog {...defaultProps} />);
+
     expect(screen.getByTestId('alert-error')).toBeInTheDocument();
     expect(screen.getByText('Mocked error message')).toBeInTheDocument();
+  });
+
+  it('displays error operation id', () => {
+    const newUseDeleteClusterResponse = {
+      ...defaultUseDeleteClusterResponse,
+      isError: true,
+      error: {
+        errorMessage: 'Mocked error message',
+        operationID: 'operation-id-123456789',
+      },
+    };
+
+    mockedUseDeleteCluster.mockReturnValue(newUseDeleteClusterResponse);
+    withState(defaultReduxState).render(<DeleteClusterDialog {...defaultProps} />);
+
+    expect(screen.getByText(/operation-id-123456789/)).toBeInTheDocument();
   });
 });

--- a/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.tsx
+++ b/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.tsx
@@ -7,11 +7,11 @@ import { closeModal } from '~/components/common/Modal/ModalActions';
 import { useDeleteCluster } from '~/queries/ClusterActionsQueries/useDeleteCluster';
 import { useGlobalState } from '~/redux/hooks';
 
-import ErroBox from '../../../common/ErrorBox';
+import ErrorBox from '../../../common/ErrorBox';
 import Modal from '../../../common/Modal/Modal';
 import modals from '../../../common/Modal/modals';
 
-type DeleteCusterDialogProps = {
+type DeleteClusterDialogProps = {
   onClose: (clusterDeleted?: boolean) => void;
   textContent?: string;
   title?: string;
@@ -24,11 +24,7 @@ type ModalData = {
   region: string | undefined;
 };
 
-type ErrorType = {
-  errorMessage?: string | undefined;
-};
-
-const DeleteClusterDialog = ({ onClose, textContent, title }: DeleteCusterDialogProps) => {
+const DeleteClusterDialog = ({ onClose, textContent, title }: DeleteClusterDialogProps) => {
   const [clusterNameInput, setClusterNameInput] = React.useState<string>('');
   const modalData = useGlobalState((state) => state.modal.data) as ModalData;
 
@@ -49,7 +45,7 @@ const DeleteClusterDialog = ({ onClose, textContent, title }: DeleteCusterDialog
     reset: resetResponse,
   } = useDeleteCluster();
 
-  const error = deleteClusterError as ErrorType;
+  const error = deleteClusterError;
 
   if (isSuccess) {
     resetResponse();
@@ -63,10 +59,11 @@ const DeleteClusterDialog = ({ onClose, textContent, title }: DeleteCusterDialog
   };
 
   const errorContainer = isError && (
-    <ErroBox
+    <ErrorBox
       message="Error deleting cluster"
       response={{
         errorMessage: error.errorMessage,
+        operationID: error.operationID,
       }}
     />
   );


### PR DESCRIPTION
> [!note]
> ported from [uhc-portal-internal-archive #498][1]


# Summary

fixes operation-ID shown as `N/A` in case of an error during cluster deletion.


# Jira

fixes [OCMUI-3476](https://issues.redhat.com/browse/OCMUI-3476)


# Additional information

### changes

##### delete-cluster dialog module

- 🎯 pass `operationID` from the cluster-delete error response to the modal's error-box
- 🎯 remove the local `ErrorType` type (too restrictive, duplicates the existing `ErrorState` type)
- 🧹 fix typo: `ErroBox` --> `ErrorBox`
- 🧹 fix typo: `DeleteCusterDialogProps` --> `DeleteClusterDialogProps`


##### unit test

- 🎯 add test-case for checking an error's operation ID is displayed
- 🧹 remove redundant assertions: no use in verifying no function calls were made before the test's 'act' phase, when no equivalent checks are made after the 'act' phase
- 🧹 remove redundant `async` modifiers
- 🧹 remove redundant variable declaration (`config`) and inline function body
- 🧹 remove obsolete ts-ignore comments

<br/>

> [!note]
> _🎯 : on-topic / critical-path / must-have_
> _🧹 : off-topic / refactor / nice to have_



# How to Test

QE didn't provide any E2E test-flow.

i couldn't find an easy way to test or mock it E2E; i tried:

- mocking it in the browser via various dev-tools.  neither content-overrides nor headers-overrides could successfully mock responses from a `DELETE`-method request.  request-blocking also didn't do the trick
- mocking it via our mockserver, to no avail; delete requests just silently fail
- writing up a storybook story for the delete-cluster modal.  had some success but ultimately had too much problems around setting up multiple new use-cases our storybook setup still doesn't support (e.g. state management, global build-time env-vars, global test-framework variables...)


guess we just have to rely on unit-tests  🤷 

...

well i guess it's possible to do some hacky A/B testing via local source, but i don't like it!

1. check out the PR
1. run the test - _DeleteClusterDialog.test.tsx_, and verify it passes
1. comment out the newly added line (no. 66) in _DeleteClusterDialog.tsx_ -
`operationID: error.operationID,`
1. re-run the test and see the new test-case (_"displays error operation id"_) fail


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation



[1]: https://github.com/RedHatInsights/uhc-portal-internal-archive/pull/498