### PR TITLE
OCMUI-3588, OCMUI-3589 - Add  accessibility table header

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/LogTable.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/LogTable.tsx
@@ -219,7 +219,7 @@ const LogTable = ({ logs, setSorting, pending, refreshEvent }: LogTableParams) =
         <Table aria-label="Expandable table" variant={TableVariant.compact}>
           <Thead>
             <Tr>
-              <Th />
+              <Th screenReaderText="Row expansion" />
               {columns.map((column, index) => (
                 <Th sort={getSortParams(index + 1)} key={column.title}>
                   {column.title}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolsTable.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolsTable.jsx
@@ -181,7 +181,11 @@ export const MachinePoolsTable = ({
       Object.keys(columnCells).map((column) => {
         const columnOptions = columnCells[column];
         return (
-          <Th key={column.title} width={column.columnWidth}>
+          <Th
+            key={columnOptions.title}
+            width={columnOptions.columnWidth}
+            screenReaderText={columnOptions.screenReaderText}
+          >
             {columnOptions.title}
           </Th>
         );


### PR DESCRIPTION
# Summary

This PR adds screen-reader text for table headers that currently do not have text.  After this PR the following error will not be displayed the unit test output:  `table headers must have an accessible name`

# Jira

Fixes [OCMUI-3588](https://issues.redhat.com/browse/OCMUI-3588)
Fixes [OCMUI-3589](https://issues.redhat.com/browse/OCMUI-3589)

# Additional information

Changes were only made to the headers without text.  Other table logic/layout have not been changed.

# How to Test

Go to a ROSA or OSD cluster
On the "Cluster history" tab, ensure that the table looks correctly - especially the table headers
On the "Machine pools" tab,  ensure that the table looks correctly - especially the table headers
Run the tests and have the output into a file.  For example `yarn run test > test-results.txt`
In the test results, ensure that the error `table headers must have an accessible name` is not found.

# Screen Captures
 ## Cluster history tab
<img width="800"  alt="Screenshot 2025-07-31 at 6 24 32 PM" src="https://github.com/user-attachments/assets/9b9308c6-47b9-4aae-8734-31921da2be04" />

## Machine pools tab
<img width="800"  alt="Screenshot 2025-07-31 at 6 28 43 PM" src="https://github.com/user-attachments/assets/456ec287-1b7c-4b63-9f2d-400b58f95523" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
