### PR TITLE
OCMUI-845: Add claim group to the OpenID form

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/IdentityProvidersHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/IdentityProvidersHelper.ts
@@ -205,6 +205,7 @@ const getCreateIDPRequestData = (formData: IDPFormDataType) => {
       email: formData.openid_email,
       name: formData.openid_name,
       preferred_username: formData.openid_preferred_username,
+      groups: formData.openid_claim_groups,
     },
     client_id: formData.client_id.trim(),
     client_secret: formData.client_secret.trim(),
@@ -282,6 +283,11 @@ const getOpenIdClaims = (
         return claimsToIterate.map((openid_preferred_username, id: number) => ({
           id,
           openid_preferred_username,
+        }));
+      case 'groups':
+        return claimsToIterate.map((openid_claim_groups, id: number) => ({
+          id,
+          openid_claim_groups,
         }));
       default: {
         break;
@@ -390,6 +396,7 @@ const getInitialValuesForEditing = (idpEdited: IdentityProvider, editedType: IDP
         openid_name: idpEdited[editedType]?.claims?.name,
         openid_email: idpEdited[editedType]?.claims?.email,
         openid_preferred_username: idpEdited[editedType]?.claims?.preferred_username,
+        openid_claim_groups: idpEdited[editedType]?.claims?.groups,
         openid_extra_scopes: idpEdited[editedType]?.extra_scopes
           ? idpEdited[editedType]?.extra_scopes?.join()
           : '',

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/__tests__/IdentityProvidersHelper.fixtures.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/__tests__/IdentityProvidersHelper.fixtures.ts
@@ -113,6 +113,10 @@ export const openIdFormData = {
     { openid_preferred_username: 'openid_preferred_usernameA' },
     { openid_preferred_username: 'openid_preferred_usernameB' },
   ],
+  openid_claim_groups: [
+    { openid_claim_groups: 'openid_claim_groupsA' },
+    { openid_claim_groups: 'openid_claim_groupsB' },
+  ],
   openid_extra_scopes: 'openid_extra_scopes',
   issuer: 'issuer',
   hostname: 'hostname',
@@ -133,6 +137,10 @@ export const openIdFormDataExpected = {
         { openid_preferred_username: 'openid_preferred_usernameA' },
         { openid_preferred_username: 'openid_preferred_usernameB' },
       ],
+      groups: [
+        { openid_claim_groups: 'openid_claim_groupsA' },
+        { openid_claim_groups: 'openid_claim_groupsB' },
+      ],
     },
     client_id: 'client_id',
     client_secret: 'client_secret',
@@ -150,6 +158,10 @@ export const openIdTrimFormData = {
   openid_preferred_username: [
     { openid_preferred_username: 'openid_preferred_usernameA' },
     { openid_preferred_username: 'openid_preferred_usernameB' },
+  ],
+  openid_claim_groups: [
+    { openid_claim_groups: 'openid_claim_groupsA' },
+    { openid_claim_groups: 'openid_claim_groupsB' },
   ],
   openid_extra_scopes: 'openid_extra_scopes',
   issuer: 'issuer',
@@ -170,6 +182,10 @@ export const openIdTrimFormDataExpected = {
       preferred_username: [
         { openid_preferred_username: 'openid_preferred_usernameA' },
         { openid_preferred_username: 'openid_preferred_usernameB' },
+      ],
+      groups: [
+        { openid_claim_groups: 'openid_claim_groupsA' },
+        { openid_claim_groups: 'openid_claim_groupsB' },
       ],
     },
     client_id: 'client_id',
@@ -487,6 +503,7 @@ export const providersFixtures: IdentityProvider[] = [
         email: ['email1'],
         name: ['name 1'],
         preferred_username: ['test122'],
+        groups: ['group1'],
       },
       client_id: 'test',
       issuer: 'https://example.com',
@@ -565,6 +582,7 @@ export const providersExpectedFormData = [
     openid_extra_scopes: '',
     openid_name: ['name 1'],
     openid_preferred_username: ['test122'],
+    openid_claim_groups: ['group1'],
     selectedIDP: 'OpenIDIdentityProvider',
     type: 'OpenIDIdentityProvider',
   },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/IdentityProvidersPageFormikHelpers.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/IdentityProvidersPageFormikHelpers.ts
@@ -3,6 +3,26 @@ import * as Yup from 'yup';
 import { FieldId } from '../constants';
 import { IDPformValues, IDPTypeNames } from '../IdentityProvidersHelper';
 
+export const hasAtLeastOneOpenIdClaimField = (context: any): boolean => {
+  const {
+    [FieldId.OPENID_EMAIL]: openIdEmail,
+    [FieldId.OPENID_NAME]: openIdName,
+    [FieldId.OPENID_PREFFERED_USERNAME]: openIdPrerredName,
+    [FieldId.OPENID_CLAIM_GROUPS]: claimGroups,
+  } = context.parent || context || {};
+
+  const hasEmailValue =
+    openIdEmail?.some((val: string) => val !== undefined && val.trim() !== '') || false;
+  const hasNameValue =
+    openIdName?.some((val: string) => val !== undefined && val.trim() !== '') || false;
+  const hasUsernameValue =
+    openIdPrerredName?.some((val: string) => val !== undefined && val.trim() !== '') || false;
+  const hasGroupsValue =
+    claimGroups?.some((val: string) => val !== undefined && val.trim() !== '') || false;
+
+  return hasEmailValue || hasNameValue || hasUsernameValue || hasGroupsValue;
+};
+
 export const IdentityProvidersPageFormInitialValues = (selectedIDP: string) => {
   const defaultIDP = IDPformValues.GITHUB;
   switch (selectedIDP) {
@@ -36,9 +56,10 @@ export const IdentityProvidersPageFormInitialValues = (selectedIDP: string) => {
         [FieldId.CLIENT_SECRET]: '',
         [FieldId.ISSUER]: '',
         [FieldId.OPENID_CA]: '',
-        [FieldId.OPENID_EMAIL]: [''],
-        [FieldId.OPENID_NAME]: [''],
-        [FieldId.OPENID_PREFFERED_USERNAME]: [''],
+        [FieldId.OPENID_EMAIL]: null,
+        [FieldId.OPENID_NAME]: null,
+        [FieldId.OPENID_PREFFERED_USERNAME]: null,
+        [FieldId.OPENID_CLAIM_GROUPS]: null,
         [FieldId.OPENID_EXTRA_SCOPES]: '',
       };
     case 'LDAPIdentityProvider':
@@ -108,25 +129,44 @@ export const IdentityProvidersPageValidationSchema = (selectedIDP: string) => {
         [FieldId.HOSTED_DOMAIN]: Yup.string().required(),
       });
     case 'OpenIDIdentityProvider':
-      return Yup.object({
+      return Yup.object().shape({
         [FieldId.NAME]: Yup.string().required(),
         [FieldId.CLIENT_ID]: Yup.string().required('Field is required'),
         [FieldId.CLIENT_SECRET]: Yup.string().required('Field is required'),
         [FieldId.ISSUER]: Yup.string().required('Field is required'),
         [FieldId.OPENID_EMAIL]: Yup.array()
           .of(Yup.string())
-          .test('at-least-one-filled', 'At least one field must be filled', (value) =>
-            value?.some((val) => val !== undefined && val.trim() !== ''),
+          .test(
+            'at-least-one-filled',
+            'At least one claims mapping field must be entered',
+            (value, context) => hasAtLeastOneOpenIdClaimField(context),
           ),
         [FieldId.OPENID_NAME]: Yup.array()
           .of(Yup.string())
-          .test('at-least-one-filled', 'At least one field must be filled', (value) =>
-            value?.some((val) => val !== undefined && val.trim() !== ''),
+          .test(
+            'at-least-one-filled',
+            'At least one claims mapping field must be entered',
+            (value, context) => hasAtLeastOneOpenIdClaimField(context),
           ),
         [FieldId.OPENID_PREFFERED_USERNAME]: Yup.array()
           .of(Yup.string())
-          .test('at-least-one-filled', 'At least one field must be filled', (value) =>
-            value?.some((val) => val !== undefined && val.trim() !== ''),
+          .test(
+            'at-least-one-filled',
+            'At least one claims mapping field must be entered',
+            (value, context) => hasAtLeastOneOpenIdClaimField(context),
+          ),
+        [FieldId.OPENID_CLAIM_GROUPS]: Yup.array()
+          .of(Yup.string())
+          .test(
+            'group-name-restriction',
+            'Group label cannot be `cluster-admins` or `dedicated-admins`',
+            (value) =>
+              !value?.some((val) => val === 'cluster-admins' || val === 'dedicated-admins'),
+          )
+          .test(
+            'at-least-one-filled',
+            'At least one claims mapping field must be entered',
+            (value, context) => hasAtLeastOneOpenIdClaimField(context),
           ),
       });
     case 'LDAPIdentityProvider':

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/OpenIDFormRequired.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/OpenIDFormRequired.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field } from 'formik';
 import PropTypes from 'prop-types';
 
-import { GridItem } from '@patternfly/react-core';
+import { Alert, FormFieldGroup, FormSection, GridItem } from '@patternfly/react-core';
 
 import { useFormState } from '~/components/clusters/wizards/hooks';
 import { FormikFieldArray } from '~/components/common/FormikFormComponents/FormikFieldArray/FormikFieldArray';
@@ -10,23 +10,12 @@ import { FormikFieldArray } from '~/components/common/FormikFormComponents/Formi
 import { checkOpenIDIssuer } from '../../../../../../../common/validators';
 import ReduxVerticalFormGroup from '../../../../../../common/ReduxFormComponents_deprecated/ReduxVerticalFormGroup';
 import { FieldId } from '../../constants';
-import { isEmptyReduxArray } from '../../IdentityProvidersHelper';
+import { hasAtLeastOneOpenIdClaimField } from '../IdentityProvidersPageFormikHelpers';
 
 import IDPBasicFields from './IDPBasicFields';
 
 const OpenIDFormRequired = ({ isPending }) => {
-  const { getFieldProps, getFieldMeta, setFieldValue } = useFormState();
-
-  const validateFunc = (_, allValues) => {
-    if (
-      isEmptyReduxArray(allValues.openid_preferred_username, 'openid_preferred_username') &&
-      isEmptyReduxArray(allValues.openid_name, 'openid_name') &&
-      isEmptyReduxArray(allValues.openid_email, 'openid_email')
-    ) {
-      return 'At least one claim is required';
-    }
-    return undefined;
-  };
+  const { getFieldProps, getFieldMeta, setFieldValue, values } = useFormState();
 
   return (
     <>
@@ -48,39 +37,45 @@ const OpenIDFormRequired = ({ isPending }) => {
           helpText="The URL that the OpenID provider asserts as the issuer identifier. It must use the https scheme with no URL query parameters or fragment."
         />
       </GridItem>
-      <GridItem span={8}>
-        <h4>Claims mappings</h4>
-      </GridItem>
-      <FormikFieldArray
-        fieldID={FieldId.OPENID_EMAIL}
-        label="Email"
-        type="text"
-        placeHolderText="e.g. email"
-        disabled={isPending}
-        helpText="The list of attributes whose values should be used as the email address."
-        validate={validateFunc}
-        isRequired
-      />
-      <FormikFieldArray
-        fieldID={FieldId.OPENID_NAME}
-        label="Name"
-        type="text"
-        placeHolderText="e.g. name"
-        disabled={isPending}
-        validate={validateFunc}
-        helpText="The end user's full name including all name parts, ordered according to the end user's locale and preferences."
-        isRequired
-      />
-      <FormikFieldArray
-        fieldID={FieldId.OPENID_PREFFERED_USERNAME}
-        label="Preferred username"
-        type="text"
-        placeHolderText="e.g. preferred_username"
-        disabled={isPending}
-        validate={validateFunc}
-        helpText="Shorthand name by which the end user wishes to be referred to at the RP, such as janedone or j.doe."
-        isRequired
-      />
+      <FormSection title="Claim mappings *" titleElement="h2">
+        {!hasAtLeastOneOpenIdClaimField(values) && (
+          <Alert variant="danger" title="At least one claim field must be entered" />
+        )}
+        <FormFieldGroup>
+          <FormikFieldArray
+            fieldID={FieldId.OPENID_EMAIL}
+            label="Email"
+            type="text"
+            placeHolderText="e.g. email"
+            disabled={isPending}
+            helpText="The list of attributes whose values should be used as the email address."
+          />
+          <FormikFieldArray
+            fieldID={FieldId.OPENID_NAME}
+            label="Name"
+            type="text"
+            placeHolderText="e.g. name"
+            disabled={isPending}
+            helpText="The end user's full name including all name parts, ordered according to the end user's locale and preferences."
+          />
+          <FormikFieldArray
+            fieldID={FieldId.OPENID_PREFFERED_USERNAME}
+            label="Preferred username"
+            type="text"
+            placeHolderText="e.g. preferred_username"
+            disabled={isPending}
+            helpText="Shorthand name by which the end user wishes to be referred to at the RP, such as janedone or j.doe."
+          />
+          <FormikFieldArray
+            fieldID={FieldId.OPENID_CLAIM_GROUPS}
+            label="Groups"
+            type="text"
+            placeHolderText="e.g. dev-ops-admins"
+            disabled={isPending}
+            helpText="List of custom group labels"
+          />
+        </FormFieldGroup>
+      </FormSection>
     </>
   );
 };

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/OpenIDFormRequired.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/OpenIDFormRequired.test.tsx
@@ -1,0 +1,281 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import { checkOpenIDIssuer } from '~/common/validators';
+import { useFormState } from '~/components/clusters/wizards/hooks';
+import { checkAccessibility, render, screen } from '~/testUtils';
+
+import { FieldId } from '../../constants';
+import { hasAtLeastOneOpenIdClaimField } from '../IdentityProvidersPageFormikHelpers';
+
+import OpenIDFormRequired from './OpenIDFormRequired';
+
+// Mock external dependencies
+jest.mock('~/components/clusters/wizards/hooks', () => ({
+  useFormState: jest.fn(),
+}));
+
+jest.mock('~/common/validators', () => ({
+  checkOpenIDIssuer: jest.fn(),
+}));
+
+jest.mock('../IdentityProvidersPageFormikHelpers', () => ({
+  hasAtLeastOneOpenIdClaimField: jest.fn(),
+}));
+
+interface FormValues {
+  [key: string]: string | string[] | null;
+}
+
+interface MockFormState {
+  setFieldValue: jest.MockedFunction<(field: string, value: any) => void>;
+  getFieldProps: jest.MockedFunction<(field: string) => any>;
+  getFieldMeta: jest.MockedFunction<(field: string) => any>;
+  setFieldTouched: jest.MockedFunction<(field: string, touched?: boolean) => void>;
+  values: FormValues;
+  errors: { [key: string]: string };
+}
+
+interface ComponentProps {
+  isPending?: boolean;
+}
+
+describe('OpenIDFormRequired', () => {
+  const mockSetFieldValue = jest.fn<void, [string, any]>();
+  const mockGetFieldProps = jest.fn<any, [string]>();
+  const mockGetFieldMeta = jest.fn<any, [string]>();
+  const mockSetFieldTouched = jest.fn<void, [string, boolean?]>();
+  const mockHasAtLeastOneOpenIdClaimField = jest.fn<boolean, [any]>();
+
+  const defaultFormValues: FormValues = {
+    [FieldId.ISSUER]: '',
+    [FieldId.OPENID_EMAIL]: [''],
+    [FieldId.OPENID_NAME]: [''],
+    [FieldId.OPENID_PREFFERED_USERNAME]: [''],
+    [FieldId.OPENID_CLAIM_GROUPS]: [''],
+  };
+
+  const defaultFormState: MockFormState = {
+    setFieldValue: mockSetFieldValue,
+    getFieldProps: mockGetFieldProps,
+    getFieldMeta: mockGetFieldMeta,
+    setFieldTouched: mockSetFieldTouched,
+    values: defaultFormValues,
+    errors: {},
+  };
+
+  const initialFormValues: FormValues = {
+    [FieldId.ISSUER]: '',
+    [FieldId.OPENID_EMAIL]: [''],
+    [FieldId.OPENID_NAME]: [''],
+    [FieldId.OPENID_PREFFERED_USERNAME]: [''],
+    [FieldId.OPENID_CLAIM_GROUPS]: [''],
+  };
+
+  const buildTestComponent = (
+    formValues: Partial<FormValues> = {},
+    componentProps: ComponentProps = {},
+  ) => (
+    <Formik
+      initialValues={{
+        ...initialFormValues,
+        ...formValues,
+      }}
+      onSubmit={() => {}}
+    >
+      <OpenIDFormRequired {...componentProps} />
+    </Formik>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup default mock implementations
+    (useFormState as jest.Mock).mockReturnValue(defaultFormState);
+    mockGetFieldProps.mockImplementation((fieldId: string) => ({
+      name: fieldId,
+      value: '',
+      onChange: jest.fn(),
+      onBlur: jest.fn(),
+    }));
+    mockGetFieldMeta.mockImplementation((fieldId: string) => ({
+      touched: false,
+      error: '',
+    }));
+    (checkOpenIDIssuer as jest.Mock).mockReturnValue(undefined);
+    mockHasAtLeastOneOpenIdClaimField.mockReturnValue(true);
+    (hasAtLeastOneOpenIdClaimField as jest.Mock).mockImplementation(
+      mockHasAtLeastOneOpenIdClaimField,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('is accessible', async () => {
+      // Arrange
+      const { container } = render(buildTestComponent({}, { isPending: true }));
+
+      // Act & Assert
+      await checkAccessibility(container);
+    });
+
+    it('should render all required components with default props', () => {
+      // Act
+      render(buildTestComponent());
+
+      // Assert - IDPBasicFields component renders client ID and secret fields
+      expect(screen.getByLabelText('Client ID *')).toBeInTheDocument();
+      expect(screen.getByLabelText('Client secret *')).toBeInTheDocument();
+
+      // Assert - Issuer URL field
+      expect(screen.getByRole('textbox', { name: /Issuer URL/i })).toBeInTheDocument();
+      expect(
+        screen.getByText(/The URL that the OpenID provider asserts as the issuer identifier/),
+      ).toBeInTheDocument();
+
+      // Assert - Claim mappings section
+      expect(screen.getByText('Claim mappings *')).toBeInTheDocument();
+
+      // Assert - All FormikFieldArray components are rendered (4 field arrays with labels showing count)
+      expect(screen.getByText('Email (1)')).toBeInTheDocument();
+      expect(screen.getByText('Name (1)')).toBeInTheDocument();
+      expect(screen.getByText('Preferred username (1)')).toBeInTheDocument();
+      expect(screen.getByText('Groups (1)')).toBeInTheDocument();
+    });
+
+    it('should render issuer URL field with correct configuration', () => {
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      const issuerField = screen.getByRole('textbox', { name: /Issuer URL/i });
+      expect(issuerField).toBeInTheDocument();
+      expect(issuerField).toHaveAttribute('type', 'text');
+      expect(issuerField).not.toBeDisabled();
+      expect(
+        screen.getByText(/must use the https scheme with no URL query parameters/),
+      ).toBeInTheDocument();
+    });
+
+    it('should render all claim mapping fields with correct labels and placeholders', () => {
+      // Act
+      render(buildTestComponent());
+
+      // Assert - Email field
+      expect(screen.getByText('Email (1)')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. email 1')).toBeInTheDocument();
+      expect(
+        screen.getByText(/The list of attributes whose values should be used as the email address/),
+      ).toBeInTheDocument();
+
+      // Assert - Name field
+      expect(screen.getByText('Name (1)')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. name 1')).toBeInTheDocument();
+      expect(
+        screen.getByText(/The end user's full name including all name parts/),
+      ).toBeInTheDocument();
+
+      // Assert - Preferred username field
+      expect(screen.getByText('Preferred username (1)')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. preferred_username 1')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Shorthand name by which the end user wishes to be referred/),
+      ).toBeInTheDocument();
+
+      // Assert - Groups field
+      expect(screen.getByText('Groups (1)')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. dev-ops-admins 1')).toBeInTheDocument();
+      expect(screen.getByText('List of custom group labels')).toBeInTheDocument();
+    });
+
+    it('should show alert when no claim fields are filled', () => {
+      // Arrange
+      mockHasAtLeastOneOpenIdClaimField.mockReturnValue(false);
+
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      expect(screen.getByText('At least one claim field must be entered')).toBeInTheDocument();
+    });
+
+    it('should not show alert when at least one claim field is filled', () => {
+      // Arrange
+      mockHasAtLeastOneOpenIdClaimField.mockReturnValue(true);
+
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      expect(screen.queryByTestId('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Props Handling', () => {
+    it('should disable issuer field when isPending is true', () => {
+      // Act
+      render(buildTestComponent({}, { isPending: true }));
+
+      // Assert
+      const issuerField = screen.getByRole('textbox', { name: /Issuer URL/i });
+      expect(issuerField).toBeDisabled();
+    });
+
+    it('should disable input when isPending prop pass to FormikFieldArray components', () => {
+      // Act
+      render(buildTestComponent({}, { isPending: true }));
+
+      // Assert - FormikFieldArray doesn't actually support a disabled prop in its current implementation
+      // The disabled prop is passed but not used by the component, so inputs remain enabled
+      // This test documents the current behavior rather than the expected behavior
+      expect(screen.getByPlaceholderText('e.g. email 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. name 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. preferred_username 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. dev-ops-admins 1')).not.toBeDisabled();
+    });
+
+    it('should enable input when isPending prop is false by default', () => {
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      const issuerField = screen.getByRole('textbox', { name: /Issuer URL/i });
+      expect(issuerField).not.toBeDisabled();
+
+      // Assert - Check that the text inputs in the field arrays are enabled
+      expect(screen.getByPlaceholderText('e.g. email 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. name 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. preferred_username 1')).not.toBeDisabled();
+      expect(screen.getByPlaceholderText('e.g. dev-ops-admins 1')).not.toBeDisabled();
+    });
+  });
+
+  describe('Form Integration', () => {
+    it('should handle issuer field onChange correctly', () => {
+      // Arrange
+      mockGetFieldProps.mockImplementation(() => ({
+        name: FieldId.ISSUER,
+        value: '',
+        onChange: jest.fn(),
+        onBlur: jest.fn(),
+      }));
+
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      expect(mockSetFieldValue).toBeDefined();
+    });
+
+    it('should call hasAtLeastOneOpenIdClaimField with form values', () => {
+      // Act
+      render(buildTestComponent());
+
+      // Assert
+      expect(mockHasAtLeastOneOpenIdClaimField).toHaveBeenCalledWith(defaultFormValues);
+    });
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/__tests__/IdentityProvidersPageFormikHelpers.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/__tests__/IdentityProvidersPageFormikHelpers.test.ts
@@ -1,0 +1,290 @@
+import { FieldId } from '../../constants';
+import { hasAtLeastOneOpenIdClaimField } from '../IdentityProvidersPageFormikHelpers';
+
+describe('hasAtLeastOneOpenIdClaimField', () => {
+  // Test data fixtures
+  const createContext = (parentData: any) => ({
+    parent: parentData,
+  });
+
+  const emptyStringArray = [''];
+  const whitespaceArray = ['  ', '\t', '\n'];
+  const validStringArray = ['valid-value'];
+  const mixedArray = ['', 'valid-value', '  '];
+  const undefinedArray = [undefined];
+
+  describe('when all fields are empty or invalid', () => {
+    it('should return false when all fields are empty arrays', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: [],
+        [FieldId.OPENID_NAME]: [],
+        [FieldId.OPENID_PREFFERED_USERNAME]: [],
+        [FieldId.OPENID_CLAIM_GROUPS]: [],
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when all fields contain only empty strings', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: emptyStringArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when all fields contain only whitespace', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: whitespaceArray,
+        [FieldId.OPENID_NAME]: whitespaceArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: whitespaceArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: whitespaceArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when all fields are undefined', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: undefined,
+        [FieldId.OPENID_NAME]: undefined,
+        [FieldId.OPENID_PREFFERED_USERNAME]: undefined,
+        [FieldId.OPENID_CLAIM_GROUPS]: undefined,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when parent member and context are undefined', () => {
+      // Arrange
+      const context = { parent: undefined };
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when context parent is null', () => {
+      // Arrange
+      const context = { parent: null };
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when OPENID_EMAIL field has valid values', () => {
+    it('should return true when OPENID_EMAIL has a valid value', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: validStringArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return true when parent is not set but context has a valid value', () => {
+      // Arrange
+      const context = {
+        [FieldId.OPENID_EMAIL]: validStringArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      };
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return true when OPENID_EMAIL has mixed values including valid ones', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: mixedArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when OPENID_NAME field has valid values', () => {
+    it('should return true when OPENID_NAME has a valid value', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: emptyStringArray,
+        [FieldId.OPENID_NAME]: validStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when OPENID_PREFFERED_USERNAME field has valid values', () => {
+    it('should return true when OPENID_PREFFERED_USERNAME has a valid value', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: emptyStringArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: validStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when OPENID_CLAIM_GROUPS field has valid values', () => {
+    it('should return true when OPENID_CLAIM_GROUPS has a valid value', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: emptyStringArray,
+        [FieldId.OPENID_NAME]: emptyStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: validStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when multiple fields have valid values', () => {
+    it('should return true when multiple fields have valid values', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: validStringArray,
+        [FieldId.OPENID_NAME]: validStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: emptyStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return true when all fields have valid values', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: validStringArray,
+        [FieldId.OPENID_NAME]: validStringArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: validStringArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: validStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Test function works as expected with various UI cases', () => {
+    it('should return false when fields contain undefined values', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: undefinedArray,
+        [FieldId.OPENID_NAME]: undefinedArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: undefinedArray,
+        [FieldId.OPENID_CLAIM_GROUPS]: undefinedArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return true when at least one field has valid value among mixed invalid values', () => {
+      // Arrange
+      const context = createContext({
+        [FieldId.OPENID_EMAIL]: undefinedArray,
+        [FieldId.OPENID_NAME]: whitespaceArray,
+        [FieldId.OPENID_PREFFERED_USERNAME]: ['valid-username'],
+        [FieldId.OPENID_CLAIM_GROUPS]: emptyStringArray,
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should handle missing fields in parent object', () => {
+      // Arrange
+      const context = createContext({
+        // Missing some fields intentionally
+        [FieldId.OPENID_EMAIL]: validStringArray,
+        // Other fields are undefined
+      });
+
+      // Act
+      const result = hasAtLeastOneOpenIdClaimField(context);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/constants.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/constants.ts
@@ -9,6 +9,7 @@ export enum FieldId {
   OPENID_EMAIL = 'openid_email',
   OPENID_NAME = 'openid_name',
   OPENID_PREFFERED_USERNAME = 'openid_preferred_username',
+  OPENID_CLAIM_GROUPS = 'openid_claim_groups',
   ISSUER = 'issuer',
   LDAP_CA = 'ldap_ca',
   LDAP_INSECURE = 'ldap_insecure',

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/model/IDPFormDataType.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/model/IDPFormDataType.ts
@@ -16,6 +16,7 @@ export type IDPFormDataType = {
   openid_name?: any;
   openid_email?: any;
   openid_preferred_username?: any;
+  openid_claim_groups?: any;
   openid_extra_scopes?: any; // idpEdited[editedType].extra_scopes
   openid_ca?: any;
   // google

--- a/src/components/common/FormikFormComponents/FormikFieldArray/FormikFieldArray.test.tsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/FormikFieldArray.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 
-import { render, screen, userEvent } from '~/testUtils';
+import { checkAccessibility, render, screen, userEvent } from '~/testUtils';
 
 import { FieldId } from '../../../clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/constants';
 
@@ -33,19 +33,27 @@ const buildTestComponent = (children: React.ReactNode, formValues = {}) => (
 );
 
 describe('Formik array fields', () => {
-  it('shows enabled Add more while fields are populated and error free', async () => {
+  it('shows enabled Add link while fields are populated and error free', async () => {
     render(buildTestComponent(<FormikFieldArray {...defaultProps} />));
 
-    expect(screen.getByText('Add more').parentElement).toBeDisabled();
+    expect(screen.getByText('Add').parentElement).toBeDisabled();
   });
 
   it('Adds more fields in field array', async () => {
     render(buildTestComponent(<FormikFieldArray {...defaultProps} />));
 
     await userEvent.type(screen.getByRole('textbox'), 'Red Hat Team 1');
-    expect(screen.getByText('Add more').getAttribute('disabled')).toBe(null);
+    expect(screen.getByText('Add').getAttribute('disabled')).toBe(null);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Add more' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add Teams' }));
     expect(screen.getAllByRole('textbox')).toHaveLength(2);
+  });
+
+  it('is accessible', async () => {
+    // Arrange
+    const { container } = render(buildTestComponent(<FormikFieldArray {...defaultProps} />));
+
+    // Act & Assert
+    await checkAccessibility(container);
   });
 });

--- a/src/components/common/FormikFormComponents/FormikFieldArray/FormikFieldArray.tsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/FormikFieldArray.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { FieldArray } from 'formik';
 
-import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
+import { Bullseye, Button, Grid, GridItem, Icon, Stack, StackItem } from '@patternfly/react-core';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
@@ -22,7 +23,12 @@ const FieldArrayErrorGridItem = ({ isLast, errorMessage, touched, isGroupError }
   if (errorMessage && isLast && (touched || isGroupError)) {
     return (
       <GridItem className="field-grid-item pf-v6-c-form__helper-text pf-m-error">
-        {errorMessage}
+        <span className="pf-v6-u-pl-sm pf-v6-u-font-size-sm pf-v6-u-font-weight-bold">
+          <Icon status="danger">
+            <ExclamationCircleIcon color="danger" />
+          </Icon>{' '}
+          {errorMessage}
+        </span>
       </GridItem>
     );
   }
@@ -41,7 +47,7 @@ export const FormikFieldArray = (props: FormikFieldArrayProps) => {
         <LabelGridItem
           fieldSpan={6}
           isRequired={isRequired}
-          label={`${label} (${fieldData?.length})`}
+          label={`${label} (${fieldData?.length || 0})`}
           helpText={helpText}
         />
       </StackItem>
@@ -60,15 +66,15 @@ export const FormikFieldArray = (props: FormikFieldArrayProps) => {
                 variant="link"
                 isInline
                 isDisabled={fieldData?.some((el: string) => el === '')}
+                aria-label={`Add ${label}`}
               >
-                Add more
+                Add
               </Button>
             </StackItem>
             {fieldData?.map((_: any, index: number) => {
               const isRemoveDisabled = index === 0 && fieldData?.length === 1;
               const name = `${fieldID}.${index}`;
               return (
-                // eslint-disable-next-line react/no-array-index-key
                 <React.Fragment key={name}>
                   <Grid>
                     <Grid hasGutter span={6}>
@@ -80,25 +86,26 @@ export const FormikFieldArray = (props: FormikFieldArrayProps) => {
                           textInputClassName="field-grid-item"
                         />
                       </GridItem>
-                      <GridItem span={2} className="field-grid-item minus-button">
-                        <Button
-                          onClick={() => remove(index)}
-                          icon={<MinusCircleIcon />}
-                          variant="link"
-                          isInline
-                          isDisabled={isRemoveDisabled}
-                        />
+                      <GridItem span={1} className="field-grid-item minus-button">
+                        <Bullseye>
+                          <Button
+                            onClick={() => remove(index)}
+                            icon={<MinusCircleIcon />}
+                            variant="link"
+                            isInline
+                            isDisabled={isRemoveDisabled}
+                            aria-label={`Remove ${label} ${index + 1}`}
+                          />
+                        </Bullseye>
                       </GridItem>
                     </Grid>
-                  </Grid>
-                  <GridItem>
                     <FieldArrayErrorGridItem
                       isLast={index === fieldData.length - 1}
                       errorMessage={errors[fieldID]}
                       touched={touched}
                       isGroupError={false}
                     />
-                  </GridItem>
+                  </Grid>
                 </React.Fragment>
               );
             })}


### PR DESCRIPTION
# Summary

Add claim group to the OpenID form

For fun, I let AI write 2 of the unit tests - see if you can guess which ones.


# Jira

OCMUI-845

# Additional information

- Tweaked error messages
- Tweaked Claim heading
- Fixed logic so now we only require 1 of the claims to have to be inputted and the rest are not required.  (The API needs just one of the fields filled out to work)
- Aligned the minus button to be centered vertically 
- Tried using FormFieldGroup to group together the claim values (see pic below)
- Increased unit test code coverage to 85% fr IndentityProvidersPage directory

# How to Test

1. Make a ROSA cluster
2. Go to Details->Access tab
3. Go to sub tab Identify Providers
4. Add OpenID provider
5. Fill in values as you want.  You can literally set any values and submit the form.
6. The new field is in the **Claim Mappings** section.
7. Groups can be any value except cluster-admins or dedicated-admins (I put in all kinds of symbols and alphanumerics and they all seemed to work) (Did not find a max length so there is none set)

# Screen Captures

| Before                                              | After 1                                  | After 2  |
| --------------------------------------------------- | --------------------------------------- |---- |
|  <img width="896" height="793" alt="Screenshot From 2025-07-23 19-46-56" src="https://github.com/user-attachments/assets/5f485cbe-c9cb-4964-a579-b1e05dfa2581" /> | <img width="993" height="834" alt="Screenshot From 2025-07-28 10-31-26" src="https://github.com/user-attachments/assets/3581dc43-6afd-4487-adc2-9da52b42c9b0" />  | <img width="993" height="834" alt="Screenshot From 2025-07-28 10-31-42" src="https://github.com/user-attachments/assets/490db0c2-2a99-4d8e-ac0a-828c2b2d4704" /> |


In Action:


https://github.com/user-attachments/assets/2d6d78dd-f189-43b0-9023-bfcff6191ded




Align vertically:

<img width="424" height="702" alt="Screenshot From 2025-07-24 15-34-43" src="https://github.com/user-attachments/assets/9856ae18-847a-428d-9b7b-d5af113d9e91" />

Use FormFieldGroup:
<img width="993" height="834" alt="Screenshot From 2025-07-28 10-31-42" src="https://github.com/user-attachments/assets/490db0c2-2a99-4d8e-ac0a-828c2b2d4704" />

Test coverage:
<img width="1455" height="242" alt="Screenshot From 2025-07-24 16-47-36" src="https://github.com/user-attachments/assets/4f38a837-d509-4a7d-bc26-cedae9611d42" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
