### PR TITLE
OCMUI1029: When adding a new machine pool, move unused subnets to the top

### DIFF
--- a/cypress/fixtures/rosa-hosted/RosaClusterHostedWizardValidation.json
+++ b/cypress/fixtures/rosa-hosted/RosaClusterHostedWizardValidation.json
@@ -102,7 +102,7 @@
       "HostPrefix": [
         {
           "Value": "hello",
-          "Error": "The value '/hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
+          "Error": "The value 'hello' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'"
         },
         {
           "Value": "28",

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/SubnetField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/SubnetField.tsx
@@ -7,18 +7,34 @@ import { RefreshClusterVPCAlert } from '~/components/clusters/ClusterDetailsMult
 import { SubnetSelectField } from '~/components/clusters/common/SubnetSelectField';
 import { useAWSVPCFromCluster } from '~/components/clusters/common/useAWSVPCFromCluster';
 import { ClusterFromSubscription } from '~/types/types';
+import { MachinePool, NodePool } from '~/types/clusters_mgmt.v1';
 
 const fieldId = 'privateSubnetId';
+
+const getSubnetIds = (machinePoolOrNodePool: MachinePool | NodePool): string[] => {
+  const { subnet, subnets } = machinePoolOrNodePool as any;
+  const subnetArray = subnet ? [subnet] : subnets || [];
+  return Array.isArray(subnetArray) ? subnetArray : [subnetArray];
+};
 
 const SubnetField = ({
   cluster,
   region,
+  machinePools = [],
 }: {
   cluster: ClusterFromSubscription;
   region?: string;
+  machinePools?: MachinePool[];
 }) => {
   const [inputField, metaField, { setValue }] = useField<string | undefined>(fieldId);
   const { clusterVpc, isLoading, hasError, refreshVPC } = useAWSVPCFromCluster(cluster, region);
+
+  const usedSubnetIds = React.useMemo(
+    () =>
+      machinePools.flatMap((nodePool) => getSubnetIds(nodePool)).filter((subnetId) => !!subnetId),
+    [machinePools],
+  );
+
   const fieldProps = React.useMemo(
     () => ({
       input: {
@@ -51,6 +67,7 @@ const SubnetField = ({
       label="Private subnet name"
       isRequired
       selectedVPC={clusterVpc}
+      usedSubnetIds={usedSubnetIds}
       {...fieldProps}
     />
   );

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditDetailsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditDetailsSection.tsx
@@ -46,7 +46,9 @@ const EditDetailsSection = ({
   ) : (
     <>
       <TextField fieldId="name" label="Machine pool name" isRequired />
-      {isHypershiftCluster(cluster) ? <SubnetField cluster={cluster} region={region} /> : null}
+      {isHypershiftCluster(cluster) ? (
+        <SubnetField cluster={cluster} region={region} machinePools={machinePools} />
+      ) : null}
       <InstanceTypeField cluster={cluster} machineTypesResponse={machineTypesResponse} />
     </>
   );

--- a/src/components/clusters/common/SubnetSelectField.test.tsx
+++ b/src/components/clusters/common/SubnetSelectField.test.tsx
@@ -303,3 +303,116 @@ describe('SubnetSelectField', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe('Subent ordering and used subnet functionality', () => {
+  it('groups subnets by availability zone and orders unused before used', async () => {
+    const usedSubnetIds = ['subnet-011f8e5c954b17ad9', 'subnet-013caf96f643315eb'];
+
+    const { user } = render(<SubnetSelectField {...defaultProps} usedSubnetIds={usedSubnetIds} />);
+
+    const selectDropdown = screen.getByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdown);
+
+    //check availability groups are present for only unused subnets
+    expect(screen.queryByText('us-east-1a')).not.toBeInTheDocument();
+    expect(screen.queryByText('us-east-1b')).not.toBeInTheDocument();
+    expect(screen.getByText('us-east-1c')).toBeInTheDocument();
+    expect(screen.getByText('us-east-1d')).toBeInTheDocument();
+
+    //check that unused subnets are present and used subnets are not
+    expect(
+      screen.getByRole('option', { name: /ddonati-test4.*private-us-east-1c1/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /ddonati-test4.*private-us-east-1c2/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /ddonati-test4.*private-us-east-1d/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /ddonati-test4.*private-us-east-1a/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /ddonati-test4.*private-us-east-1b/i }),
+    ).not.toBeInTheDocument();
+
+    //"View Used Subnets" button shown
+    expect(screen.getByRole('option', { name: 'View Used Subnets' })).toBeInTheDocument();
+  });
+
+  it('shows and hides used subnets when toggle is clicked', async () => {
+    const usedSubnetIds = ['subnet-011f8e5c954b17ad9', 'subnet-013caf96f643315eb'];
+
+    const { user } = render(<SubnetSelectField {...defaultProps} usedSubnetIds={usedSubnetIds} />);
+
+    const selectDropdown = screen.getByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdown);
+
+    const viewUsedButton = screen.getByRole('option', { name: 'View Used Subnets' });
+    await user.click(viewUsedButton);
+
+    //used subnets with '- Used' label should be visible
+    expect(screen.getByText('us-east-1a - Used')).toBeInTheDocument();
+    expect(screen.getByText('us-east-1b - Used')).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /ddonati-test4.*private-us-east-1a/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /ddonati-test4.*private-us-east-1b/i }),
+    ).toBeInTheDocument();
+
+    //button text = 'Hide Used Subnets'
+    expect(screen.getByRole('option', { name: 'Hide Used Subnets' })).toBeInTheDocument();
+
+    const hideUsedButton = screen.getByRole('option', { name: 'Hide Used Subnets' });
+    await user.click(hideUsedButton);
+
+    //verify used subnet groups are hidden
+    expect(screen.queryByText('us-east-1a - Used')).not.toBeInTheDocument();
+    expect(screen.queryByText('us-east-1b - Used')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /ddonati-test4.*private-us-east-1a/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /ddonati-test4.*private-us-east-1b/i }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'View Used Subnets' })).toBeInTheDocument();
+  });
+
+  it('filters work correctly with used subnets shown', async () => {
+    const usedSubnetIds = ['subnet-011f8e5c954b17ad9', 'subnet-013caf96f643315eb'];
+
+    const { user } = render(<SubnetSelectField {...defaultProps} usedSubnetIds={usedSubnetIds} />);
+
+    const selectDropdown = screen.getByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdown);
+
+    const viewUsedButton = screen.getByRole('option', { name: 'View Used Subnets' });
+    await user.click(viewUsedButton);
+
+    //1b should show both unused and used subnets in zone
+    const searchBox = screen.getByPlaceholderText(/Filter by subnet/i);
+    await user.clear(searchBox);
+    await user.type(searchBox, '1b');
+    const options = await screen.findAllByRole('option');
+    expect(options.length).toBeGreaterThan(0);
+  });
+
+  it('respects allowedAZs when filtering subnets', async () => {
+    const allowedAZs = ['us-east-1a', 'us-east-1b'];
+
+    const { user } = render(<SubnetSelectField {...defaultProps} allowedAZs={allowedAZs} />);
+
+    const selectDropdown = screen.getByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdown);
+
+    expect(screen.getByText('us-east-1a')).toBeInTheDocument();
+    expect(screen.getByText('us-east-1b')).toBeInTheDocument();
+    expect(screen.queryByText('us-east-1c')).not.toBeInTheDocument();
+    expect(screen.queryByText('us-east-1d')).not.toBeInTheDocument();
+
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(2);
+  });
+});

