### PR TITLE
OCMUI-3622 Prevent input overlap on min/max nodes

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useFormikContext } from 'formik';
 
-import { Grid, GridItem, Spinner } from '@patternfly/react-core';
+import { Spinner, Split, SplitItem } from '@patternfly/react-core';
 
 import { isHypershiftCluster } from '~/components/clusters/common/clusterStates';
 import { getNodeOptions } from '~/components/clusters/common/machinePools/utils';
@@ -82,24 +82,24 @@ const EditNodeCountSection = ({
       ) : (
         <>
           {values.autoscaling ? (
-            <Grid hasGutter>
-              <GridItem span={5}>
+            <Split hasGutter>
+              <SplitItem>
                 <AutoscaleMinReplicasField
                   minNodes={minNodesRequired}
                   cluster={cluster}
                   mpAvailZones={machinePool?.availability_zones?.length}
                   options={options}
                 />
-              </GridItem>
-              <GridItem span={5}>
+              </SplitItem>
+              <SplitItem>
                 <AutoscaleMaxReplicasField
                   mpAvailZones={machinePool?.availability_zones?.length}
                   minNodes={minNodesRequired}
                   cluster={cluster}
                   options={options}
                 />
-              </GridItem>
-            </Grid>
+              </SplitItem>
+            </Split>
           ) : (
             <NodeCountField
               mpAvailZones={machinePool?.availability_zones?.length}


### PR DESCRIPTION
# Summary

On small screens the min/max fields will be misaligned on the Add/Edit Machine Pool modal on smaller screens.  This PR fixes that issue.

NOTE:  The original PR is available at: https://github.com/RedHatInsights/uhc-portal-internal-archive/pull/509

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3622](https://issues.redhat.com/browse/OCMUI-3622)

# Additional information

This changes the wrapper from PatternFly Grid to Split.  There are no changes to the min/max component and the modal.  This is strictly a layout change (and a minor one at that)


# How to Test

- Go to an existing ROSA or OSD cluster.
- Open the add machine pool modal
- Click on "Enable autoscale" checkbox
- Make the screen width smaller
- Ensure that the min and max node fields are aligned

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="468" height="838" alt="Screenshot 2025-07-24 at 3 23 54 PM" src="https://github.com/user-attachments/assets/cb75d394-d3e6-41de-841a-ec32cffabfe4" /> | <img width="468" height="756" alt="Screenshot 2025-07-24 at 3 20 51 PM" src="https://github.com/user-attachments/assets/2326f948-e363-4ea0-9034-9ce8bc259e59" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
