### PR TITLE
OCMUI-2302 - [ROSA wizard]The existing validation error removed once user face another validation error in same wizard step.

### DIFF
--- a/src/components/clusters/wizards/rosa/MachinePoolScreen/components/WorkerNodeVolumeSizeSection/WorkerNodeVolumeSizeSection.tsx
+++ b/src/components/clusters/wizards/rosa/MachinePoolScreen/components/WorkerNodeVolumeSizeSection/WorkerNodeVolumeSizeSection.tsx
@@ -22,7 +22,10 @@ const WorkerNodeVolumeSizeSection = ({
   maxWorkerVolumeSizeGiB,
 }: WorkerNodeVolumeSizeSectionProps) => {
   const {
-    values: { [FieldId.WorkerVolumeSizeGib]: workerVolumeSizeGib },
+    values: {
+      [FieldId.WorkerVolumeSizeGib]: workerVolumeSizeGib,
+      [FieldId.MinReplicas]: minReplicas,
+    },
     setFieldValue,
     setFieldTouched,
     getFieldProps,
@@ -34,6 +37,12 @@ const WorkerNodeVolumeSizeSection = ({
       setFieldValue(FieldId.WorkerVolumeSizeGib, defaultWorkerNodeVolumeSizeGiB, true);
     }
   }, [setFieldValue, workerVolumeSizeGib]);
+
+  useEffect(() => {
+    // to trigger WorkerVolumeSizeGib field validation on min replicas change
+    setFieldTouched(FieldId.WorkerVolumeSizeGib, true, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [minReplicas]);
 
   return (
     <FormGroup


### PR DESCRIPTION
# Summary

The root disk size validation error message was disappearing when a user changed the min nodes field value. This PR adds a fix so that the error persists.

# Jira

Fixes [OCMUI-2302](https://issues.redhat.com/browse/OCMUI-2302) 

# Additional information

Pretty strange formik bug. The issue lives in the useEffect in AutoScaleEnabledInputs.tsx --> 
```
useEffect(() => {
    if (maxReplicas) {
      // to trigger MaxReplicas field validation
      setFieldValue(RosaFieldId.MaxReplicas, maxReplicas, true);
    }
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, [minReplicas]);
```
Though it seems like this useEffect should be completely decoupled from the Root disk size field, it for whatever reason isn't when it comes to the validation error. 
Usually these bugs we can workaround by using formik's setFieldTouched() in an onChange handler or formik's validateForm() function but this was not solving the issue at all. What worked was using a useEffect in the component that contains the root disk size field and triggering setFieldTouched whenever the minReplicas changes. (What is also weird is that it is just the min nodes field when it comes to this issue, the max nodes field does not remove the error for root disk size)

# How to Test

1. Begin creating either a rosa classic or hyperhshift cluster
2. When you get to the Machine pool step, check enable autoscaling
3. Set the Root disk size field to anything outside of its allowed range
4. Adjust the min and max nodes field values and make sure the Root disk size error message persists 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| https://github.com/user-attachments/assets/87fe0a1e-5072-46ba-b32c-61ca1d6d18f6 | https://github.com/user-attachments/assets/e929d32e-66c2-4284-a5d3-9f1c08dfa03e

 |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
