### PR TITLE
OCMUI-3653 Double scrolling issue 

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 
 import useResizeObserver from '@react-hook/resize-observer';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -24,12 +24,6 @@ import { queryClient } from './queryClient';
 import Router from './Router';
 
 import './App.scss';
-// import patternfly styles until hcc is on PF v6
-// import '@patternfly/patternfly/patternfly.css';
-
-type Props = {
-  children?: ReactNode | undefined;
-};
 
 function getHeightUpdater(
   currentHeight: number,
@@ -44,24 +38,23 @@ function getHeightUpdater(
   };
 }
 
-const App = ({ children }: Props) => {
-  const header = document.getElementsByTagName('header')?.[0];
-  const switcher = document.getElementsByClassName('chr-c-beta-switcher')?.[0];
-  const [headerHeight, setHeaderHeight] = useState(
-    header ? header.getBoundingClientRect().height : 0,
+const App = () => {
+  const mainPage = document.querySelector('main.pf-v6-c-page__main');
+  const breadcrumb = document.querySelector('.chr-c-breadcrumbs__group');
+  const [mainPageHeight, setMainPageHeaderHeight] = useState(
+    mainPage ? mainPage.getBoundingClientRect().height : 0,
   );
-  const [switcherHeight, setSwitcherHeight] = useState(
-    switcher ? switcher.getBoundingClientRect().height : 0,
+  const [breadcrumbHeight, setBreadcrumbHeight] = useState(
+    breadcrumb ? breadcrumb.getBoundingClientRect().height : 0,
   );
 
-  useResizeObserver(header, getHeightUpdater(headerHeight, setHeaderHeight));
-  useResizeObserver(switcher, getHeightUpdater(switcherHeight, setSwitcherHeight));
+  useResizeObserver(mainPage, getHeightUpdater(mainPageHeight, setMainPageHeaderHeight));
+  useResizeObserver(breadcrumb, getHeightUpdater(breadcrumbHeight, setBreadcrumbHeight));
+
+  const containerHeight = mainPageHeight - breadcrumbHeight;
 
   return (
-    <div
-      id="app-outer-div"
-      style={{ height: `calc(100vh - ${headerHeight}px - ${switcherHeight}px` }}
-    >
+    <div id="app-outer-div" style={{ height: containerHeight > 0 ? containerHeight : 'auto' }}>
       <QueryClientProvider client={queryClient}>
         <Router />
         <ReactQueryDevtools initialIsOpen={false} position="bottom" buttonPosition="bottom-right" />


### PR DESCRIPTION
# Summary

Fixing the double scrolling issue re-introduced after HCC migrated to PF6.

# Jira

Fixes [OCMUI-3653](https://issues.redhat.com/browse/OCMUI-3653)

# Additional information

While waiting for HCC to address this on their side, I realized that we still have an issue in how we calculate our app container height. In theory this fix will make their ticket not necessary anymore.

After the PF6 upgrade the page layout changed, we can't use the viewport height and subtract header and banner size anymore. We also have new content inside the app area (the HCC breadcrumb) and some spacing below the chrome wrapper container (`.chr-render`). I had to change approach and take the size of our container and subtract the breadcrumb size.

Calculating manually the height was and remains a brittle solution. I also explored if we can remove it and rely only on flexbox. I couldn't find a quick solution mainly because of too much nesting between chrome elements and ours. I will open a ticket to investigate it properly if we agree with the fix in this PR. I think the current double scrollbar is too ugly and needs to be fixed.

`App.tsx` doesn't have any unit test coverage. I didn't add a test because I think I will end up mocking too many things inside/outside the app and Jest doesn't support DOM inspection. I can still give it a try if anyone thinks it could be valuable. 


# How to Test

- Go to https://prod.foo.redhat.com:1337/openshift
- Browse the app and verify there is no more double scrolling inside long pages
- Also verify there is no scrolling at all inside pages with little content
- Verify that drawers content scrolls independently from the rest of the page
  - Go to https://prod.foo.redhat.com:1337/openshift/overview and click one of the "Learn more" links inside one of the featured products cards
  - Go to the [ROSA wizard](https://prod.foo.redhat.com:1337/openshift/create/rosa/wizard), reach the "Account and roles" step and click on "How to associate a new AWS account"
- Try resizing the browser window and verify nothing breaks and scrolling still works as expected

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|  <img width="1552" height="1015" alt="Screenshot 2025-08-01 at 15 30 56" src="https://github.com/user-attachments/assets/9dfff8b6-12b4-4671-b404-2d2c92d6c47c" /> | <img width="1549" height="1014" alt="Screenshot 2025-08-01 at 15 30 49" src="https://github.com/user-attachments/assets/ed7f58ff-157a-485b-9bac-91994ec80354" /> |



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