--- a/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.test.tsx
+++ b/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.test.tsx
@@ -722,10 +722,12 @@ describe('<VersionSelection />', () => {
       await user.click(screen.getByRole('button', { name: componentText.SELECT_TOGGLE.label }));
 
       expect(await screen.findByText(defaultProps.label)).toBeInTheDocument();
-      expect(screen.getAllByRole('listbox')).toHaveLength(2);
+      expect(screen.getAllByRole('listbox')).toHaveLength(3);
 
       // Assert
-      const fullSupportList = screen.getAllByRole('listbox')[0];
+      const fullSupportList = screen.getByRole('listbox', {
+        name: 'Select options list for Full support',
+      });
       expect(within(fullSupportList).getAllByRole('option')).toHaveLength(1);
       expect(within(fullSupportList).getByRole('option', { name: '4.12.1' })).toBeInTheDocument();
     });
@@ -742,10 +744,12 @@ describe('<VersionSelection />', () => {
       await user.click(screen.getByRole('button', { name: componentText.SELECT_TOGGLE.label }));
 
       expect(await screen.findByText(defaultProps.label)).toBeInTheDocument();
-      expect(screen.getAllByRole('listbox')).toHaveLength(2);
+      expect(screen.getAllByRole('listbox')).toHaveLength(3);
 
       // Assert
-      const maintenanceSupportList = screen.getAllByRole('listbox')[1];
+      const maintenanceSupportList = screen.getByRole('listbox', {
+        name: 'Select options list for Maintenance support',
+      });
       expect(within(maintenanceSupportList).getAllByRole('option')).toHaveLength(3);
 
       expect(

--- a/src/components/clusters/wizards/rosa/MachinePoolScreen/MachinePoolsSubnets.tsx
+++ b/src/components/clusters/wizards/rosa/MachinePoolScreen/MachinePoolsSubnets.tsx
@@ -52,9 +52,14 @@ const MachinePoolsSubnets = () => {
 
   const MachinePoolSubnetsFormComponent = useCallback(
     (props: any) => (
-      <MachinePoolSubnetsForm selectedVPC={selectedVPC} {...props} warning={subnetWarnings} />
+      <MachinePoolSubnetsForm
+        selectedVPC={selectedVPC}
+        allMachinePoolSubnets={machinePoolsSubnets as FormSubnet[]}
+        {...props}
+        warning={subnetWarnings}
+      />
     ),
-    [selectedVPC, subnetWarnings],
+    [selectedVPC, subnetWarnings, machinePoolsSubnets],
   );
 
   return (

--- a/src/components/common/FormikFormComponents/MachinePoolSubnetsForm.tsx
+++ b/src/components/common/FormikFormComponents/MachinePoolSubnetsForm.tsx
@@ -20,11 +20,15 @@ import './MachinePoolSubnetsForm.scss';
 type MachinePoolSubnetsFormProps = {
   selectedVPC?: CloudVpc;
   warning?: string;
+  allMachinePoolSubnets: FormSubnet[];
 };
 
-const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsFormProps) => {
+const MachinePoolSubnetsForm = ({
+  selectedVPC,
+  warning,
+  allMachinePoolSubnets,
+}: MachinePoolSubnetsFormProps) => {
   const {
-    values: { [FieldId.MachinePoolsSubnets]: machinePoolsSubnets },
     values,
     getFieldProps,
     setFieldValue,
@@ -33,6 +37,8 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
     validateForm,
     setTouched,
   } = useFormState();
+
+  const machinePoolsSubnetsFromProps = allMachinePoolSubnets;
 
   useEffect(
     () => {
@@ -44,12 +50,12 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
         }
       };
 
-      if (machinePoolsSubnets?.length) {
+      if (machinePoolsSubnetsFromProps?.length) {
         updateFormErrors();
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [machinePoolsSubnets, setTouched, validateForm],
+    [machinePoolsSubnetsFromProps, setTouched, validateForm],
   );
 
   // Helper to infer region if not present
@@ -73,22 +79,28 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
     region && selectedVPC ? getMatchingAvailabilityZones(region, selectedVPC, ['private']) : [];
 
   const addMachinePool = (machinePoolSubnet: FormSubnet) =>
-    setFieldValue(FieldId.MachinePoolsSubnets, [...machinePoolsSubnets, machinePoolSubnet], false);
+    setFieldValue(
+      FieldId.MachinePoolsSubnets,
+      [...machinePoolsSubnetsFromProps, machinePoolSubnet],
+      false,
+    );
 
   const removeMachinePool = (machinePoolsSubnetsIndex: number) => {
     setFieldValue(
       FieldId.MachinePoolsSubnets,
-      (machinePoolsSubnets as FormSubnet[]).filter((e, i) => i !== machinePoolsSubnetsIndex),
+      (machinePoolsSubnetsFromProps as FormSubnet[]).filter(
+        (e, i) => i !== machinePoolsSubnetsIndex,
+      ),
     );
     const fieldNameSubnetId = `${FieldId.MachinePoolsSubnets}[${machinePoolsSubnetsIndex}].privateSubnetId`;
     setFieldTouched(fieldNameSubnetId, false, false);
   };
 
   useEffect(() => {
-    if (machinePoolsSubnets === undefined) {
+    if (machinePoolsSubnetsFromProps === undefined || machinePoolsSubnetsFromProps.length === 0) {
       setFieldValue(FieldId.MachinePoolsSubnets, [emptyAWSSubnet()]);
     }
-  }, [machinePoolsSubnets, setFieldValue]);
+  }, [machinePoolsSubnetsFromProps, setFieldValue]);
 
   return (
     <Grid hasGutter>
@@ -105,9 +117,10 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
       </GridItem>
       <GridItem span={6} />
 
-      {(machinePoolsSubnets as FormSubnet[])?.map((subnet, index) => {
-        const isRemoveDisabled = machinePoolsSubnets.length === 1;
+      {(machinePoolsSubnetsFromProps as FormSubnet[])?.map((subnet, index) => {
+        const isRemoveDisabled = machinePoolsSubnetsFromProps.length === 1;
         const fieldNameSubnetId = `${FieldId.MachinePoolsSubnets}[${index}].privateSubnetId`;
+
         return selectedVPC ? (
           // eslint-disable-next-line react/no-array-index-key
           <React.Fragment key={`${subnet.privateSubnetId}_${index}`}>
@@ -117,14 +130,18 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
                 component={SubnetSelectField}
                 name={fieldNameSubnetId}
                 validate={(subnetId: string) =>
-                  validateMultipleMachinePoolsSubnets(subnetId, { machinePoolsSubnets })
+                  validateMultipleMachinePoolsSubnets(subnetId, {
+                    machinePoolsSubnets: machinePoolsSubnetsFromProps,
+                  })
                 }
                 isRequired
                 privacy="private"
                 selectedVPC={selectedVPC}
                 allowedAZs={allowedAZs}
                 withAutoSelect={false}
-                isNewCluster
+                usedSubnetIds={machinePoolsSubnetsFromProps
+                  .map((mp) => mp.privateSubnetId)
+                  .filter((id) => id && id !== subnet.privateSubnetId)}
                 input={{
                   ...getFieldProps(fieldNameSubnetId),
                   onChange: (subnetId: string) => {

--- a/src/components/common/FormikFormComponents/__tests__/MachinePoolSubnetsForm.test.tsx
+++ b/src/components/common/FormikFormComponents/__tests__/MachinePoolSubnetsForm.test.tsx
@@ -10,25 +10,44 @@ import MachinePoolSubnetsForm from '../MachinePoolSubnetsForm';
 
 import { repeatedSubnets } from './MachinePoolSubnetsForm.fixtures';
 
+const machinePoolSubnetsFormProps = {
+  selectedVPC: {
+    name: 'test-123abc-vpc',
+    id: 'vpc-123456789',
+    aws_subnets: [
+      {
+        availability_zone: 'us-east-2a',
+        cidr_block: '10.0.0.0/19',
+        name: 'subnet-03df6fb9d7677c84c',
+        public: false,
+        red_hat_managed: false,
+        subnet_id: 'subnet-03df6fb9d7677c84c',
+      },
+      {
+        availability_zone: 'us-east-2b',
+        cidr_block: '10.0.32.0/19',
+        name: 'subnet-0b6h8g574bcdc20kp',
+        public: false,
+        red_hat_managed: false,
+        subnet_id: 'subnet-0b6h8g574bcdc20kp',
+      },
+      {
+        availability_zone: 'us-east-2c',
+        cidr_block: '10.0.64.0/19',
+        name: 'subnet-0cv67g3h4w859v0t1',
+        public: false,
+        red_hat_managed: false,
+        subnet_id: 'subnet-0cv67g3h4w859v0t1',
+      },
+    ],
+  },
+  allMachinePoolSubnets: [],
+};
+
 describe('<MachinePoolSubnetsForm />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  const defaultProps = {
-    selectedVPC: {
-      name: 'test-123abc-vpc',
-      aws_subnets: [
-        {
-          availability_zone: 'us-east-2a',
-          cidr_block: '10.0.0.0/19',
-          name: 'subnet-03df6fb9d7677c84c',
-          public: false,
-          red_hat_managed: false,
-          subnet_id: 'subnet-03df6fb9d7677c84c',
-        },
-      ],
-    },
-  };
 
   describe('it is accessible', () => {
     it('no content', async () => {
@@ -40,7 +59,10 @@ describe('<MachinePoolSubnetsForm />', () => {
           }}
           onSubmit={() => {}}
         >
-          <MachinePoolSubnetsForm {...defaultProps} />
+          <MachinePoolSubnetsForm
+            {...machinePoolSubnetsFormProps}
+            allMachinePoolSubnets={repeatedSubnets}
+          />
         </Formik>,
       );
 
@@ -57,7 +79,7 @@ describe('<MachinePoolSubnetsForm />', () => {
           }}
           onSubmit={() => {}}
         >
-          <MachinePoolSubnetsForm {...defaultProps} />
+          <MachinePoolSubnetsForm {...machinePoolSubnetsFormProps} />
         </Formik>,
       );
 
@@ -87,10 +109,10 @@ describe('<MachinePoolSubnetsForm />', () => {
           machinePoolsSubnets: [
             undefined,
             {
-              privateSubnetId: 'Subnet is required',
+              privateSubnetId: 'Every machine pool must be associated to a different subnet',
             },
             {
-              privateSubnetId: 'Subnet is required',
+              privateSubnetId: 'Every machine pool must be associated to a different subnet',
             },
           ],
         },
@@ -103,7 +125,10 @@ describe('<MachinePoolSubnetsForm />', () => {
           }}
           onSubmit={() => {}}
         >
-          <MachinePoolSubnetsForm {...defaultProps} />
+          <MachinePoolSubnetsForm
+            {...machinePoolSubnetsFormProps}
+            allMachinePoolSubnets={repeatedSubnets}
+          />
         </Formik>,
       );
 
@@ -114,15 +139,123 @@ describe('<MachinePoolSubnetsForm />', () => {
       await user.click(screen.getAllByLabelText('Remove machine pool')[0]);
 
       // Assert
-      expect(setNestedObjectValuesSpy).toHaveBeenCalledTimes(4);
-      expect(setNestedObjectValuesSpy).toHaveBeenCalledWith(expectedErrors[0], true);
+      expect(setNestedObjectValuesSpy).toHaveBeenCalledTimes(1);
       expect(setNestedObjectValuesSpy).toHaveBeenCalledWith(expectedErrors[1], true);
 
       expect(screen.queryByText('subnet-03df6fb9d7677c84c')).toBe(null);
 
-      expect(getScrollErrorIdsSpy).toHaveBeenCalledTimes(4);
-      expect(getScrollErrorIdsSpy).toHaveBeenCalledWith(expectedErrors[0]);
+      expect(getScrollErrorIdsSpy).toHaveBeenCalledTimes(1);
       expect(getScrollErrorIdsSpy).toHaveBeenCalledWith(expectedErrors[1]);
     });
+  });
+});
+
+describe('subnet ordering and grouping functionality', () => {
+  it('renders subnet select fields grouped by availability zone', async () => {
+    const machinePoolSubnets = [
+      { availabilityZone: '', privateSubnetId: 'subnet-03df6fb9d7677c84c', publicSubnetId: '' },
+      { availabilityZone: '', privateSubnetId: 'subnet-0b6h8g574bcdc20kp', publicSubnetId: '' },
+    ];
+
+    const { user } = withState({}).render(
+      <Formik
+        initialValues={{
+          [FieldId.MachinePoolsSubnets]: machinePoolSubnets,
+        }}
+        onSubmit={() => {}}
+      >
+        <MachinePoolSubnetsForm
+          {...machinePoolSubnetsFormProps}
+          allMachinePoolSubnets={machinePoolSubnets}
+        />
+      </Formik>,
+    );
+
+    const selectDropdowns = screen.getAllByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdowns[1]);
+
+    expect(
+      screen.queryByRole('option', { name: 'subnet-03df6fb9d7677c84c' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'subnet-0b6h8g574bcdc20kp' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'subnet-0cv67g3h4w859v0t1' })).toBeInTheDocument();
+  });
+
+  it('can toggle to view used subnets', async () => {
+    const initialSubnets = [
+      {
+        availabilityZone: 'us-east-2a',
+        privateSubnetId: 'subnet-03df6fb9d7677c84c',
+        publicSubnetId: '',
+      },
+      {
+        availabilityZone: '',
+        privateSubnetId: '',
+        publicSubnetId: '',
+      },
+    ];
+
+    const { user } = withState({}).render(
+      <Formik
+        initialValues={{
+          [FieldId.MachinePoolsSubnets]: initialSubnets,
+        }}
+        onSubmit={() => {}}
+      >
+        <MachinePoolSubnetsForm
+          {...machinePoolSubnetsFormProps}
+          allMachinePoolSubnets={initialSubnets}
+        />
+      </Formik>,
+    );
+
+    const addButton = screen.getByRole('button', { name: /Add machine pool/i });
+    await user.click(addButton);
+
+    const selectDropdowns = screen.getAllByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdowns[1]);
+    const viewUsedButton = screen.getByRole('option', { name: 'View Used Subnets' });
+    await user.click(viewUsedButton);
+
+    //used subnet should be visible with "- Used" suffix in group name
+    expect(screen.getByText('us-east-2a - Used')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'subnet-03df6fb9d7677c84c' })).toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'Hide Used Subnets' })).toBeInTheDocument();
+  });
+
+  it('allows adding and removing machine pools with proper subnet handling', async () => {
+    const initialMachinePoolSubnets = [
+      { availabilityZone: '', privateSubnetId: 'subnet-03df6fb9d7677c84c', publicSubnetId: '' },
+    ];
+
+    const { user } = withState({}).render(
+      <Formik
+        initialValues={{
+          [FieldId.MachinePoolsSubnets]: initialMachinePoolSubnets,
+        }}
+        onSubmit={() => {}}
+      >
+        <MachinePoolSubnetsForm
+          {...machinePoolSubnetsFormProps}
+          allMachinePoolSubnets={initialMachinePoolSubnets}
+        />
+      </Formik>,
+    );
+
+    //add machine pool
+    const addButton = screen.getByRole('button', { name: /Add machine pool/i });
+    expect(addButton).toBeInTheDocument();
+
+    expect(screen.getByText('Machine pool 1')).toBeInTheDocument();
+
+    //select subnet for first machine pool
+    const selectDropdowns = screen.getAllByRole('button', { name: 'Options menu' });
+    await user.click(selectDropdowns[0]);
+    const firstSubnet = screen.getByRole('option', { name: 'subnet-03df6fb9d7677c84c' });
+    expect(firstSubnet).toBeInTheDocument();
+
+    expect(screen.getByRole('option', { name: 'subnet-0b6h8g574bcdc20kp' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'subnet-0cv67g3h4w859v0t1' })).toBeInTheDocument();
   });
 });

--- a/src/components/common/FuzzySelect/FuzzySelect.scss
+++ b/src/components/common/FuzzySelect/FuzzySelect.scss
@@ -8,8 +8,15 @@
   bottom: 0;
   background-color: var(--pf-t--global--background--color--secondary--default);
 }
+
 // Compensating the max height of a scrollable select with footer because the footer is now sticky
 // Increasing from 18.75rem (300px) to 23.75 (380px)
 .fuzzy-select--scrollable-with-footer {
   --pf-v6-c-menu--m-scrollable__content--MaxHeight: 23.75rem;
+}
+
+// Styling for the toggle used subnets options
+.fuzzy-select__toggle-used-subnets {
+  color: var(--pf-t--global--color--brand--default) !important;
+  cursor: pointer;
 }

--- a/src/components/common/FuzzySelect/FuzzySelect.tsx
+++ b/src/components/common/FuzzySelect/FuzzySelect.tsx
@@ -27,6 +27,8 @@ import { FuzzyDataType, FuzzyEntryType } from '~/components/common/FuzzySelect/t
 import { findGroupedItemById, isFuzzyEntryGroup } from './fuzzySelectHelpers';
 
 import './FuzzySelect.scss';
+import { Subnetwork } from '~/types/clusters_mgmt.v1';
+import { isSubnetMatchingPrivacy } from '~/common/vpcHelpers';
 
 export interface FuzzySelectProps
   extends Omit<SelectProps, 'onOpenChange' | 'onOpenChangeKeys' | 'toggle' | 'selected'> {
@@ -65,6 +67,20 @@ export interface FuzzySelectProps
   additionalFilterControls?: React.ReactNode;
   /** Flag to include disabled results while filtering options. Default to false. */
   includeDisabledInSearchResults?: boolean;
+  /** Flag to show/hide used subnets in the dropdown. */
+  showUsedSubnets?: boolean;
+  /** Callback to toggle the visibility of used subnets. */
+  onToggleUsedSubnets?: () => void;
+  /** Flag to indicate if there are any used subnets. */
+  hasUsedSubnets?: boolean;
+  /** Array of used subnets ids. */
+  usedSubnetIds?: string[];
+  /** All available subnets. */
+  allSubnets?: Subnetwork[];
+  /** Privacy setting for subnets. */
+  privacy?: 'public' | 'private';
+  /** Allowed availability zones for subnets. */
+  allowedAZs?: string[];
 }
 
 const defaultSortFn = (a: FuzzyEntryType, b: FuzzyEntryType): number =>
@@ -93,21 +109,108 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
     additionalFilterControls,
     includeDisabledInSearchResults = false,
     isScrollable = true,
+    showUsedSubnets = false,
+    onToggleUsedSubnets,
+    hasUsedSubnets = false,
+    usedSubnetIds = [],
+    allSubnets,
+    privacy,
+    allowedAZs,
     ...rest
   } = props;
 
   const [inputValue, setInputValue] = React.useState<string>('');
   const [filterValue, setFilterValue] = React.useState<string>('');
-  const [selectOptions, setSelectOptions] = React.useState<FuzzyDataType>(selectionData);
+  const [currentSelectOptions, setCurrentSelectOptions] =
+    React.useState<FuzzyDataType>(selectionData);
   const textInputRef = React.useRef<HTMLInputElement>(null);
   const [invalidFilter, setInvalidFilter] = React.useState(false);
-  const isGroupedSelect = isFuzzyEntryGroup(selectOptions);
+  const isGroupedSelect = isFuzzyEntryGroup(selectionData);
 
   const NO_RESULTS = 'no results';
+  const VIEW_MORE_OPTION_ID = 'view-more-used-subnets';
+  const isSubnetSelectMode = Boolean(allSubnets);
 
-  React.useEffect(() => {
+  const generateOptions = useCallback(() => {
+    let allFilteredSubnets: Subnetwork[] = [];
+    if (allSubnets) {
+      allSubnets.forEach((subnet) => {
+        const subnetAZ = subnet.availability_zone || '';
+        if (
+          isSubnetMatchingPrivacy(subnet, privacy) &&
+          (allowedAZs === undefined || allowedAZs.includes(subnetAZ))
+        ) {
+          allFilteredSubnets.push(subnet);
+        }
+      });
+    }
+
+    const unusedSubnets: Subnetwork[] = [];
+    const usedSubnets: Subnetwork[] = [];
+
+    allFilteredSubnets.forEach((subnet) => {
+      if (usedSubnetIds.includes(subnet.subnet_id as string)) {
+        usedSubnets.push(subnet);
+      } else {
+        unusedSubnets.push(subnet);
+      }
+    });
+
+    const subnetsByAZ: FuzzyDataType = {};
+
+    if (unusedSubnets.length > 0) {
+      const unusedByAZ: Record<string, FuzzyEntryType[]> = {};
+      unusedSubnets.forEach((subnet) => {
+        const subnetAZ = subnet.availability_zone || '';
+        if (!unusedByAZ[subnetAZ]) {
+          unusedByAZ[subnetAZ] = [];
+        }
+        unusedByAZ[subnetAZ].push({
+          groupId: subnetAZ,
+          entryId: subnet.subnet_id as string,
+          label: subnet.name || (subnet.subnet_id as string),
+        });
+      });
+
+      Object.entries(unusedByAZ)
+        .sort(([azA], [azB]) => azA.localeCompare(azB))
+        .forEach(([az, subnets]) => {
+          subnetsByAZ[az] = subnets;
+        });
+    }
+
+    if (showUsedSubnets && usedSubnets.length > 0) {
+      const usedByAZ: Record<string, FuzzyEntryType[]> = {};
+      usedSubnets.forEach((subnet) => {
+        const subnetAZ = subnet.availability_zone || '';
+        if (!usedByAZ[subnetAZ]) {
+          usedByAZ[subnetAZ] = [];
+        }
+        usedByAZ[subnetAZ].push({
+          groupId: `${subnetAZ} - Used`,
+          entryId: subnet.subnet_id as string,
+          label: subnet.name || (subnet.subnet_id as string),
+        });
+      });
+
+      Object.entries(usedByAZ)
+        .sort(([azA], [azB]) => azA.localeCompare(azB))
+        .forEach(([az, subnets]) => {
+          const groupKey = `${az} - Used`;
+          subnetsByAZ[groupKey] = subnets;
+        });
+    }
+
+    return subnetsByAZ;
+  }, [allSubnets, usedSubnetIds, showUsedSubnets, privacy, allowedAZs]);
+
+  useEffect(() => {
     if (!filterValue) {
-      setSelectOptions(selectionData);
+      if (isSubnetSelectMode) {
+        setCurrentSelectOptions(generateOptions());
+      } else {
+        setCurrentSelectOptions(selectionData);
+      }
       setInvalidFilter(false);
     } else {
       if (filterValidate) {
@@ -117,10 +220,12 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
       }
 
       let selectionList: FuzzyEntryType[] = [];
-      if (Array.isArray(selectionData)) {
-        selectionList = selectionData;
+      //all options
+      const fullSelectionData = isSubnetSelectMode ? generateOptions() : selectionData;
+      if (Array.isArray(fullSelectionData)) {
+        selectionList = fullSelectionData;
       } else {
-        Object.entries(selectionData || {}).forEach(([_group, list]) => {
+        Object.entries(fullSelectionData || {}).forEach(([_group, list]) => {
           selectionList = [...selectionList, ...list];
         });
       }
@@ -169,12 +274,12 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
       });
 
       if (matchedEntries.length) {
-        setSelectOptions(matchedEntries);
+        setCurrentSelectOptions(matchedEntries);
       } else if (hasGroupEntries) {
-        setSelectOptions(matchedEntriesByGroup);
+        setCurrentSelectOptions(matchedEntriesByGroup);
       } else {
         // no results
-        setSelectOptions([
+        setCurrentSelectOptions([
           {
             disabled: true,
             label: `No results found`,
@@ -188,8 +293,12 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
     filterValue,
     fuzziness,
     includeDisabledInSearchResults,
-    selectionData,
     sortFn,
+    isSubnetSelectMode,
+    selectionData,
+    ...(isSubnetSelectMode
+      ? [allSubnets, usedSubnetIds, showUsedSubnets, privacy, allowedAZs]
+      : []),
   ]);
 
   const closeMenu = useCallback(() => {
@@ -217,16 +326,21 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
       event: React.MouseEvent<Element, MouseEvent> | undefined,
       value: string | number | undefined,
     ) => {
-      if (value && value !== NO_RESULTS) {
-        const optionText = isGroupedSelect
-          ? findGroupedItemById(selectOptions, String(value))?.label
-          : selectOptions.find((option) => option.entryId === value)?.label;
+      if (value == VIEW_MORE_OPTION_ID) {
+        onToggleUsedSubnets?.();
+      } else if (value && value !== NO_RESULTS) {
+        const optionText =
+          isGroupedSelect && !Array.isArray(currentSelectOptions)
+            ? findGroupedItemById(currentSelectOptions, String(value))?.label
+            : Array.isArray(currentSelectOptions)
+              ? currentSelectOptions.find((option) => option.entryId === value)?.label
+              : undefined;
         if (optionText) {
           selectOption(value, optionText, event);
         }
       }
     },
-    [isGroupedSelect, selectOption, selectOptions],
+    [isGroupedSelect, selectOption, currentSelectOptions, onToggleUsedSubnets],
   );
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
@@ -301,85 +415,115 @@ export const FuzzySelect: React.FC<FuzzySelectProps> = (props) => {
     }
 
     if (
-      Array.isArray(selectOptions) &&
-      selectOptions.length === 1 &&
-      selectOptions[0].entryId === NO_RESULTS
+      Array.isArray(currentSelectOptions) &&
+      currentSelectOptions.length === 1 &&
+      currentSelectOptions[0].entryId === NO_RESULTS
     ) {
       return (
         <SelectList aria-label="Select options list">
           <SelectOption isDisabled key="no-results">
-            {selectOptions[0].label}
+            {currentSelectOptions[0].label}
           </SelectOption>
         </SelectList>
       );
     }
 
-    if (Array.isArray(selectOptions)) {
-      const sortedItems = selectOptions.sort(sortFn);
-      return (
-        <SelectList aria-label="Select options list">
-          {sortedItems.map((entry) => {
-            const entryLabel = filterValue ? (
-              <FuzzySelectMatchName key={entry.entryId} entry={entry} filterText={filterValue} />
-            ) : (
-              truncateTextWithEllipsis(entry.label, truncation)
-            );
-            return (
-              <FuzzySelectOption
-                key={entry.entryId}
-                entry={entry}
-                displayLabel={entryLabel}
-                nonTruncatedLabel={entry.label}
-                isPopover={isPopover}
-              />
-            );
-          })}
-        </SelectList>
-      );
+    let optionsToRender: React.ReactNode[] = [];
+
+    if (Array.isArray(currentSelectOptions)) {
+      const sortedItems = currentSelectOptions.sort(sortFn);
+      optionsToRender = sortedItems.map((entry) => {
+        const entryLabel = filterValue ? (
+          <FuzzySelectMatchName key={entry.entryId} entry={entry} filterText={filterValue} />
+        ) : (
+          truncateTextWithEllipsis(entry.label, truncation)
+        );
+        return (
+          <FuzzySelectOption
+            key={entry.entryId}
+            entry={entry}
+            displayLabel={entryLabel}
+            nonTruncatedLabel={entry.label}
+            isPopover={isPopover}
+          />
+        );
+      });
+    } else {
+      const originalOrder = isSubnetSelectMode
+        ? Object.keys(generateOptions())
+        : Object.keys(selectionData);
+      const sortedGroups = filterValue
+        ? Object.entries(currentSelectOptions).sort(
+            ([groupA], [groupB]) => originalOrder.indexOf(groupA) - originalOrder.indexOf(groupB),
+          )
+        : Object.entries(currentSelectOptions);
+
+      optionsToRender = sortedGroups.map(([groupKey, groupEntries], index) => {
+        const showDivider =
+          isSubnetSelectMode &&
+          index > 0 &&
+          !sortedGroups[index - 1][0].endsWith('Used') &&
+          groupKey.endsWith('Used');
+
+        return (
+          <React.Fragment key={groupKey}>
+            {showDivider && <Divider />}
+            <SelectGroup label={groupKey}>
+              <SelectList aria-label={`Select options list for ${groupKey}`}>
+                {groupEntries.map((groupEntry) => {
+                  const entryLabel = filterValue ? (
+                    <FuzzySelectMatchName
+                      key={groupEntry.entryId}
+                      entry={groupEntry}
+                      filterText={filterValue}
+                    />
+                  ) : (
+                    truncateTextWithEllipsis(groupEntry.label, truncation)
+                  );
+                  return (
+                    <FuzzySelectOption
+                      key={groupEntry.entryId}
+                      entry={groupEntry}
+                      displayLabel={entryLabel}
+                      nonTruncatedLabel={groupEntry.label}
+                      isPopover={isPopover}
+                    />
+                  );
+                })}
+              </SelectList>
+            </SelectGroup>
+          </React.Fragment>
+        );
+      });
     }
 
-    const originalOrder = Object.keys(selectionData);
-    const sortedGroups = filterValue
-      ? Object.entries(selectOptions).sort(
-          ([groupA], [groupB]) => originalOrder.indexOf(groupA) - originalOrder.indexOf(groupB),
-        )
-      : Object.entries(selectOptions);
-
-    return sortedGroups.map(([groupKey, groupEntries]) => (
-      <SelectGroup label={groupKey} key={groupKey}>
-        <SelectList aria-label={`Select options list for ${groupKey}`}>
-          {groupEntries.map((groupEntry) => {
-            const entryLabel = filterValue ? (
-              <FuzzySelectMatchName
-                key={groupEntry.entryId}
-                entry={groupEntry}
-                filterText={filterValue}
-              />
-            ) : (
-              truncateTextWithEllipsis(groupEntry.label, truncation)
-            );
-            return (
-              <FuzzySelectOption
-                key={groupEntry.entryId}
-                entry={groupEntry}
-                displayLabel={entryLabel}
-                nonTruncatedLabel={groupEntry.label}
-                isPopover={isPopover}
-              />
-            );
-          })}
-        </SelectList>
-      </SelectGroup>
-    ));
+    if (isSubnetSelectMode && hasUsedSubnets && !filterValue) {
+      optionsToRender.push(
+        <SelectOption
+          key={VIEW_MORE_OPTION_ID}
+          id={VIEW_MORE_OPTION_ID}
+          onClick={(e) => handleSelect(e, VIEW_MORE_OPTION_ID)}
+          className="fuzzy-select__toggle-used-subnets"
+        >
+          {showUsedSubnets ? 'Hide Used Subnets' : 'View Used Subnets'}
+        </SelectOption>,
+      );
+    }
+    return <SelectList aria-label="Select options list">{optionsToRender}</SelectList>;
   }, [
     invalidFilter,
-    selectOptions,
-    selectionData,
+    currentSelectOptions,
     filterValue,
     filterValidate?.message,
     sortFn,
     truncation,
     isPopover,
+    isSubnetSelectMode,
+    hasUsedSubnets,
+    showUsedSubnets,
+    handleSelect,
+    generateOptions,
+    selectionData,
   ]);
 
   const scrollableClass = isScrollable && footer ? ' fuzzy-select--scrollable-with-footer' : '';


### PR DESCRIPTION
# Summary

Already used subnets in a cluster are moved to the bottom of the list in subnet selection for machine pools. Subnets are ordered alphabetically by availability zone and used subnets are listed under a "View/Hide" toggle.

# Jira

Fixes [OCMUI-1029](https://issues.redhat.com/browse/OCMUI-1029)

# How to Test

1. Prepare a ROSA HCP cluster
2. Go to cluster details
3. Create a few machine pools using different subnets
4. Verify subnets are correctly classified into used/unused 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="815" height="836" alt="Screenshot 2025-08-06 at 9 31 16 PM" src="https://github.com/user-attachments/assets/acb03528-dcf6-47f5-bd36-4952ea29a8b6" /> | <img width="599" height="284" alt="Screenshot 2025-08-06 at 9 29 45 PM" src="https://github.com/user-attachments/assets/677a7fe8-ef20-443d-ac4e-a9366d475fa9" /> <img width="633" height="301" alt="Screenshot 2025-07-28 at 9 23 25 PM" src="https://github.com/user-attachments/assets/dbe41091-6e3b-4118-96ef-39af83d1c252" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
