### PR TITLE
OCMUI-3480: Fix 'existing VPC' tooltip text in GCP wizard

### DIFF
--- a/src/components/clusters/wizards/osd/Networking/VpcSettings/GcpVpcSettings.tsx
+++ b/src/components/clusters/wizards/osd/Networking/VpcSettings/GcpVpcSettings.tsx
@@ -1,7 +1,15 @@
 import React, { ReactElement, useMemo } from 'react';
 import { Field } from 'formik';
 
-import { Alert, AlertActionLink, GridItem, Title, useWizardContext } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertActionLink,
+  Content,
+  ContentVariants,
+  GridItem,
+  Title,
+  useWizardContext,
+} from '@patternfly/react-core';
 
 import links from '~/common/installLinks.mjs';
 import { required, validateGCPHostProjectId, validateGCPSubnet } from '~/common/validators';
@@ -112,10 +120,10 @@ export const GcpVpcSettings = () => {
             iconClassName="pf-v6-u-ml-sm"
             hint={
               <>
-                <p>
+                <Content component={ContentVariants.p}>
                   Install into a user-defined subnet within a custom VPC network that is provisioned
                   and fully managed within the same GCP project.
-                </p>
+                </Content>
                 <ExternalLink href={links.INSTALL_GCP_VPC}>
                   Learn more about installing into an existing VPC
                 </ExternalLink>


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->

The tooltip text associated with the "Existing VPC" section under the "Virtual Private Cloud (VPC) subnet settings" step in the GCP installation wizard is incorrect.

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->
Fixes [OCMUI-3480](https://issues.redhat.com/browse/OCMUI-3480)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

Steps to reproduce:
  1. Launch the OCM UI.
  2. Open the OSD cluster creation wizard.
  3. In the Billing Model step:
  4. Select Subscription type: Annual: Fixed capacity subscription from Red Hat.
  5. Select Infrastructure type: Customer Cloud Subscription.
  6. Click Next and choose GCP as the cloud provider.
  7. Continue through the wizard until you reach the Networking Configurations step.
  8. Select the checkbox: "Install into existing VPC."
  9. Click Next to proceed to the Virtual Private Cloud (VPC) subnet settings step.
  10. Click the question mark  icon associated with the "Existing VPC" section.
  11. Review the tooltip content that appears.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="801" height="374" alt="image" src="https://github.com/user-attachments/assets/37193cbf-2552-4f55-8ddf-094feca355be" /> | <img width="1342" height="574" alt="image" src="https://github.com/user-attachments/assets/8a258315-ed48-430f-93f3-3409b708c0ad" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
