### PR TITLE
OCMUI-3257: update typescript typings around VPC details card

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/Networking.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/Networking.jsx
@@ -8,7 +8,7 @@ import { useGetClusterRouters } from '~/queries/ClusterDetailsQueries/Networking
 import ApplicationIngressCard from './components/ApplicationIngressCard';
 import { ClusterIngressCard } from './components/ClusterIngressCard/ClusterIngressCard';
 import NetworkConfigurationCard from './components/NetworkConfigurationCard';
-import VPCDetailsCard from './components/VPCDetailsCard';
+import { VPCDetailsCard } from './components/VPCDetailsCard/VPCDetailsCard';
 import VPCSubnetsCard from './components/VPCSubnetsCard';
 
 import './Networking.scss';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { Formik } from 'formik';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
 import { arrayToString } from '~/common/helpers';
@@ -16,7 +15,7 @@ import EditClusterWideProxyForm from './EditClusterWideProxyForm';
 
 type EditClusterWideProxyDialogProps = {
   cluster: ClusterFromSubscription;
-  region: string;
+  region?: string;
 };
 
 const OnlyReturnValueIfChanged = (newValue: string | undefined, oldValue: string | undefined) =>
@@ -102,11 +101,6 @@ const EditClusterWideProxyDialog = ({ cluster, region }: EditClusterWideProxyDia
       )}
     </Formik>
   ) : null;
-};
-
-EditClusterWideProxyDialog.propTypes = {
-  cluster: PropTypes.object,
-  region: PropTypes.string,
 };
 
 export default EditClusterWideProxyDialog;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.test.tsx
@@ -1,23 +1,22 @@
 import * as React from 'react';
 
 import { ClusterState } from '~/types/clusters_mgmt.v1/enums';
+import { AugmentedCluster } from '~/types/types';
 
 import { mockRestrictedEnv, render, screen } from '../../../../../../../testUtils';
 
