### PR TITLE
OCMUI-3638: Remove duplicate rosa wizard route

### DIFF
--- a/src/components/App/Router.tsx
+++ b/src/components/App/Router.tsx
@@ -191,7 +191,6 @@ const Router: React.FC<RouterProps> = ({ planType, clusterId, externalClusterId 
             </TermsGuard>
           }
         />
-        <Route path="/create/rosa/wizard" element={<CreateROSAWizard />} />
         <Route path="/create" element={<CreateClusterPage activeTab="" />} />
         <Route
           path="/details/s/:id/insights/:reportId/:errorKey"


### PR DESCRIPTION
Link to issue: https://issues.redhat.com/browse/OCMUI-3638

# Summary

<!-- add a summarized description of the PR content -->
The router had a duplicate route for '/create/rosa/wizard'. 
In this PR the second route was removed as it is always ignored.

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->
Fices: [OCMUI-3638](https://issues.redhat.com/browse/OCMUI-3638)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
