### PR TITLE
[OCMUI-3658]e2e tests - fixed failing rosa hosted overview actions test case.

### DIFF
--- a/cypress/e2e/rosa-hosted/RosaHostedClusterOverviewActions.js
+++ b/cypress/e2e/rosa-hosted/RosaHostedClusterOverviewActions.js
@@ -48,13 +48,10 @@ describe(
 
     it(`Update billing account values within the Billing marketplace account dropdown`, () => {
       ClusterDetailsPage.showBillingMarketplaceAccountLink();
-
+      ClusterDetailsPage.verifyBillingAccountDocLink('Connect a new AWS billing account');
       ClusterDetailsPage.clickAWSBillingAccountsDropDown();
-
       ClusterDetailsPage.filterAWSBillingAccount(secondaryAWSBillingAccountId);
       ClusterDetailsPage.selectAWSBillingAccount(secondaryAWSBillingAccountId);
-      ClusterDetailsPage.verifyBillingAccountDocLink('Connect a new AWS billing account');
-
       ClusterDetailsPage.refreshBillingAWSAccountButton();
       ClusterDetailsPage.updateAWSBillingAccount();
     });
@@ -71,7 +68,6 @@ describe(
     after(`Revert the Billing account changes made in the earlier test steps`, () => {
       ClusterDetailsPage.overviewTab().click();
       ClusterDetailsPage.showBillingMarketplaceAccountLink();
-
       ClusterDetailsPage.clickAWSBillingAccountsDropDown();
       ClusterDetailsPage.filterAWSBillingAccount(awsBillingAccountId);
       ClusterDetailsPage.selectAWSBillingAccount(awsBillingAccountId);

--- a/cypress/pageobjects/ClusterDetails.page.js
+++ b/cypress/pageobjects/ClusterDetails.page.js
@@ -227,7 +227,11 @@ class ClusterDetails extends Page {
   }
 
   clickAWSBillingAccountsDropDown() {
-    cy.get('button[aria-describedby="aws-infra-accounts"]').click();
+    cy.get('#edit-billing-aws-account-modal').within(() => {
+      cy.get('button[aria-label="Options menu"]')
+        .should('be.enabled', { timeout: 30000 })
+        .click({ force: true });
+    });
   }
 
   updateAWSBillingAccount() {
@@ -235,9 +239,8 @@ class ClusterDetails extends Page {
   }
 
   verifyBillingAccountDocLink(text) {
-    cy.get('a')
-      .contains(text)
-      .should('have.attr', 'href', 'https://console.aws.amazon.com/rosa/home');
+    // Find the link that contains the text (even if text is in a nested span)
+    cy.contains('a', text).should('have.attr', 'href', 'https://console.aws.amazon.com/rosa/home');
   }
 
   filterAWSBillingAccount(awsBillingAccount) {
@@ -247,10 +250,9 @@ class ClusterDetails extends Page {
   }
 
   selectAWSBillingAccount(awsBillingAccount) {
-    cy.get('div[label="AWS billing account"]')
-      .find('button')
-      .contains(awsBillingAccount)
-      .click({ force: true });
+    cy.get('div[aria-describedby="aws-infra-accounts"]').within(() => {
+      cy.contains('button', awsBillingAccount).click({ force: true });
+    });
   }
 
   showEditAWSBillingAccountModal() {


### PR DESCRIPTION
# Summary

E2e tests - fixed failing rosa hosted overview actions (day2) test case.
# Jira

Fixes [OCMUI-3658](https://issues.redhat.com/browse/OCMUI-3658) 

# Additional information

Recent feature updates on product definition including PF6 updates were caused failures rosa hosted overview actions (day2) test cases. This PR provide necessary steps to fix the failing test cases.


# How to Test
- Create a rosa-hosted cluster with the name `cyp-rosa-hosted-public`
-  Run the below test case
- `yarn cypress-headless  --browser chrome --config baseUrl='https://prod.foo.redhat.com:1337/openshift/' --spec cypress/e2e/rosa-hosted/RosaHostedClusterOverviewActions.js`



# Screen Captures
nil

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
