### PR TITLE
OCMUI-3621 GCP Wizard VPC fields alignment

### DIFF
--- a/src/components/clusters/wizards/osd/Networking/VpcSettings/GcpVpcSettings.tsx
+++ b/src/components/clusters/wizards/osd/Networking/VpcSettings/GcpVpcSettings.tsx
@@ -134,7 +134,7 @@ export const GcpVpcSettings = () => {
         </div>
       </GridItem>
 
-      <GridItem md={3}>
+      <GridItem md={showPSCSubnet ? 12 : 4}>
         {installToSharedVpc ? (
           <TextInputField
             name={FieldId.VpcName}
@@ -158,7 +158,7 @@ export const GcpVpcSettings = () => {
         )}
       </GridItem>
 
-      <GridItem md={3}>
+      <GridItem md={showPSCSubnet ? 12 : 4}>
         {installToSharedVpc ? (
           <TextInputField
             name={FieldId.ControlPlaneSubnet}
@@ -182,7 +182,7 @@ export const GcpVpcSettings = () => {
         )}
       </GridItem>
 
-      <GridItem md={3}>
+      <GridItem md={showPSCSubnet ? 12 : 4}>
         {installToSharedVpc ? (
           <TextInputField
             name={FieldId.ComputeSubnet}
@@ -206,7 +206,7 @@ export const GcpVpcSettings = () => {
         )}
       </GridItem>
       {showPSCSubnet ? (
-        <GridItem md={3}>
+        <GridItem md={12}>
           {installToSharedVpc ? (
             <TextInputField
               name={FieldId.PSCSubnet}


### PR DESCRIPTION
# Summary

On the OSD GCP wizard, the VPC fields can be misaligned.

This is due to the fact there just isn't enough room to horizontally display both the fields and their labels.  When there are only three fields - the app will continue to display horizontally, but when there are four fields - they will be displayed vertically.

Note that that this is purely a layout change - there was no change to the fields or the logic in the wizard.


# Jira

<!-- link to the corresponding Jira item -->
 Fixes [OCMUI-3621](https://issues.redhat.com/browse/OCMUI-3621)


# How to Test

- Go to the OSD wizard
- Choose "Customer cloud subscription" as the Infrastructure type
- Choose GCP as the cloud provider
- On the Networking step, choose "Public" and "Install into an existing VPC"
- Click on next to go to the VPC screen
- Verify that the Existing VPC fields align correctly
- Click on the back button (to go back to the Networking step)
- This time, choose "Private"
- Click next to go back to the VPC screen
- Verify that the Existing VPC fields align correctly

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="893" height="540" alt="Screenshot 2025-07-24 at 10 53 08 PM" src="https://github.com/user-attachments/assets/a0f9cc53-d02f-4271-b5fb-4f3f4876dc37" /> <img width="893" height="511" alt="Screenshot 2025-07-24 at 10 54 05 PM" src="https://github.com/user-attachments/assets/cde1e538-bf32-4525-968e-230d6684f37b" />   | <img width="893" height="511" alt="Screenshot 2025-07-24 at 10 53 33 PM" src="https://github.com/user-attachments/assets/d3aebd62-c75f-43a8-95dc-6b3e76f8450d" />  <img width="893" height="561" alt="Screenshot 2025-07-24 at 10 54 30 PM" src="https://github.com/user-attachments/assets/7b6c4797-ab19-40d3-aaf2-b3c3f05242d1" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
