### PR TITLE
OCMUI-3604, OCMUI-2836 - [OSD-GCP] Make WIF auth as the default authentication type, [OSD Wizard] WIF authorization, update Auth Type tooltip

### DIFF
--- a/src/components/clusters/wizards/osd/ClusterSettings/CloudProvider/GcpByocFields/GcpByocFields.tsx
+++ b/src/components/clusters/wizards/osd/ClusterSettings/CloudProvider/GcpByocFields/GcpByocFields.tsx
@@ -60,6 +60,7 @@ export const GcpByocFields = (props: GcpByocFieldsProps) => {
 
   const handleAuthChange: ToggleGroupItemProps['onChange'] = (event) => {
     const { id } = event.currentTarget;
+
     const selection =
       id === GCPAuthType.WorkloadIdentityFederation
         ? GCPAuthType.WorkloadIdentityFederation
@@ -95,14 +96,12 @@ export const GcpByocFields = (props: GcpByocFieldsProps) => {
                   bodyContent={
                     <div>
                       <div>
-                        Workload Identity Federation (WIF) uses short-lived credentials which is
+                        Workload Identity Federation (WIF) uses short-lived credentials which are
                         more secure. Use of WIF requires an OSD cluster running OpenShift{' '}
                         <span className="pf-v6-u-font-family-monospace">4.17</span> or later.
                       </div>
                       <br />
-                      <div>
-                        Service Account uses longer-lived credentials, which are less secure.
-                      </div>
+                      <div>Service Account uses long-lived credentials, which are less secure.</div>
                     </div>
                   }
                 >

--- a/src/components/clusters/wizards/osd/ClusterSettings/CloudProvider/GcpByocFields/GcpByocFields.tsx
+++ b/src/components/clusters/wizards/osd/ClusterSettings/CloudProvider/GcpByocFields/GcpByocFields.tsx
@@ -34,7 +34,7 @@ import { WorkloadIdentityFederationPrerequisites } from '~/components/clusters/w
 import { GCPAuthType } from '~/components/clusters/wizards/osd/ClusterSettings/CloudProvider/types';
 import { FieldId } from '~/components/clusters/wizards/osd/constants';
 import ExternalLink from '~/components/common/ExternalLink';
-import { OSD_GCP_WIF } from '~/queries/featureGates/featureConstants';
+import { GCP_WIF_DEFAULT, OSD_GCP_WIF } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
@@ -47,6 +47,7 @@ export const GcpByocFields = (props: GcpByocFieldsProps) => {
   } = useFormState();
 
   const isWifEnabled = useFeatureGate(OSD_GCP_WIF);
+  const isWifDefaultEnabled = useFeatureGate(GCP_WIF_DEFAULT);
 
   const gcpTitle = 'Have you prepared your Google account?';
   const gcpText = `To prepare your account, accept the Google Cloud Terms and Agreements. If you've already accepted the terms, you can continue to complete OSD prerequisites.`;
@@ -70,6 +71,46 @@ export const GcpByocFields = (props: GcpByocFieldsProps) => {
     // when auth type changes, prerequisites change too, so resetting the acknowledgment state
     setFieldValue(FieldId.AcknowledgePrereq, false);
   };
+
+  const authButtons = (
+    <ToggleGroup aria-label="Authentication type">
+      {isWifDefaultEnabled ? (
+        <>
+          <ToggleGroupItem
+            text="Workload Identity Federation"
+            key={0}
+            buttonId={GCPAuthType.WorkloadIdentityFederation}
+            isSelected={authType === GCPAuthType.WorkloadIdentityFederation}
+            onChange={handleAuthChange}
+          />
+          <ToggleGroupItem
+            text="Service Account"
+            key={1}
+            buttonId={GCPAuthType.ServiceAccounts}
+            isSelected={authType === GCPAuthType.ServiceAccounts}
+            onChange={handleAuthChange}
+          />
+        </>
+      ) : (
+        <>
+          <ToggleGroupItem
+            text="Service Account"
+            key={0}
+            buttonId={GCPAuthType.ServiceAccounts}
+            isSelected={authType === GCPAuthType.ServiceAccounts}
+            onChange={handleAuthChange}
+          />
+          <ToggleGroupItem
+            text="Workload Identity Federation"
+            key={1}
+            buttonId={GCPAuthType.WorkloadIdentityFederation}
+            isSelected={authType === GCPAuthType.WorkloadIdentityFederation}
+            onChange={handleAuthChange}
+          />
+        </>
+      )}
+    </ToggleGroup>
+  );
 
   return (
     <Form isWidthLimited onSubmit={(e) => e.preventDefault()}>
@@ -115,22 +156,7 @@ export const GcpByocFields = (props: GcpByocFieldsProps) => {
                 </Popover>
               }
             >
-              <ToggleGroup aria-label="Authentication type">
-                <ToggleGroupItem
-                  text="Service Account"
-                  key={0}
-                  buttonId={GCPAuthType.ServiceAccounts}
-                  isSelected={authType === GCPAuthType.ServiceAccounts}
-                  onChange={handleAuthChange}
-                />
-                <ToggleGroupItem
-                  text="Workload Identity Federation"
-                  key={1}
-                  buttonId={GCPAuthType.WorkloadIdentityFederation}
-                  isSelected={authType === GCPAuthType.WorkloadIdentityFederation}
-                  onChange={handleAuthChange}
-                />
-              </ToggleGroup>
+              {authButtons}
             </FormGroup>
           </FlexItem>
         )}

--- a/src/queries/featureGates/featureConstants.ts
+++ b/src/queries/featureGates/featureConstants.ts
@@ -38,6 +38,7 @@ export const IMDS_SELECTION = 'ocmui-imds-selection';
 export const AWS_TAGS_NEW_MP = 'ocmui-aws-tags-new-mp';
 export const TABBED_MACHINE_POOL_MODAL = 'ocmui-tabbed-machine-pool-modal';
 export const ROSA_ARCHITECTURE_RENAMING_ALERT = 'ocmui-rosa-architecture-renaming-alert';
+export const GCP_WIF_DEFAULT = 'ocmui-gcp-wif-default';
 
 export default {
   AUTO_CLUSTER_TRANSFER_OWNERSHIP,
@@ -62,4 +63,5 @@ export default {
   AWS_TAGS_NEW_MP,
   TABBED_MACHINE_POOL_MODAL,
   ROSA_ARCHITECTURE_RENAMING_ALERT,
+  GCP_WIF_DEFAULT,
 } as const;


### PR DESCRIPTION
# Summary

This PR makes fixes to allow WIF as the default auth type for GCP OSD clusters and changes the wording on the WIF tooltip text to fix a couple grammar errors.
Also flips the order for the auth buttons. As Wif is now the first and Service account is the 2nd.

# Jira

[OCMUI-3604](https://issues.redhat.com/browse/OCMUI-3604) 
[OCMUI-2836](https://issues.redhat.com/browse/OCMUI-2836) 

# Additional information
WIF as the default auth type is behind a feature gate which made this story a bit more tricky. Usually we could just change the formik initialValue for this but because it had to be behind a feature gate I had to edit the initialValues object within the parent component (CreateOSDWizard). 
Because of this, I'm not sure how to add a unit test to properly test this as the logic behind it does not live in the GcpByocFields.tsx component. 
Once this feature is rolled out and the feature gate is enabled for all users, it may be a good idea to have a clean up story to just remove the feature gate logic and the logic for this in CreateOSDWizard.tsx and just update the initialValue in /osd/constants for [FieldId.GcpAuthType] as well as add the unit tests to GcpByocFields.test.tsx

# How to Test

1. Begin creating an OSD Gcp cluster
2. Select Customer cloud subscription as the infrastructure type
3. Proceed to the next step and ensure Workload Identity Federation is the selected default type





# Screen Captures

| OCMUI-3604 After                                             | OCMUI-2836 After                                   |
| --------------------------------------------------- | --------------------------------------- |
| https://github.com/user-attachments/assets/eb7026b8-b38b-46d1-bd2f-b516870068ad | <img width="520" height="481" alt="ocmui2836_after" src="https://github.com/user-attachments/assets/4b42d544-4a10-4eb2-b40d-822137aa186d" /> |

<br />
**OCMUI-3604 (updated) after (buttons switched)** 
<img width="1111" height="743" alt="ocmui3604_flipped_after" src="https://github.com/user-attachments/assets/b667a2d4-b434-4aa0-b869-97be32f3de27" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
