### PR TITLE
[OCMUI-3671] ROSA Architecture Rename Followup

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
@@ -16,6 +16,7 @@ import { HAS_USER_DISMISSED_RECOMMENDED_OPERATORS_ALERT } from '~/common/localSt
 import { useNavigate } from '~/common/routing';
 import { normalizedProducts } from '~/common/subscriptionTypes';
 import { PreviewLabel } from '~/components/clusters/common/PreviewLabel';
+import { RosaArchitectureRenamingAlert } from '~/components/clusters/wizards/rosa/common/Banners/RosaArchitectureRenamingAlert';
 import Breadcrumbs from '~/components/common/Breadcrumbs';
 import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
 import { modalActions } from '~/components/common/Modal/ModalActions';
@@ -352,6 +353,8 @@ function ClusterDetailsTop(props) {
       </Split>
 
       {topCard}
+
+      {isROSA ? <RosaArchitectureRenamingAlert /> : null}
 
       <LimitedSupportAlert
         limitedSupportReasons={cluster.limitedSupportReasons}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
@@ -354,7 +354,7 @@ function ClusterDetailsTop(props) {
 
       {topCard}
 
-      {isROSA ? <RosaArchitectureRenamingAlert /> : null}
+      {isROSA ? <RosaArchitectureRenamingAlert className="pf-v6-u-mt-md" /> : null}
 
       <LimitedSupportAlert
         limitedSupportReasons={cluster.limitedSupportReasons}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
@@ -4,8 +4,9 @@ import * as reactRedux from 'react-redux';
 import * as notifications from '@redhat-cloud-services/frontend-components-notifications';
 
 import { normalizedProducts } from '~/common/subscriptionTypes';
+import { ROSA_ARCHITECTURE_RENAMING_ALERT } from '~/queries/featureGates/featureConstants';
 import * as clusterService from '~/services/clusterService';
-import { checkAccessibility, render, screen, within } from '~/testUtils';
+import { checkAccessibility, mockUseFeatureGate, render, screen, within } from '~/testUtils';
 import { SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 
 import clusterStates from '../../../common/clusterStates';
@@ -311,5 +312,31 @@ describe('<ClusterDetailsTop />', () => {
     render(<ClusterDetailsTop {...newProps} />);
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('Should show ROSA Architecture Renaming Alert when feature gate is enabled', () => {
+    // Arrange
+    mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, true]]);
+
+    render(<ClusterDetailsTop {...props} />);
+
+    // Act
+    // Assert
+    expect(
+      screen.getByText('Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed'),
+    ).toBeInTheDocument();
+  });
+
+  it('Should not show ROSA Architecture Renaming Alert when feature gate is disabled', () => {
+    // Arrange
+    mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, false]]);
+
+    render(<ClusterDetailsTop {...props} />);
+
+    // Act
+    // Assert
+    expect(
+      screen.queryByText('Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
@@ -120,7 +120,7 @@ describe('<ClusterDetailsTop />', () => {
     expect(await screen.findByRole('button', { name: 'Open console' })).not.toBeEnabled();
   });
 
-  it('should disable open console button when cluster is unistalling', async () => {
+  it('should disable open console button when cluster is uninstalling', async () => {
     const cluster = { ...defaultCluster, state: clusterStates.uninstalling };
     mockedGetLogs.mockResolvedValue('hello world');
     mockGetClusterServiceForRegion.mockReturnValue({ getLogs: mockedGetLogs });
@@ -314,29 +314,54 @@ describe('<ClusterDetailsTop />', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('Should show ROSA Architecture Renaming Alert when feature gate is enabled', () => {
-    // Arrange
-    mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, true]]);
+  describe('ROSA Architecture Renaming Alert', () => {
+    it('Should show Alert when cluster is ROSA and feature flag is enabled', () => {
+      // Arrange
+      mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, true]]);
+      const rosaCluster = { ...fixtures.ROSAClusterDetails.cluster };
+      const newProps = { ...props, cluster: rosaCluster };
 
-    render(<ClusterDetailsTop {...props} />);
+      render(<ClusterDetailsTop {...newProps} />);
 
-    // Act
-    // Assert
-    expect(
-      screen.getByText('Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed'),
-    ).toBeInTheDocument();
-  });
+      // Act
+      // Assert
+      expect(
+        screen.getByText('Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed'),
+      ).toBeInTheDocument();
+    });
 
-  it('Should not show ROSA Architecture Renaming Alert when feature gate is disabled', () => {
-    // Arrange
-    mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, false]]);
+    it('Should not show Alert when the cluster is not of type ROSA and feature flag is enabled', () => {
+      // Arrange
+      mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, true]]);
+      const nonRosaCluster = { ...fixtures.OSDGCPClusterDetails.cluster };
+      const newProps = { ...props, cluster: nonRosaCluster };
 
-    render(<ClusterDetailsTop {...props} />);
+      render(<ClusterDetailsTop {...newProps} />);
 
-    // Act
-    // Assert
-    expect(
-      screen.queryByText('Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed'),
-    ).not.toBeInTheDocument();
+      // Act
+      // Assert
+      expect(
+        screen.queryByText(
+          'Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should not show ROSA Architecture Renaming Alert when feature gate is disabled', () => {
+      // Arrange
+      mockUseFeatureGate([[ROSA_ARCHITECTURE_RENAMING_ALERT, false]]);
+      const rosaCluster = { ...fixtures.ROSAClusterDetails.cluster };
+      const newProps = { ...props, cluster: rosaCluster };
+
+      render(<ClusterDetailsTop {...newProps} />);
+
+      // Act
+      // Assert
+      expect(
+        screen.queryByText(
+          'Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed',
+        ),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
@@ -369,7 +369,12 @@ const ClusterStatusMonitor = (props) => {
       // Cluster install failure
       if (clusterStatus.state === clusterStates.error) {
         alerts.push(
-          <Alert variant="danger" isInline title={`${errorCode} Cluster installation failed`}>
+          <Alert
+            variant="danger"
+            isInline
+            title={`${errorCode} Cluster installation failed`}
+            className="pf-v6-u-mt-md"
+          >
             <p>
               This cluster cannot be recovered, however you can use the logs and network validation
               to diagnose the problem:

--- a/src/components/clusters/wizards/rosa/CreateRosaGetStarted/CreateRosaGetStarted.tsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaGetStarted/CreateRosaGetStarted.tsx
@@ -55,7 +55,6 @@ const breadcrumbs = (
 const CreateRosaGetStarted = () => (
   <AppPage>
     <PageTitle breadcrumbs={breadcrumbs} title={title(productName)}>
-      <RosaArchitectureRenamingAlert />
       <Content className="pf-v6-u-mt-md pf-v6-u-mb-md">
         <Content component={ContentVariants.p}>
           Deploy fully operational and managed Red Hat OpenShift clusters while leveraging the full
@@ -66,6 +65,7 @@ const CreateRosaGetStarted = () => (
           <ExternalLink href={links.ROSA_COMMUNITY_SLACK}>Slack us</ExternalLink>
         </Content>
       </Content>
+      <RosaArchitectureRenamingAlert />
       <Alert
         variant={AlertVariant.info}
         isInline

--- a/src/components/clusters/wizards/rosa/CreateRosaGetStarted/CreateRosaGetStarted.tsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaGetStarted/CreateRosaGetStarted.tsx
@@ -55,7 +55,7 @@ const breadcrumbs = (
 const CreateRosaGetStarted = () => (
   <AppPage>
     <PageTitle breadcrumbs={breadcrumbs} title={title(productName)}>
-      <Content className="pf-v6-u-mt-md pf-v6-u-mb-md">
+      <Content>
         <Content component={ContentVariants.p}>
           Deploy fully operational and managed Red Hat OpenShift clusters while leveraging the full
           breadth and depth of AWS using ROSA.

--- a/src/components/clusters/wizards/rosa/common/Banners/RosaArchitectureRenamingAlert.tsx
+++ b/src/components/clusters/wizards/rosa/common/Banners/RosaArchitectureRenamingAlert.tsx
@@ -7,7 +7,7 @@ import ExternalLink from '~/components/common/ExternalLink';
 import { ROSA_ARCHITECTURE_RENAMING_ALERT } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 
-const RosaArchitectureRenamingAlert = () => {
+const RosaArchitectureRenamingAlert = ({ className }: { className?: string }) => {
   const allowAlert = useFeatureGate(ROSA_ARCHITECTURE_RENAMING_ALERT);
 
   const learnMoreLink = links.ROSA_ARCHITECTURE_RENAMING_KNOWLEDGE_BASE_ARTICLE;
@@ -17,6 +17,7 @@ const RosaArchitectureRenamingAlert = () => {
       variant="info"
       title="Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed"
       actionLinks={<ExternalLink href={learnMoreLink}>Learn more</ExternalLink>}
+      className={className}
     >
       <List>
         <ListItem>


### PR DESCRIPTION
# Summary

This PR addresses the followup requests, coming from PMs, to add the ROSA Architecture Renaming Alert Banner to the Cluster Details page of ROSA clusters.
It also switches between the description and the Banner on the ROSA Get Started page as requested to group the alerts together. 

More details can be found on the Epic linked to the story this PR comes to address. 

This PR also addresses some white space changes necessary for those changes, which are debatable and optional, but I thought I should correct them in the same effort.
There was also a tiny spelling issue in one of the test names I corrected.

# Jira

Link to issue: [OCMUI-3671](https://issues.redhat.com/browse/OCMUI-3671)

# Additional information

# How to Test

Go to Cluster Details page of a ROSA Classic & HCP Clusters
Verify that the new Alert Banner is present for both

Also, go to ROSA Get Started page
Verify that the 2 alerts are grouped together and that the description is found below the title

# Screen Captures

ROSA Cluster Details (Before):
<img width="1918" height="1036" alt="Before: ROSA Cluster Details page" src="https://github.com/user-attachments/assets/02e85a1e-3b9a-4a21-b34f-aef154083481" />

ROSA Cluster Details (After):
<img width="1918" height="1036" alt="After: ROSA Cluster Details page" src="https://github.com/user-attachments/assets/1ec15182-b349-4902-9ded-0c18c20217e3" />

ROSA Get Started Page (Before):
<img width="1917" height="1036" alt="Before: ROSA Get Started Page" src="https://github.com/user-attachments/assets/9e821b4d-9c71-4297-8a2b-f5d4aa3fb759" />

ROSA Get Started Page (After):
<img width="1917" height="1036" alt="After: ROSA Get Started Page" src="https://github.com/user-attachments/assets/8780301d-4d87-4499-9f9a-5543beb46f6b" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
