### PR TITLE
[OCMUI-1029]Updated test case to fit the subnet reorder feature definition

### DIFF
--- a/cypress/e2e/rosa-hosted/RosaClusterHostedWizardValidation.js
+++ b/cypress/e2e/rosa-hosted/RosaClusterHostedWizardValidation.js
@@ -155,10 +155,18 @@ describe('Rosa hosted(Hypershift) cluster wizard validations', { tags: ['smoke',
     CreateRosaWizardPage.isTextContainsInPage(
       clusterFieldValidations.ClusterSettings.Machinepool.SubnetRequiredError,
     );
+    CreateRosaWizardPage.checkVieworHideUsedSubnetsPresence(
+      qeInfrastructure.SUBNETS.ZONES[clusterFieldValidations.MachinePools[0].AvailabilityZones]
+        .PRIVATE_SUBNET_NAME,
+      2,
+    );
+    CreateRosaWizardPage.removeMachinePool(2);
+    CreateRosaWizardPage.addMachinePoolLink().click();
     CreateRosaWizardPage.selectMachinePoolPrivateSubnet(
       qeInfrastructure.SUBNETS.ZONES[clusterFieldValidations.MachinePools[0].AvailabilityZones]
         .PRIVATE_SUBNET_NAME,
       2,
+      true,
     );
     CreateRosaWizardPage.isTextContainsInPage(
       clusterFieldValidations.ClusterSettings.Machinepool.DuplicateSubnetsError,

--- a/cypress/pageobjects/CreateRosaWizard.page.js
+++ b/cypress/pageobjects/CreateRosaWizard.page.js
@@ -449,13 +449,31 @@ class CreateRosaCluster extends Page {
     cy.get('[aria-label="Private subnet"]').contains('private').first().click();
   }
 
-  selectMachinePoolPrivateSubnet(privateSubnetNameOrId, machinePoolIndex = 1) {
+  selectMachinePoolPrivateSubnet(
+    privateSubnetNameOrId,
+    machinePoolIndex = 1,
+    viewUsedSubnets = false,
+  ) {
     let mpIndex = machinePoolIndex - 1;
     cy.get(`button[id="machinePoolsSubnets[${mpIndex}].privateSubnetId"]`).click();
+    if (viewUsedSubnets) {
+      cy.contains('button', 'View Used Subnets').scrollIntoView().click();
+    }
     cy.get('input[placeholder="Filter by subnet ID / name"]', { timeout: 50000 })
       .clear()
       .type(privateSubnetNameOrId);
     cy.get('li').contains(privateSubnetNameOrId).scrollIntoView().click();
+  }
+
+  checkVieworHideUsedSubnetsPresence(usedSubnetNameOrId, machinePoolIndex = 1) {
+    let mpIndex = machinePoolIndex - 1;
+    cy.get(`button[id="machinePoolsSubnets[${mpIndex}].privateSubnetId"]`).click();
+    cy.contains('button', 'View Used Subnets').scrollIntoView().should('be.visible').click();
+    cy.get('li').contains(usedSubnetNameOrId).scrollIntoView().should('be.visible');
+    cy.contains('button', 'Hide Used Subnets').scrollIntoView().should('be.visible').click();
+    cy.get('li').should('not.contain', usedSubnetNameOrId);
+    cy.contains('button', 'View Used Subnets').scrollIntoView().should('be.visible');
+    cy.get(`button[id="machinePoolsSubnets[${mpIndex}].privateSubnetId"]`).blur();
   }
 
   removeMachinePool(machinePoolIndex = 1) {


### PR DESCRIPTION
# Summary

Updated test case to fit the subnet reorder feature definition

# Jira
 Fixes [OCMUI-1029](https://issues.redhat.com/browse/OCMUI-1029)

# Additional information

In OCMUI-1029, there was feature definition change in private subnet reorder and display based on the previously selected or added definition. The ROSA hosted validation test case breaks this functionality. This PR will address following parts
1. Fixed broken test case definition.
2. Added new checkpoint for the View used subnets/Hide used subnets feature definitions from wizard side.

# How to Test

Pre conditions

Create necessary cypress env variables and its configuration for the test run. See more details in [doc](https://docs.google.com/document/d/1LNcU9iWMqd40HXJjGn98jcg9fdT2nOr_xIdbwu9BPB4/edit#bookmark=id.ig0sbv83q60l).
Start the server from the PR locally (use the command : reviewx 25)
Run the test case
```
npx cypress run --browser chrome --config baseUrl='https://prod.foo.redhat.com:1337/openshift/' --spec cypress/e2e/rosa-hosted/RosaClusterHostedWizardValidation.js 
```

# Screen Captures

nil
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
