### PR TITLE
[OCMUI-3666]Fix failing e2e CI testcase

### DIFF
--- a/cypress/e2e/osd/OSDClusterCreation.js
+++ b/cypress/e2e/osd/OSDClusterCreation.js
@@ -17,9 +17,7 @@ describe('OSD cluster tests', { tags: ['ci'] }, () => {
     it('navigates to create OSD cluster', () => {
       cy.getByTestId('create_cluster_btn').click();
       CreateClusterPage.isCreateClusterPage();
-      cy.get('a[data-testid="osd-create-cluster-button"]', {
-        timeout: 15000,
-      }).click();
+      CreateOSDWizardPage.osdCreateClusterButton().click();
       CreateOSDWizardPage.isCreateOSDPage();
     });
 


### PR DESCRIPTION
# Summary

Fixed failing e2e CI test case : osd/OSDClusterCreation.js

# Jira

Fixes [OCMUI-3666](https://issues.redhat.com/browse/OCMUI-3666)

# Additional information

The recent e2e CI workflow from the main branch reported failures on an existing test case osd/OSDClusterCreation.js.
This PR provide a fix for the same.

# How to Test

Run the following command
`yarn cypress-headless  --browser chrome --config baseUrl='<url>' --spec cypress/e2e/osd/OSDClusterCreation.js`

# Screen Captures

```javascript
DevTools listening on ws://127.0.0.1:56785/devtools/browser/2bebe329-c30c-4a78-a892-633a12d833f4
@cypress/grep: will omit filtered tests
grep and/or grepTags has eliminated all specs
Will leave all specs to run to filter at run-time

================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        13.13.0                                                                        │
  │ Browser:        Chrome 138 (headless)                                                          │
  │ Node Version:   v22.11.0 (/usr/local/bin/node)                                                 │
  │ Specs:          1 found (OSDClusterCreation.js)                                                │
  │ Searched:       cypress/e2e/osd/OSDClusterCreation.js                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  OSDClusterCreation.js                                                           (1 of 1)


  OSD cluster tests
    Create OSD cluster on AWS flow
      ✓ navigates to create OSD cluster (76264ms)
      ✓ shows an error with invalid and empty names (19529ms)
      ✓ fills OSD wizard but does not really create an OSD cluster (2564ms)

  OSD Trial cluster tests
    View Create OSD Trial cluster page
      ✓ navigates to create OSD Trial cluster and CCS is selected (1473ms)


  4 passing (2m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        4                                                                                │
  │ Passing:      4                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     1 minute, 40 seconds                                                             │
  │ Spec Ran:     OSDClusterCreation.js                                                            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  OSDClusterCreation.js                    01:40        4        4        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:40        4        4        -        -        -  

✨  Done in 108.40s.

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
