### PR TITLE
[OCMUI-3652]e2e tests - fixed ROSA wizard validation test failures

### DIFF
--- a/cypress/fixtures/rosa-hosted/RosaClusterHostedWizardValidation.json
+++ b/cypress/fixtures/rosa-hosted/RosaClusterHostedWizardValidation.json
@@ -102,7 +102,7 @@
       "HostPrefix": [
         {
           "Value": "hello",
-          "Error": "The value 'hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
+          "Error": "The value '/hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
         },
         {
           "Value": "28",

--- a/cypress/fixtures/rosa/RosaClusterClassicWizardValidation.json
+++ b/cypress/fixtures/rosa/RosaClusterClassicWizardValidation.json
@@ -130,7 +130,7 @@
       "HostPrefix": [
         {
           "Value": "hello",
-          "Error": "The value 'hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
+          "Error": "The value '/hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
         },
         {
           "Value": "28",


### PR DESCRIPTION
# Summary
OCMUI e2e tests - fixed ROSA wizard validation test failures

# Jira
Fixes [OCMUI-3652](https://issues.redhat.com/browse/OCMUI-3652)

# Additional information
Recent QE CI [runs](https://ci.int.devshift.net/job/RedHatInsights-uhc-portal-qe-gh-cypress-smoke/187/display/redirect) reported failures related to ROSA wizard validation e2e tests.
This is because of change in the product feature definition as part of OCMUI-3569 

# How to Test

Run the test
`npx cypress run --browser chrome --config baseUrl='https://console.dev.redhat.com/openshift/' --spec cypress/e2e/rosa/RosaClusterClassicWizardValidation.js`  


# Screen Captures

nil

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
