### PR TITLE
OCMUI-3586: rosa login command update

### DIFF
--- a/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
+++ b/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
@@ -46,7 +46,7 @@ function ActionRequiredModal({ cluster, isOpen, onClose, regionalInstance }) {
     const oidcConfigID = cluster.aws.sts?.oidc_config?.id;
     const operatorRolePrefix = cluster.aws?.sts?.operator_role_prefix;
     const installerRole = cluster.aws?.sts?.role_arn;
-    const rosaRegionLoginCommand = `rosa login --use-auth-code`;
+    const rosaRegionLoginCommand = `rosa login --use-auth-code --url ${regionalInstance?.url}`;
     const operatorRolesCliCommand = `rosa create operator-roles ${
       isHCPCluster ? '--hosted-cp' : ''
     } --prefix "${operatorRolePrefix}" --oidc-config-id "${oidcConfigID}"  --installer-role-arn ${installerRole}`;

--- a/src/components/clusters/wizards/rosa/ClusterRolesScreen/CustomerOIDCConfiguration.jsx
+++ b/src/components/clusters/wizards/rosa/ClusterRolesScreen/CustomerOIDCConfiguration.jsx
@@ -79,7 +79,11 @@ function CustomerOIDCConfiguration({
   input: { onChange },
   meta: { error, touched },
 }) {
-  const { getFieldProps, getFieldMeta } = useFormState();
+  const {
+    getFieldProps,
+    getFieldMeta,
+    values: { [FieldId.RegionalInstance]: regionalInstance },
+  } = useFormState();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isRefreshLoading, setIsRefreshLoading] = useState(false);
   const [oidcConfigs, setOidcConfigs] = useState([]);
@@ -143,7 +147,7 @@ function CustomerOIDCConfiguration({
     [oidcConfigs],
   );
 
-  const rosaRegionLoginCommand = `rosa login --use-auth-code`;
+  const rosaRegionLoginCommand = `rosa login --use-auth-code --url ${regionalInstance?.url}`;
 
   return (
     <Instructions wide>


### PR DESCRIPTION
# Summary

Update to rosa login commands to reflect new way of loginning into the ROSA CLI. Instead of offline tokens use SSO login command

# Jira

[OCMUI-3586](https://issues.redhat.com/browse/OCMUI-3586)

# Additional information

Simple string update from rosa login --env ${env} to rosa login --use-auth-code

# How to Test

Start creating an hcp cluster.
On Cluster Roles and policies step check Step 3 commands. Confirm that rosa login --use-auth-code is present.
Click on Create new OIDC config link and confirm that in the Popup rosa login --use-auth-code command is present.
Finish cluster creation BUT DO NOT add OIDC config. We need a warning on the cluster installation stepper.
Click on the link Action required on OIDC and operator roles in Cluster installation stepper. Confirm that rosa login --use-auth-code command is present.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| Screenshots of BEFORE are in the Jira ticket | <img width="2552" height="956" alt="image" src="https://github.com/user-attachments/assets/59d775c0-4d04-4420-b214-928e95c39f47" /> 
<img width="2552" height="956" alt="image" src="https://github.com/user-attachments/assets/dedf15ca-a8b2-4a3b-879a-4aa241df2f33" />
|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