-import VPCDetailsCard from './VPCDetailsCard';
+import { VPCDetailsCard } from './VPCDetailsCard';
 
 describe('<VPCDetailsCard />', () => {
-  const defaultProps = {
-    cluster: {
-      aws: {
-        subnet_ids: ['subnet-05281fa2678b6d8cd', 'subnet-03f3654ffc25369ac'],
-      },
+  const defaultCluster = {
+    aws: {
+      subnet_ids: ['subnet-05281fa2678b6d8cd', 'subnet-03f3654ffc25369ac'],
     },
-  };
+  } as AugmentedCluster;
 
   describe('in default environment', () => {
     it('renders footer', () => {
-      render(<VPCDetailsCard {...defaultProps} />);
+      render(<VPCDetailsCard cluster={defaultCluster} />);
       expect(screen.queryByText('Edit cluster-wide proxy')).toBeInTheDocument();
     });
   });
@@ -31,25 +30,24 @@ describe('<VPCDetailsCard />', () => {
       isRestrictedEnv.mockReturnValue(false);
     });
     it('does not render footer', () => {
-      render(<VPCDetailsCard {...defaultProps} />);
+      render(<VPCDetailsCard cluster={defaultCluster} />);
       expect(screen.queryByText('Edit cluster-wide proxy')).not.toBeInTheDocument();
     });
   });
 
   describe('When Private Service Connect Subnet is provided', () => {
-    const props = {
-      cluster: {
-        gcp_network: 'gcpNetwork',
-        gcp: {
-          private_service_connect: {
-            service_attachment_subnet: 'gcpPrivateServiceConnect',
-          },
+    const cluster = {
+      ...defaultCluster,
+      gcp_network: 'gcpNetwork',
+      gcp: {
+        private_service_connect: {
+          service_attachment_subnet: 'gcpPrivateServiceConnect',
         },
       },
-    };
+    } as AugmentedCluster;
 
     it('renders Private Service Connect Subnet', () => {
-      render(<VPCDetailsCard {...props} />);
+      render(<VPCDetailsCard cluster={cluster} />);
       expect(screen.queryByText('Private Service Connect Subnet')).toBeInTheDocument();
       expect(screen.queryByText('gcpPrivateServiceConnect')).toBeInTheDocument();
     });
@@ -85,15 +83,13 @@ describe('<VPCDetailsCard />', () => {
       },
     ],
   ])('When %s', (title, clusterProps) => {
-    const props = {
-      cluster: {
-        ...defaultProps.cluster,
-        ...clusterProps,
-      },
-    };
+    const cluster = {
+      ...defaultCluster,
+      ...clusterProps,
+    } as AugmentedCluster;
 
     it('Edit button is disabled', () => {
-      render(<VPCDetailsCard {...props} />);
+      render(<VPCDetailsCard cluster={cluster} />);
       expect(screen.queryByText('Edit cluster-wide proxy').parentElement).toHaveAttribute(
         'aria-disabled',
         'true',
@@ -102,19 +98,17 @@ describe('<VPCDetailsCard />', () => {
   });
 
   describe('When cluster is neither in read-only mode nor in one of the hibernation states, and user is allowed updates to the cluster resource', () => {
-    const props = {
-      cluster: {
-        ...defaultProps.cluster,
-        canUpdateClusterResource: true,
-        state: ClusterState.installing,
-        status: {
-          configuration_mode: 'full',
-        },
+    const cluster = {
+      ...defaultCluster,
+      canUpdateClusterResource: true,
+      state: ClusterState.installing,
+      status: {
+        configuration_mode: 'full',
       },
-    };
+    } as AugmentedCluster;
 
     it('Edit button is enabled', () => {
-      render(<VPCDetailsCard {...props} />);
+      render(<VPCDetailsCard cluster={cluster} />);
       expect(screen.queryByText('Edit cluster-wide proxy')).not.toHaveAttribute(
         'aria-disabled',
         'false',

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
 import {
@@ -22,12 +21,20 @@ import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
 import { modalActions } from '~/components/common/Modal/ModalActions';
 import modals from '~/components/common/Modal/modals';
 import { isRestrictedEnv } from '~/restrictedEnv';
+import { AugmentedCluster } from '~/types/types';
 
 import EditClusterWideProxyDialog from '../EditClusterWideProxyDialog';
 
 import './VPCDetailsCard.scss';
 
-const resolveDisableEditReason = ({ isReadOnly, clusterHibernating, canUpdateClusterResource }) => {
+const resolveDisableEditReason = ({
+  isReadOnly,
+  clusterHibernating,
+  canUpdateClusterResource,
+}: Pick<AugmentedCluster, 'canUpdateClusterResource'> & {
+  isReadOnly: boolean;
+  clusterHibernating: boolean;
+}) => {
   const readOnlyReason = isReadOnly && 'This operation is not available during maintenance';
   const hibernatingReason =
     clusterHibernating && 'This operation is not available while cluster is hibernating';
@@ -37,7 +44,11 @@ const resolveDisableEditReason = ({ isReadOnly, clusterHibernating, canUpdateClu
   return readOnlyReason || hibernatingReason || canNotEditReason;
 };
 
-const VPCDetailsCard = ({ cluster }) => {
+type VPCDetailsCardProps = {
+  cluster: AugmentedCluster;
+};
+
+const VPCDetailsCard = ({ cluster }: VPCDetailsCardProps) => {
   const dispatch = useDispatch();
 
   const privateLink = cluster.aws?.private_link;
@@ -64,9 +75,8 @@ const VPCDetailsCard = ({ cluster }) => {
     canUpdateClusterResource,
   });
 
-  const handleEditClusterProxy = () => {
+  const handleEditClusterProxy = () =>
     dispatch(modalActions.openModal(modals.EDIT_CLUSTER_WIDE_PROXY));
-  };
 
   const renderNoProxyDomains = noProxyDomains
     ? noProxyDomains.map((domain) => (
@@ -163,8 +173,4 @@ const VPCDetailsCard = ({ cluster }) => {
   );
 };
 
-VPCDetailsCard.propTypes = {
-  cluster: PropTypes.object.isRequired,
-};
-
-export default VPCDetailsCard;
+export { VPCDetailsCard };

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/index.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/index.js
@@ -1,3 +1,0 @@
-import VPCDetailsCard from './VPCDetailsCard';
-
-export default VPCDetailsCard;


### PR DESCRIPTION
> [!note]
> ported from [uhc-portal-internal-archive \#477][5]

# Summary

use typescript types around VPC details card.


# Jira

resolves [OCMUI-3257][4]


# Additional information

- this is tech-debt, originally a follow-up to [OCMUI-62][2]
- based on [eliranmal/uhc-portal #4][1], these changes were ported and adapted as per recent code
-  PR [eliranmal/uhc-portal #4][1] was suggested/contributed by @Ginxo as part of code-review feedback on #206


# How to Test

no changes to functional code.

not sure how TS changes are tested (probably as part of the next regression-tests cycle).


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/master/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation



[1]: https://github.com/eliranmal/uhc-portal/pull/4
[2]: https://issues.redhat.com/browse/OCMUI-62
[4]: https://issues.redhat.com/browse/OCMUI-3257
[5]: https://github.com/RedHatInsights/uhc-portal-internal-archive/pull/477
