### PR TITLE
OCMUI-3490 Fix root disk size validation

### DIFF
--- a/src/components/common/FormikFormComponents/MachinePoolSubnetsForm.tsx
+++ b/src/components/common/FormikFormComponents/MachinePoolSubnetsForm.tsx
@@ -127,8 +127,9 @@ const MachinePoolSubnetsForm = ({ selectedVPC, warning }: MachinePoolSubnetsForm
                 isNewCluster
                 input={{
                   ...getFieldProps(fieldNameSubnetId),
-                  onChange: (subnetId: string) => {
-                    setFieldValue(fieldNameSubnetId, subnetId, false);
+                  onChange: async (subnetId: string) => {
+                    await setFieldValue(fieldNameSubnetId, subnetId, false);
+                    validateForm();
                   },
                 }}
                 meta={getFieldMeta(fieldNameSubnetId)}


### PR DESCRIPTION
# Summary

The validation message for root disk size is removed when the user changes subnets on the HCP wizard machine pool step.   This PR fixes this issue.  On the Jira ticket there is a nice video showing this bug.

NOTE: This was copied from #12 which was approved by David.

# Jira

Fixes [OCMUI-3490](https://issues.redhat.com/browse/OCMUI-3490) 

# Additional information

This is fixed by re-validating the form after a change.  An `await` was added when setting the subnet field value.  Without it the form would validate before the value was truly set.  

There was an original PR for this that was close a while ago.  The thing added (and truly fixed the issue) is the addition of of `await` when setting the field value.

# How to Test

1. Launch the OCM UI.
2. Open the ROSA wizard, Choose control plane as Hosted.
3. Continue through the wizard until you reach the Machine pools step.
4. Select a VPC and Add couple of machine pool subnet definition.
5. Input the root disk size value as "60" and observe the validation error message.
6. Click on a subnet value and change it (do not add a new machine pool).
7. Ensure the validation error message shown against the root disk size field.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
