### PR TITLE
OCMUI-3422: E2E test automation - Cloud and Datacenter providers installer pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,14 @@ backend-config.yml
 /cypress/screenshots/
 /cypress/downloads/
 /cypress/videos/
+/cypress/downloads/
 /coverage/
 .nyc_output/out.json
 
 .yalc
 yalc.lock
+
+cypress.env.json
 
 
 *.patch

--- a/cypress/e2e/clusters/CloudInstallers.js
+++ b/cypress/e2e/clusters/CloudInstallers.js
@@ -1,28 +1,27 @@
 import InstallersPage from '../../pageobjects/Installers.page';
 import installerData from '../../fixtures/installer/CloudInstaller.json';
+import { getCurrentOpenshiftVersion } from '../../support/versionUtils';
 
 describe('Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
   let currentVersion;
   before(() => {
-    cy.request(
-      'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4',
-    ).then((response) => {
-      currentVersion = response.body.data[0].versions[0].name;
+    getCurrentOpenshiftVersion().then((version) => {
+      currentVersion = version;
     });
   });
 
   installerData.installerSubpages.forEach((testData, index) => {
     describe(`Verification for: ${testData.name}`, () => {
+      // before(() => {
+      //   if (index > 0) {
+      //     // Clear memory between test suites
+      //     cy.window().then((win) => {
+      //       win.location.href = 'about:blank';
+      //     });
+      //     cy.clearCookies();
+      //     cy.clearLocalStorage();
+      //   }
       before(() => {
-        if (index > 0) {
-          // Clear memory between test suites
-          cy.window().then((win) => {
-            win.location.href = 'about:blank';
-          });
-          cy.clearCookies();
-          cy.clearLocalStorage();
-        }
-
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
       });

--- a/cypress/e2e/clusters/CloudInstallers.js
+++ b/cypress/e2e/clusters/CloudInstallers.js
@@ -19,15 +19,13 @@ describe('Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
           cy.window().then((win) => {
             win.location.href = 'about:blank';
           });
-          cy.wait(2000);
           cy.clearCookies();
           cy.clearLocalStorage();
         }
-      });
 
-      before(() => {
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
+
       });
 
       it('should verify installer and OC CLI dropdowns exist and work', () => {

--- a/cypress/e2e/clusters/CloudInstallers.js
+++ b/cypress/e2e/clusters/CloudInstallers.js
@@ -25,7 +25,6 @@ describe('Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
 
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
-
       });
 
       it('should verify installer and OC CLI dropdowns exist and work', () => {

--- a/cypress/e2e/clusters/CloudInstallers.js
+++ b/cypress/e2e/clusters/CloudInstallers.js
@@ -1,0 +1,135 @@
+import InstallersPage from '../../pageobjects/Installers.page';
+import installerData from '../../fixtures/installer/CloudInstaller.json';
+
+describe('Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
+  // Test a representative sample of pages instead of all 16
+  const pagesToTest = [
+    installerData.installerSubpages[0], // Platform Agnostic Agent-based
+    installerData.installerSubpages[2], // AWS x86_64 Automated
+    installerData.installerSubpages[3], // AWS x86_64 Full Control (has RHCOS)
+    installerData.installerSubpages[7], // Azure x86_64 Automated
+    installerData.installerSubpages[11], // GCP Automated
+    installerData.installerSubpages[15], // IBM PowerVS (different architecture)
+  ];
+
+  before(() => {
+    cy.log(
+      `Testing ${pagesToTest.length} out of ${installerData.installerSubpages.length} pages to prevent memory issues`,
+    );
+  });
+
+  pagesToTest.forEach((testData, index) => {
+    describe(`Verification for: ${testData.name}`, () => {
+      before(() => {
+        if (index > 0) {
+          // Clear memory between test suites
+          cy.window().then((win) => {
+            win.location.href = 'about:blank';
+          });
+          cy.wait(2000);
+          cy.clearCookies();
+          cy.clearLocalStorage();
+        }
+      });
+
+      beforeEach(() => {
+        cy.visit(testData.url);
+        InstallersPage.verifyPageTitle(testData.expectedTitle);
+      });
+
+      it('should verify installer and OC CLI dropdowns exist and work', () => {
+        InstallersPage.verifyInstallerDropdown(testData.installerType);
+        InstallersPage.verifyOCDropdown();
+      });
+
+      it('should verify pull secret buttons are visible', () => {
+        InstallersPage.getPullSecretCopyButton().scrollIntoView().should('be.visible');
+        InstallersPage.getPullSecretDownloadButton().scrollIntoView().should('be.visible');
+      });
+
+      if (testData.hasCommandSnippet) {
+        it('should verify the command snippet and related links', () => {
+          cy.on('uncaught:exception', (err) => {
+            if (err.message.includes('Clipboard write was blocked')) {
+              return false;
+            }
+          });
+
+          cy.window().then((win) => {
+            cy.stub(win.navigator.clipboard, 'writeText').as('clipboardStub');
+          });
+
+          InstallersPage.getCommandSnippetInput().should('have.value', testData.commandText);
+          InstallersPage.clickCommandCopyButton();
+          cy.get('@clipboardStub').should('be.calledOnceWith', testData.commandText);
+
+          if (testData.customizeLink) {
+            InstallersPage.getCustomizationsLink()
+              .should('have.attr', 'href')
+              .and('include', testData.customizeLink);
+          }
+
+          if (testData.telemetryLink) {
+            InstallersPage.getTelemetryLink()
+              .should('have.attr', 'href')
+              .and('include', testData.telemetryLink);
+          }
+        });
+      }
+
+      if (testData.hasPreReleaseLink) {
+        it('should verify the pre-release builds link', () => {
+          InstallersPage.getPrereleaseLink()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', '/openshift/install/')
+            .and('include', '/pre-release');
+        });
+      }
+
+      if (testData.getStartedLink) {
+        it('should have a valid "Get started" button with correct link', () => {
+          InstallersPage.getGetStartedButton().scrollIntoView().should('be.visible');
+
+          InstallersPage.verifyDocumentationLink(
+            InstallersPage.getGetStartedButton(),
+            testData.getStartedLink,
+          );
+        });
+      }
+
+      if (testData.rhcosData) {
+        it('should verify the RHCOS section elements and download links', () => {
+          InstallersPage.getRhcosLearnMoreLink()
+            .scrollIntoView()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', testData.rhcosData.learnMoreLinkPartial);
+
+          // Test only the first RHCOS download button to save memory
+          const firstButton = testData.rhcosData.downloadButtons[0];
+          InstallersPage.getRhcosDownloadButtonByText(firstButton.text)
+            .scrollIntoView()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', firstButton.hrefPartial);
+        });
+      }
+    });
+  });
+
+  describe('Detailed Dropdown Functionality Test - AWS Page', () => {
+    beforeEach(() => {
+      cy.visit('/install/aws/installer-provisioned');
+      cy.wait(2000);
+    });
+
+    it('should thoroughly verify all installer dropdown combinations', () => {
+      InstallersPage.verifyInstallerDropdownThoroughly();
+    });
+
+    it('should thoroughly verify all OC CLI dropdown combinations', () => {
+      InstallersPage.verifyOCDropdownThoroughly();
+    });
+  });
+});

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -19,15 +19,13 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
           cy.window().then((win) => {
             win.location.href = 'about:blank';
           });
-          cy.wait(2000);
           cy.clearCookies();
           cy.clearLocalStorage();
         }
-      });
 
-      before(() => {
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
+
       });
 
       it('should verify installer and OC CLI dropdowns exist', () => {

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -2,22 +2,16 @@ import InstallersPage from '../../pageobjects/Installers.page';
 import installerData from '../../fixtures/installer/DatacenterInstaller.json';
 
 describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
-  // Test a representative sample of pages instead of all 16
-  const pagesToTest = [
-    installerData.installerSubpages[0], // Bare Metal Agent-based (x86_64)
-    installerData.installerSubpages[3], // ARM Bare Metal Agent-based (aarch64)
-    installerData.installerSubpages[8], // IBM Z Agent-based (s390x)
-    installerData.installerSubpages[10], // IBM Power Agent-based (ppc64le)
-    installerData.installerSubpages[16], // vSphere Automated (common datacenter)
-  ];
-
+  let currentVersion;
   before(() => {
-    cy.log(
-      `Testing ${pagesToTest.length} out of ${installerData.installerSubpages.length} datacenter pages to prevent memory issues`,
-    );
+    cy.request(
+      'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4',
+    ).then((response) => {
+      currentVersion = response.body.data[0].versions[0].name;
+    });
   });
 
-  pagesToTest.forEach((testData, index) => {
+  installerData.installerSubpages.forEach((testData, index) => {
     describe(`Verification for: ${testData.name}`, () => {
       before(() => {
         if (index > 0) {
@@ -31,14 +25,14 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
         }
       });
 
-      beforeEach(() => {
+      before(() => {
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
       });
 
       it('should verify installer and OC CLI dropdowns exist', () => {
-        InstallersPage.verifyInstallerDropdown(testData.installerType);
-        InstallersPage.verifyOCDropdown();
+        InstallersPage.verifyInstallerDropdownThoroughly();
+        InstallersPage.verifyOCDropdownThoroughly();
       });
 
       it('should verify pull secret buttons are visible', () => {
@@ -93,6 +87,8 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
           InstallersPage.verifyDocumentationLink(
             InstallersPage.getGetStartedButton(),
             testData.getStartedLink,
+            'documentation',
+            currentVersion,
           );
         });
       }
@@ -123,23 +119,6 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
           }
         });
       }
-    });
-  });
-
-  describe('Detailed Dropdown Functionality Test - First Datacenter Page', () => {
-    const firstDatacenterPage = installerData.installerSubpages[0];
-
-    beforeEach(() => {
-      cy.visit(firstDatacenterPage.url);
-      cy.wait(2000);
-    });
-
-    it('should thoroughly verify all installer dropdown combinations', () => {
-      InstallersPage.verifyInstallerDropdownThoroughly();
-    });
-
-    it('should thoroughly verify all OC CLI dropdown combinations', () => {
-      InstallersPage.verifyOCDropdownThoroughly();
     });
   });
 });

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -101,22 +101,13 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
             .and('have.attr', 'href')
             .and('include', testData.rhcosData.learnMoreLinkPartial);
 
-          // Test only the first RHCOS download button to save memory
-          const firstButton = testData.rhcosData.downloadButtons[0];
-          InstallersPage.getRhcosDownloadButtonByText(firstButton.text)
-            .scrollIntoView()
-            .should('be.visible')
-            .and('have.attr', 'href')
-            .and('include', firstButton.hrefPartial);
-
-          if (testData.rhcosData.downloadButtons.length > 1) {
-            cy.log(
-              `Verifying existence of ${testData.rhcosData.downloadButtons.length - 1} additional RHCOS buttons`,
-            );
-            testData.rhcosData.downloadButtons.slice(1).forEach((button) => {
-              InstallersPage.getRhcosDownloadButtonByText(button.text).should('exist');
-            });
-          }
+          testData.rhcosData.downloadButtons.forEach((button) => {
+            InstallersPage.getRhcosDownloadButtonByText(button.text)
+              .scrollIntoView()
+              .should('be.visible')
+              .and('have.attr', 'href')
+              .and('include', button.hrefPartial);
+          });
         });
       }
     });

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -25,7 +25,6 @@ describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, ()
 
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
-
       });
 
       it('should verify installer and OC CLI dropdowns exist', () => {

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -1,0 +1,145 @@
+import InstallersPage from '../../pageobjects/Installers.page';
+import installerData from '../../fixtures/installer/DatacenterInstaller.json';
+
+describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
+  // Test a representative sample of pages instead of all 16
+  const pagesToTest = [
+    installerData.installerSubpages[0], // Bare Metal Agent-based (x86_64)
+    installerData.installerSubpages[3], // ARM Bare Metal Agent-based (aarch64)
+    installerData.installerSubpages[8], // IBM Z Agent-based (s390x)
+    installerData.installerSubpages[10], // IBM Power Agent-based (ppc64le)
+    installerData.installerSubpages[16], // vSphere Automated (common datacenter)
+  ];
+
+  before(() => {
+    cy.log(
+      `Testing ${pagesToTest.length} out of ${installerData.installerSubpages.length} datacenter pages to prevent memory issues`,
+    );
+  });
+
+  pagesToTest.forEach((testData, index) => {
+    describe(`Verification for: ${testData.name}`, () => {
+      before(() => {
+        if (index > 0) {
+          // Clear memory between test suites
+          cy.window().then((win) => {
+            win.location.href = 'about:blank';
+          });
+          cy.wait(2000);
+          cy.clearCookies();
+          cy.clearLocalStorage();
+        }
+      });
+
+      beforeEach(() => {
+        cy.visit(testData.url);
+        InstallersPage.verifyPageTitle(testData.expectedTitle);
+      });
+
+      it('should verify installer and OC CLI dropdowns exist', () => {
+        InstallersPage.verifyInstallerDropdown(testData.installerType);
+        InstallersPage.verifyOCDropdown();
+      });
+
+      it('should verify pull secret buttons are visible', () => {
+        InstallersPage.getPullSecretCopyButton().scrollIntoView().should('be.visible');
+        InstallersPage.getPullSecretDownloadButton().scrollIntoView().should('be.visible');
+      });
+
+      if (testData.hasCommandSnippet) {
+        it('should verify the command snippet and related links', () => {
+          cy.on('uncaught:exception', (err) => {
+            if (err.message.includes('Clipboard write was blocked')) {
+              return false;
+            }
+          });
+
+          cy.window().then((win) => {
+            cy.stub(win.navigator.clipboard, 'writeText').as('clipboardStub');
+          });
+
+          InstallersPage.getCommandSnippetInput().should('have.value', testData.commandText);
+          InstallersPage.clickCommandCopyButton();
+          cy.get('@clipboardStub').should('be.calledOnceWith', testData.commandText);
+
+          if (testData.customizeLink) {
+            InstallersPage.getCustomizationsLink()
+              .should('have.attr', 'href')
+              .and('include', testData.customizeLink);
+          }
+
+          if (testData.telemetryLink) {
+            InstallersPage.getTelemetryLink()
+              .should('have.attr', 'href')
+              .and('include', testData.telemetryLink);
+          }
+        });
+      }
+
+      if (testData.hasPreReleaseLink) {
+        it('should verify the pre-release builds link', () => {
+          InstallersPage.getPrereleaseLink()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', '/openshift/install/')
+            .and('include', '/pre-release');
+        });
+      }
+
+      if (testData.getStartedLink) {
+        it('should have a valid "Get started" button with correct link', () => {
+          InstallersPage.getGetStartedButton().scrollIntoView().should('be.visible');
+
+          InstallersPage.verifyDocumentationLink(
+            InstallersPage.getGetStartedButton(),
+            testData.getStartedLink,
+          );
+        });
+      }
+
+      if (testData.rhcosData) {
+        it('should verify the RHCOS section elements and download links', () => {
+          InstallersPage.getRhcosLearnMoreLink()
+            .scrollIntoView()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', testData.rhcosData.learnMoreLinkPartial);
+
+          // Test only the first RHCOS download button to save memory
+          const firstButton = testData.rhcosData.downloadButtons[0];
+          InstallersPage.getRhcosDownloadButtonByText(firstButton.text)
+            .scrollIntoView()
+            .should('be.visible')
+            .and('have.attr', 'href')
+            .and('include', firstButton.hrefPartial);
+
+          if (testData.rhcosData.downloadButtons.length > 1) {
+            cy.log(
+              `Verifying existence of ${testData.rhcosData.downloadButtons.length - 1} additional RHCOS buttons`,
+            );
+            testData.rhcosData.downloadButtons.slice(1).forEach((button) => {
+              InstallersPage.getRhcosDownloadButtonByText(button.text).should('exist');
+            });
+          }
+        });
+      }
+    });
+  });
+
+  describe('Detailed Dropdown Functionality Test - First Datacenter Page', () => {
+    const firstDatacenterPage = installerData.installerSubpages[0];
+
+    beforeEach(() => {
+      cy.visit(firstDatacenterPage.url);
+      cy.wait(2000);
+    });
+
+    it('should thoroughly verify all installer dropdown combinations', () => {
+      InstallersPage.verifyInstallerDropdownThoroughly();
+    });
+
+    it('should thoroughly verify all OC CLI dropdown combinations', () => {
+      InstallersPage.verifyOCDropdownThoroughly();
+    });
+  });
+});

--- a/cypress/e2e/clusters/DatacenterInstallers.js
+++ b/cypress/e2e/clusters/DatacenterInstallers.js
@@ -1,28 +1,18 @@
 import InstallersPage from '../../pageobjects/Installers.page';
 import installerData from '../../fixtures/installer/DatacenterInstaller.json';
+import { getCurrentOpenshiftVersion } from '../../support/versionUtils';
 
 describe('Datacenter Installer Subpage Component Tests', { tags: ['smoke'] }, () => {
   let currentVersion;
   before(() => {
-    cy.request(
-      'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4',
-    ).then((response) => {
-      currentVersion = response.body.data[0].versions[0].name;
+    getCurrentOpenshiftVersion().then((version) => {
+      currentVersion = version;
     });
   });
 
   installerData.installerSubpages.forEach((testData, index) => {
     describe(`Verification for: ${testData.name}`, () => {
       before(() => {
-        if (index > 0) {
-          // Clear memory between test suites
-          cy.window().then((win) => {
-            win.location.href = 'about:blank';
-          });
-          cy.clearCookies();
-          cy.clearLocalStorage();
-        }
-
         cy.visit(testData.url);
         InstallersPage.verifyPageTitle(testData.expectedTitle);
       });

--- a/cypress/fixtures/installer/CloudInstaller.json
+++ b/cypress/fixtures/installer/CloudInstaller.json
@@ -1,0 +1,235 @@
+{
+  "installerSubpages": [
+    {
+      "name": "Platform Agnostic Agent-based",
+      "url": "/install/platform-agnostic/agent-based",
+      "expectedTitle": "Install OpenShift on any x86_64 platform locally with Agent",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Platform agnostic (x86_64)",
+      "clusterType": "agent-based",
+      "isDatacenter": false,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "Platform Agnostic User-provisioned",
+      "url": "/install/platform-agnostic/user-provisioned",
+      "expectedTitle": "Install OpenShift on any x86_64 platform with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Platform agnostic (x86_64)",
+      "clusterType": "full-control",
+      "isDatacenter": false,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_any_platform/installing-platform-agnostic",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS ISO",
+            "hrefPartial": "/rhcos/latest/rhcos-live.x86_64.iso"
+          },
+          {
+            "text": "Download RHCOS kernel",
+            "hrefPartial": "/rhcos/latest/rhcos-live-kernel-x86_64"
+          },
+          {
+            "text": "Download RHCOS initramfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-initramfs.x86_64.img"
+          },
+          {
+            "text": "Download RHCOS rootfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-rootfs.x86_64.img"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_any_platform/installing-platform-agnostic"
+    },
+    {
+      "name": "AWS x86_64 Automated",
+      "url": "/install/aws/installer-provisioned",
+      "expectedTitle": "Install OpenShift on AWS with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "commandText": "./openshift-install create cluster",
+      "customizeLink": "/installing_on_aws/installer-provisioned-infrastructure#installing-aws-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "AWS (x86_64)",
+      "clusterType": "automated",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_aws/installing-aws-account"
+    },
+    {
+      "name": "AWS x86_64 Full Control",
+      "url": "/install/aws/user-provisioned",
+      "expectedTitle": "Install OpenShift on AWS with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "hasPreReleaseLink": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "AWS (x86_64)",
+      "clusterType": "full-control",
+      "isDatacenter": false,
+      "getStartedLink": "nstalling_on_aws/user-provisioned-infrastructure#installing-aws-user-infra"
+    },
+    {
+      "name": "AWS ARM Automated",
+      "url": "/install/aws/arm/installer-provisioned",
+      "expectedTitle": "Install OpenShift on AWS with installer-provisioned ARM infrastructure",
+      "installerType": "aarch64",
+      "hasCommandSnippet": true,
+      "hasPreReleaseLink": true,
+      "customizeLink": "/installing_on_aws/installer-provisioned-infrastructure#installing-aws-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "AWS (ARM)",
+      "clusterType": "automated",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_aws/installing-aws-account"
+    },
+    {
+      "name": "AWS ARM Full Control",
+      "url": "/install/aws/arm/user-provisioned",
+      "expectedTitle": "Install OpenShift on AWS with user-provisioned ARM infrastructure",
+      "installerType": "aarch64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "AWS (ARM)",
+      "clusterType": "full-control",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_aws/user-provisioned-infrastructure#installing-aws-user-infra"
+    },
+    {
+      "name": "AWS Multi-architecture",
+      "url": "/install/aws/multi/installer-provisioned",
+      "expectedTitle": "Install OpenShift on AWS with multi-architecture compute machines",
+      "installerType": "multi",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "AWS (multi-architecture)",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#creating-multi-arch-compute-nodes-aws"
+    },
+    {
+      "name": "Azure x86_64 Automated",
+      "url": "/install/azure/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Azure with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_azure/installer-provisioned-infrastructure#installing-azure-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Azure (x86_64)",
+      "clusterType": "automated",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_azure/installer-provisioned-infrastructure#installation-launching-installer_installing-azure-default"
+    },
+    {
+      "name": "Azure x86_64 Full Control",
+      "url": "/install/azure/user-provisioned",
+      "expectedTitle": "Install OpenShift on Azure with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "hasPreReleaseLink": true,
+      "provider": "Azure (x86_64)",
+      "clusterType": "full-control",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_azure/user-provisioned-infrastructure#installing-azure-user-infra"
+    },
+    {
+      "name": "Azure ARM",
+      "url": "/install/azure/arm/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Azure with installer-provisioned ARM infrastructure",
+      "installerType": "aarch64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_azure/installer-provisioned-infrastructure#installing-azure-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Azure (ARM)",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_azure/installer-provisioned-infrastructure#installation-launching-installer_installing-azure-default"
+    },
+    {
+      "name": "Azure Multi-architecture",
+      "url": "/install/azure/multi/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Azure with multi-architecture compute machines",
+      "installerType": "multi",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Azure (multi-architecture)",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#creating-multi-arch-compute-nodes-azure"
+    },
+    {
+      "name": "GCP Automated",
+      "url": "/install/gcp/installer-provisioned",
+      "expectedTitle": "Install OpenShift on GCP with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_gcp/installing-gcp-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Google Cloud",
+      "clusterType": "automated",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_gcp/installing-gcp-account"
+    },
+    {
+      "name": "GCP Full Control",
+      "url": "/install/gcp/user-provisioned",
+      "expectedTitle": "Install OpenShift on GCP with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Google Cloud",
+      "clusterType": "full-control",
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_gcp/installing-gcp-user-infra"
+    },
+    {
+      "name": "IBM Cloud",
+      "url": "/install/ibm-cloud",
+      "expectedTitle": "Install OpenShift on IBM Cloud with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "IBM Cloud",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_ibm_cloud/preparing-to-install-on-ibm-cloud"
+    },
+    {
+      "name": "Bare Metal Multi-architecture",
+      "url": "/install/metal/multi",
+      "expectedTitle": "Install OpenShift on bare metal with multi-architecture compute machines",
+      "installerType": "multi",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Baremetal (multi-architecture)",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#creating-multi-arch-compute-nodes-bare-metal"
+    },
+    {
+      "name": "IBM PowerVS",
+      "url": "/install/powervs/installer-provisioned",
+      "expectedTitle": "Install OpenShift on IBM Power Systems Virtual Server with installer-provisioned infrastructure",
+      "installerType": "ppc64le",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "IBM PowerVS (ppc64le)",
+      "directNavigation": true,
+      "isDatacenter": false,
+      "getStartedLink": "installing_on_ibm_power_virtual_server/preparing-to-install-on-ibm-power-vs"
+    }
+  ]
+}

--- a/cypress/fixtures/installer/DatacenterInstaller.json
+++ b/cypress/fixtures/installer/DatacenterInstaller.json
@@ -1,0 +1,323 @@
+{
+  "installerSubpages": [
+    {
+      "name": "Bare Metal Agent-based",
+      "url": "/install/metal/agent-based",
+      "expectedTitle": "Install OpenShift on Bare Metal locally with Agent",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Bare Metal (x86_64)",
+      "clusterType": "agent-based",
+      "isDatacenter": true,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "Bare Metal Automated",
+      "url": "/install/metal/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Bare Metal with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Bare Metal (x86_64)",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_bare_metal/installer-provisioned-infrastructure#installing-rhel-on-the-provisioner-node_ipi-install-installation-workflow"
+    },
+    {
+      "name": "Bare Metal Full Control",
+      "url": "/install/metal/user-provisioned",
+      "expectedTitle": "Install OpenShift on Bare Metal with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Bare Metal (x86_64)",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_bare_metal/user-provisioned-infrastructure#creating-machines-bare-metal",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS ISO",
+            "hrefPartial": "/rhcos/latest/rhcos-live.x86_64.iso"
+          },
+          {
+            "text": "Download RHCOS kernel",
+            "hrefPartial": "/rhcos/latest/rhcos-live-kernel-x86_64"
+          },
+          {
+            "text": "Download RHCOS initramfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-initramfs.x86_64.img"
+          },
+          {
+            "text": "Download RHCOS rootfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-rootfs.x86_64.img"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_bare_metal/user-provisioned-infrastructure#installing-bare-metal"
+    },
+    {
+      "name": "ARM Bare Metal Agent-based",
+      "url": "/install/arm/agent-based",
+      "expectedTitle": "Install OpenShift on ARM Bare Metal locally with Agent",
+      "installerType": "aarch64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Bare Metal (ARM)",
+      "clusterType": "agent-based",
+      "isDatacenter": true,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "ARM Bare Metal Automated",
+      "url": "/install/arm/installer-provisioned",
+      "expectedTitle": "Install OpenShift on ARM Bare Metal with installer-provisioned infrastructure",
+      "installerType": "aarch64",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Bare Metal (ARM)",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_bare_metal/installer-provisioned-infrastructure#installing-rhel-on-the-provisioner-node_ipi-install-installation-workflow"
+    },
+    {
+      "name": "ARM Bare Metal Full Control",
+      "url": "/install/arm/user-provisioned",
+      "expectedTitle": "Install OpenShift on ARM Bare Metal with user-provisioned infrastructure",
+      "installerType": "aarch64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Bare Metal (ARM)",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_bare_metal/user-provisioned-infrastructure#creating-machines-bare-metal",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS ISO",
+            "hrefPartial": "/rhcos/latest/rhcos-live.aarch64.iso"
+          },
+          {
+            "text": "Download RHCOS kernel",
+            "hrefPartial": "/rhcos/latest/rhcos-live-kernel-aarch64"
+          },
+          {
+            "text": "Download RHCOS initramfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-initramfs.aarch64.img"
+          },
+          {
+            "text": "Download RHCOS rootfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-rootfs.aarch64.img"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_bare_metal/user-provisioned-infrastructure#installing-bare-metal"
+    },
+    {
+      "name": "Azure Stack Hub Automated",
+      "url": "/install/azure-stack-hub/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Azure Stack Hub with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_azure_stack_hub/installer-provisioned-infrastructure#installing-azure-stack-hub-network-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Azure Stack Hub",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_azure_stack_hub/installer-provisioned-infrastructure#ash-preparing-to-install-ipi"
+    },
+    {
+      "name": "Azure Stack Hub Full Control",
+      "url": "/install/azure-stack-hub/user-provisioned",
+      "expectedTitle": "Install OpenShift on Azure Stack Hub with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Azure Stack Hub",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_azure_stack_hub/user-provisioned-infrastructure#installing-azure-stack-hub-user-infra"
+    },
+    {
+      "name": "IBM Z Agent-based",
+      "url": "/install/ibmz/agent-based",
+      "expectedTitle": "Install OpenShift on IBM Z (s390x) locally with Agent",
+      "installerType": "s390x",
+      "hasCommandSnippet": false,
+      "customizeLink": "/installing_an_on-premise_cluster_with_the_agent-based_installer/prepare-pxe-assets-agent#installing-ocp-agent-ibm-z_prepare-pxe-assets-agent",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "IBM Z (s390x)",
+      "clusterType": "agent-based",
+      "isDatacenter": true,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "IBM Z Full Control",
+      "url": "/install/ibmz/user-provisioned",
+      "expectedTitle": "Install OpenShift on IBM Z (s390x) with user-provisioned infrastructure",
+      "installerType": "s390x",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "IBM Z (s390x)",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_ibm_z_and_ibm_linuxone/user-provisioned-infrastructure#installation-user-infra-machines-iso-ibm-z_installing-ibm-z",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS initramfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-initramfs.s390x.img"
+          },
+          {
+            "text": "Download RHCOS kernel",
+            "hrefPartial": "/rhcos/latest/rhcos-live-kernel-s390x"
+          },
+          {
+            "text": "Download RHCOS rootfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-rootfs.s390x.img"
+          },
+          {
+            "text": "Download QCOW2 image",
+            "hrefPartial": "/rhcos/latest/rhcos-qemu.s390x.qcow2.gz"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_ibm_z_and_ibm_linuxone/user-provisioned-infrastructure#installing-ibm-z-reqs"
+    },
+    {
+      "name": "IBM Power Agent-based",
+      "url": "/install/power/agent-based",
+      "expectedTitle": "Install OpenShift on IBM Power (ppc64le) locally with Agent",
+      "installerType": "ppc64le",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "IBM Power (ppc64le)",
+      "clusterType": "agent-based",
+      "isDatacenter": true,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "IBM Power Full Control",
+      "url": "/install/power/user-provisioned",
+      "expectedTitle": "Install OpenShift on IBM Power (ppc64le) with user-provisioned infrastructure",
+      "installerType": "ppc64le",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "IBM Power (ppc64le)",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_ibm_power/installing-ibm-power",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS ISO",
+            "hrefPartial": "/rhcos/latest/rhcos-live.ppc64le.iso"
+          },
+          {
+            "text": "Download RHCOS kernel",
+            "hrefPartial": "/rhcos/latest/rhcos-live-kernel-ppc64le"
+          },
+          {
+            "text": "Download RHCOS initramfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-initramfs.ppc64le.img"
+          },
+          {
+            "text": "Download RHCOS rootfs",
+            "hrefPartial": "/rhcos/latest/rhcos-live-rootfs.ppc64le.img"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_ibm_power/installing-ibm-power"
+    },
+    {
+      "name": "Nutanix AOS Automated",
+      "url": "/install/nutanix/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Nutanix AOS with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Nutanix AOS",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_nutanix/preparing-to-install-on-nutanix"
+    },
+    {
+      "name": "OpenStack Automated",
+      "url": "/install/openstack/installer-provisioned",
+      "expectedTitle": "Install OpenShift on Red Hat OpenStack Platform with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_openstack/installing-openstack-installer-custom",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "Red Hat OpenStack",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_openstack/installing-openstack-installer-custom"
+    },
+    {
+      "name": "OpenStack Full Control",
+      "url": "/install/openstack/user-provisioned",
+      "expectedTitle": "Install OpenShift on Red Hat OpenStack Platform with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "Red Hat OpenStack",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "rhcosData": {
+        "learnMoreLinkPartial": "/installing_on_openstack/installing-openstack-user#installation-osp-creating-image_installing-openstack-user",
+        "downloadButtons": [
+          {
+            "text": "Download RHCOS QCOW",
+            "hrefPartial": "/rhcos/latest/rhcos-openstack.x86_64.qcow2.gz"
+          }
+        ]
+      },
+      "getStartedLink": "installing_on_openstack/installing-openstack-user"
+    },
+    {
+      "name": "vSphere Agent-based",
+      "url": "/install/vsphere/agent-based",
+      "expectedTitle": "Install OpenShift on vSphere locally with Agent",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "vSphere",
+      "clusterType": "agent-based",
+      "isDatacenter": true,
+      "getStartedLink": "installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer"
+    },
+    {
+      "name": "vSphere Automated",
+      "url": "/install/vsphere/installer-provisioned",
+      "expectedTitle": "Install OpenShift on vSphere with installer-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": true,
+      "customizeLink": "/installing_on_vmware_vsphere/installer-provisioned-infrastructure#installing-vsphere-installer-provisioned-customizations",
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "commandText": "./openshift-install create cluster",
+      "provider": "vSphere",
+      "clusterType": "automated",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_vmware_vsphere/installer-provisioned-infrastructure#installing-vsphere-installer-provisioned"
+    },
+    {
+      "name": "vSphere Full Control",
+      "url": "/install/vsphere/user-provisioned",
+      "expectedTitle": "Install OpenShift on vSphere with user-provisioned infrastructure",
+      "installerType": "x86_64",
+      "hasCommandSnippet": false,
+      "telemetryLink": "/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring",
+      "provider": "vSphere",
+      "clusterType": "full-control",
+      "isDatacenter": true,
+      "getStartedLink": "installing_on_vmware_vsphere/user-provisioned-infrastructure#installing-vsphere"
+    }
+  ]
+}

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -48,18 +48,20 @@ class Installers {
     this.getPageTitle().should('contain', expectedTitle);
   }
 
-  verifyDocumentationLink(linkElement, expectedPath, linkType = 'documentation') {
-    const baseUrls = {
-      documentation: 'https://docs.redhat.com/en/documentation/openshift_container_platform/',
-    };
-
+  verifyDocumentationLink(linkElement, expectedPath, linkType = 'documentation', expectedVersion) {
     return linkElement.should('have.attr', 'href').then((href) => {
       expect(href, `${linkType} link should be absolute URL`).to.match(/^https:\/\//);
 
-      const baseUrl = baseUrls[linkType] || baseUrls.documentation;
+      const baseUrl = 'https://docs.redhat.com/en/documentation/openshift_container_platform/';
       expect(href, `${linkType} link should point to correct docs site`).to.include(baseUrl);
 
-      expect(href, `${linkType} link should include version`).to.match(/\/\d+\.\d+\//);
+      if (expectedVersion) {
+        expect(href, `${linkType} link should include version ${expectedVersion}`).to.include(
+          `/${expectedVersion}/`,
+        );
+      } else {
+        expect(href, `${linkType} link should include version`).to.match(/\/\d+\.\d+\//);
+      }
 
       expect(href, `${linkType} link should include correct path`).to.include(expectedPath);
     });

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -22,7 +22,10 @@ class Installers {
   getRhcosSection = () => cy.contains('h3', 'Red Hat Enterprise Linux CoreOS (RHCOS)').parent();
   getRhcosLearnMoreLink = () => this.getRhcosSection().contains('a', 'Learn more');
   getRhcosDownloadButtonByText = (buttonText) => {
-    return cy.getByTestId('download-btn-rhcos').contains(buttonText);
+    return cy.getByTestId('download-btn-rhcos')
+    .contains(buttonText)
+    .parent('a');
+    
   };
   getGetStartedButton = () => cy.contains('a', 'Get started');
 

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -22,10 +22,7 @@ class Installers {
   getRhcosSection = () => cy.contains('h3', 'Red Hat Enterprise Linux CoreOS (RHCOS)').parent();
   getRhcosLearnMoreLink = () => this.getRhcosSection().contains('a', 'Learn more');
   getRhcosDownloadButtonByText = (buttonText) => {
-    return cy.getByTestId('download-btn-rhcos')
-    .contains(buttonText)
-    .parent('a');
-    
+    return cy.getByTestId('download-btn-rhcos').contains(buttonText).parent('a');
   };
   getGetStartedButton = () => cy.contains('a', 'Get started');
 

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -70,22 +70,6 @@ class Installers {
     });
   }
 
-  verifyDropdownsExist() {
-    this.getOSDropdown()
-      .should('exist')
-      .should('be.visible')
-      .find('option')
-      .should('have.length.at.least', 2);
-
-    this.getArchDropdown()
-      .should('exist')
-      .then(($select) => {
-        if (!$select.is(':disabled')) {
-          cy.wrap($select).find('option').should('have.length.at.least', 1);
-        }
-      });
-  }
-
   verifyDownloadButtonExists(installerType) {
     const downloadSelectors = {
       x86_64: '[data-testid="download-btn-x86_64-openshift-install"]',

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -45,7 +45,7 @@ class Installers {
   }
 
   verifyPageTitle(expectedTitle) {
-    this.getPageTitle().should('contain', expectedTitle);
+    this.getPageTitle().should('be.visible', { timeout: 10000 }).should('contain', expectedTitle);
   }
 
   verifyDocumentationLink(linkElement, expectedPath, linkType = 'documentation', expectedVersion) {

--- a/cypress/pageobjects/Installers.page.js
+++ b/cypress/pageobjects/Installers.page.js
@@ -1,0 +1,299 @@
+class Installers {
+  // Getters using aria-labels
+  getOSDropdown = () => cy.get('[aria-label="Select OS dropdown"]').first();
+  getOCOSDropdown = () => cy.get('[aria-label="Select OS dropdown"]').eq(1);
+  getArchDropdown = () => cy.get('[aria-label="Select architecture dropdown"]').first();
+  getOCArchDropdown = () => cy.get('[aria-label="Select architecture dropdown"]').eq(1);
+
+  // For elements without aria-labels, we still need specific selectors
+  getDropdown = (testId) => cy.get(`[data-testid="${testId}"]`);
+  getDownloadButton = (selector) => cy.get(selector);
+  getPullSecretDownloadButton = () => cy.getByTestId('download-pull-secret');
+  getPullSecretCopyButton = () => cy.getByTestId('copy-pull-secret-button');
+  getCommandSnippetContainer = () => cy.getByTestId('copy-command');
+  getCommandSnippetInput = () =>
+    this.getCommandSnippetContainer().find('input[aria-label="Copyable input"]');
+  getCommandSnippetCopyButton = () =>
+    this.getCommandSnippetContainer().find('button[aria-label="Copy to clipboard"]');
+  getPrereleaseLink = () => cy.get('a').contains('Download pre-release builds');
+  getCustomizationsLink = () => cy.contains('a', 'install with customizations');
+  getTelemetryLink = () => cy.contains('a', 'Learn more');
+  getPageTitle = () => cy.get('h1');
+  getRhcosSection = () => cy.contains('h3', 'Red Hat Enterprise Linux CoreOS (RHCOS)').parent();
+  getRhcosLearnMoreLink = () => this.getRhcosSection().contains('a', 'Learn more');
+  getRhcosDownloadButtonByText = (buttonText) => {
+    return cy.getByTestId('download-btn-rhcos').contains(buttonText);
+  };
+  getGetStartedButton = () => cy.contains('a', 'Get started');
+
+  clickCommandCopyButton = () => this.getCommandSnippetCopyButton().click();
+  goBack = () => cy.go('back');
+  selectDropdownOption = (testId, value) => this.getDropdown(testId).select(value);
+
+  getEnabledOptions(testId) {
+    return this.getDropdown(testId).find('option:not([disabled])');
+  }
+
+  getArchValues(archTestId) {
+    return this.getDropdown(archTestId).then(($select) => {
+      if ($select.is(':disabled')) {
+        const onlyValue = $select.find('option:selected').text().trim();
+        return [onlyValue];
+      }
+      return [...$select.find('option:not([disabled])')].map((opt) => opt.innerText.trim());
+    });
+  }
+
+  verifyPageTitle(expectedTitle) {
+    this.getPageTitle().should('contain', expectedTitle);
+  }
+
+  verifyDocumentationLink(linkElement, expectedPath, linkType = 'documentation') {
+    const baseUrls = {
+      documentation: 'https://docs.redhat.com/en/documentation/openshift_container_platform/',
+    };
+
+    return linkElement.should('have.attr', 'href').then((href) => {
+      expect(href, `${linkType} link should be absolute URL`).to.match(/^https:\/\//);
+
+      const baseUrl = baseUrls[linkType] || baseUrls.documentation;
+      expect(href, `${linkType} link should point to correct docs site`).to.include(baseUrl);
+
+      expect(href, `${linkType} link should include version`).to.match(/\/\d+\.\d+\//);
+
+      expect(href, `${linkType} link should include correct path`).to.include(expectedPath);
+    });
+  }
+
+  verifyDropdownsExist() {
+    this.getOSDropdown()
+      .should('exist')
+      .should('be.visible')
+      .find('option')
+      .should('have.length.at.least', 2);
+
+    this.getArchDropdown()
+      .should('exist')
+      .then(($select) => {
+        if (!$select.is(':disabled')) {
+          cy.wrap($select).find('option').should('have.length.at.least', 1);
+        }
+      });
+  }
+
+  verifyDownloadButtonExists(installerType) {
+    const downloadSelectors = {
+      x86_64: '[data-testid="download-btn-x86_64-openshift-install"]',
+      aarch64: '[data-testid="download-btn-aarch64-openshift-install"]',
+      multi: '[data-testid="download-btn-multi-openshift-install"]',
+      ppc64le: '[data-testid="download-btn-ppc64le-openshift-install"]',
+      s390x: '[data-testid="download-btn-s390x-openshift-install"]',
+    };
+
+    const selector = downloadSelectors[installerType] || downloadSelectors['x86_64'];
+
+    cy.get(selector)
+      .should('exist')
+      .should('be.visible')
+      .should('have.attr', 'href')
+      .and('match', /\.(tar\.gz|zip|exe)$/);
+  }
+
+  verifyDownloadForAllCombinations(artifactKey) {
+    const osMap = {
+      Linux: 'linux',
+      MacOS: 'mac',
+      macOS: 'mac',
+      Windows: 'windows',
+      'Linux - RHEL 9': 'rhel9',
+      'RHEL 9 (FIPS)': 'rhel9',
+      'Linux - RHEL 8': 'rhel8',
+    };
+
+    const archMap = {
+      x86_64: 'amd64',
+      aarch64: 'arm64',
+    };
+
+    const isOC = artifactKey === 'client';
+
+    const getOSDropdown = () => (isOC ? this.getOCOSDropdown() : this.getOSDropdown());
+    const getArchDropdown = () => (isOC ? this.getOCArchDropdown() : this.getArchDropdown());
+
+    getOSDropdown()
+      .find('option:not([disabled])')
+      .then(($osOptions) => {
+        const osValues = [...$osOptions].map((o) => o.innerText.trim());
+
+        osValues.forEach((os) => {
+          const osKey = osMap[os] || os.toLowerCase();
+
+          // Get a fresh reference to the dropdown and select the option
+          getOSDropdown().select(os);
+
+          getArchDropdown().then(($archSelect) => {
+            let archValues = [];
+            if ($archSelect.is(':disabled')) {
+              const archValue = $archSelect.find('option:selected').text().trim();
+              archValues = [archValue];
+            } else {
+              archValues = [...$archSelect.find('option:not([disabled])')].map((opt) =>
+                opt.innerText.trim(),
+              );
+            }
+
+            archValues.forEach((arch) => {
+              const rawArch = arch.toLowerCase();
+              const mappedArch = archMap[arch] || rawArch;
+
+              // Select arch if dropdown is enabled - use fresh reference
+              if (!$archSelect.is(':disabled')) {
+                getArchDropdown().select(arch);
+              }
+
+              // Get the appropriate download button based on artifact type
+              const downloadButton =
+                artifactKey === 'client'
+                  ? cy.get('[data-testid="download-btn-oc"]')
+                  : cy
+                      .get('[data-testid*="download-btn-"][data-testid*="-openshift-install"]')
+                      .first();
+
+              // Check the href
+              downloadButton.should('have.attr', 'href').then((href) => {
+                const h = href.toLowerCase();
+
+                // OS folder check
+                expect(h.includes(osKey), `expected OS segment "${osKey}" in ${href}`).to.be.true;
+
+                // Artifact + architecture checks
+                if (osKey === 'mac') {
+                  // Build the mac filename base
+                  const base = `openshift-${artifactKey}-mac`;
+
+                  if (rawArch === 'x86_64') {
+                    // universal mac: no suffix
+                    expect(
+                      h.match(new RegExp(`${base}\\.tar\\.gz$`)),
+                      `expected universal ${artifactKey} URL for mac x86_64, got ${href}`,
+                    ).to.not.be.null;
+                  } else if (rawArch === 'aarch64') {
+                    // arm64-only: -arm64 suffix
+                    expect(
+                      h.match(new RegExp(`${base}-arm64\\.tar\\.gz$`)),
+                      `expected ARM-only ${artifactKey} URL for mac aarch64, got ${href}`,
+                    ).to.not.be.null;
+                  } else {
+                    throw new Error(`Unexpected mac arch "${arch}"`);
+                  }
+                } else {
+                  // Other OS must include either rawArch or mappedArch
+                  const archOk = h.includes(rawArch) || h.includes(mappedArch);
+                  expect(archOk, `expected arch "${rawArch}" or "${mappedArch}" in ${href}`).to.be
+                    .true;
+                }
+              });
+            });
+          });
+        });
+      });
+  }
+
+  verifyInstallerDropdown(installerType) {
+    this.verifyDropdownsExist();
+    this.verifyDownloadButtonExists(installerType);
+  }
+
+  verifyOCDropdown() {
+    cy.get('[data-testid="download-btn-oc"]')
+      .should('exist')
+      .scrollIntoView()
+      .should('be.visible')
+      .should('have.attr', 'href')
+      .and('include', 'client');
+  }
+
+  verifyInstallerDropdownThoroughly() {
+    this.verifyDownloadForAllCombinations('install');
+  }
+
+  verifyOCDropdownThoroughly() {
+    this.verifyDownloadForAllCombinations('client');
+  }
+
+  // Helper methods for testing
+  selectInstallerOS(osName) {
+    this.getOSDropdown().then(($select) => {
+      const options = [...$select.find('option')].map((opt) => ({
+        text: opt.text,
+        value: opt.value,
+      }));
+
+      const matchingOption = options.find(
+        (opt) =>
+          opt.text.toLowerCase().includes(osName.toLowerCase()) ||
+          opt.value.toLowerCase().includes(osName.toLowerCase()),
+      );
+
+      if (matchingOption) {
+        cy.wrap($select).select(matchingOption.value);
+      } else {
+        cy.log(
+          `Could not find "${osName}". Available options: ${options.map((o) => o.text).join(', ')}`,
+        );
+        throw new Error(`Option "${osName}" not found in dropdown`);
+      }
+    });
+  }
+
+  selectOCOS(osName) {
+    this.getOCOSDropdown().then(($select) => {
+      const options = [...$select.find('option')].map((opt) => ({
+        text: opt.text,
+        value: opt.value,
+      }));
+
+      const matchingOption = options.find(
+        (opt) =>
+          opt.text.toLowerCase().includes(osName.toLowerCase()) ||
+          opt.value.toLowerCase().includes(osName.toLowerCase()),
+      );
+
+      if (matchingOption) {
+        cy.wrap($select).select(matchingOption.value);
+      } else {
+        cy.log(
+          `Could not find "${osName}". Available options: ${options.map((o) => o.text).join(', ')}`,
+        );
+        throw new Error(`Option "${osName}" not found in dropdown`);
+      }
+    });
+  }
+
+  verifyInstallerDownloadContains(text) {
+    cy.get('[data-testid="download-btn-x86_64-openshift-install"]')
+      .should('have.attr', 'href')
+      .and('include', text);
+  }
+
+  verifyOCDownloadContains(text) {
+    cy.get('[data-testid="download-btn-oc"]').should('have.attr', 'href').and('include', text);
+  }
+
+  checkIfOSOptionExists(osName) {
+    return this.getOSDropdown().then(($select) => {
+      const options = [...$select.find('option')].map((o) => o.value);
+      return options.some((o) => o.toLowerCase().includes(osName.toLowerCase()));
+    });
+  }
+
+  logAvailableOSOptions() {
+    this.getOSDropdown().then(($select) => {
+      const options = [...$select.find('option')].map((opt) => opt.text);
+      cy.log('Available OS options:', options.join(', '));
+      return options;
+    });
+  }
+}
+
+export default new Installers();

--- a/cypress/support/versionUtils.js
+++ b/cypress/support/versionUtils.js
@@ -1,0 +1,10 @@
+export const getCurrentOpenshiftVersion = () => {
+  return cy
+    .request(
+      'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift+Container+Platform+4',
+    )
+    .then((response) => {
+      const currentVersion = response.body.data[0].versions[0].name;
+      return currentVersion;
+    });
+};

--- a/src/components/clusters/install/instructions/components/GetStarted.jsx
+++ b/src/components/clusters/install/instructions/components/GetStarted.jsx
@@ -31,6 +31,7 @@ const GetStarted = ({ docURL, pendoID, cloudProviderID, customizations, prerequi
       </StackItem>
       <StackItem>
         <Button
+          data-testid="get-started-button"
           component="a"
           href={docURL}
           rel="noreferrer noopener"

--- a/src/components/downloads/CopyPullSecret.tsx
+++ b/src/components/downloads/CopyPullSecret.tsx
@@ -50,6 +50,7 @@ const CopyPullSecret = ({
   const button = (
     <CopyToClipboard text={isDisabled ? '' : tokenView} onCopy={onCopy}>
       <Button
+        data-testid="copy-pull-secret-button"
         variant="link"
         type="button"
         tabIndex={0}


### PR DESCRIPTION
# Summary

E2E test automation for Cloud and Datacenter installers based on [OCP-38888 - [OCM UI] Check elements on the Pre-release webpage, Cloud and Datacenter tab on create page with quota - UI](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-38888)

# Jira

[OCMUI-3422](https://issues.redhat.com/browse/OCMUI-3422)

# Additional information

Covers installers pages for Cloud Tab and Datacenter providers in cluster create page. Especially checks existence of element such as dropdown menus and buttons.  Originally it was 1 test file, but due to the issues with cypress running out of memory and very slow, I have decided to split test files into 2, while keeping 1 object file. This could be also more convenient for reviewers when running it

I have also added cypress.env.json to projects .gitignore file, to avoid potential leaks in future
# How to Test

CLI
`yarn cypress-headless --spec 'cypress/e2e/clusters/CloudInstallers.js'`
`yarn cypress-headless --spec 'cypress/e2e/clusters/DatacenterInstallers.js'`

Cypress UI
`yarn cypress-ui`

# Screen Captures

CloudInstallers.js

<img width="932" height="560" alt="Screenshot From 2025-09-03 23-23-35" src="https://github.com/user-attachments/assets/17dc7665-b778-4902-9e59-0d15e5b4c831" />


DatacenterInstallers.js

<img width="932" height="560" alt="Screenshot From 2025-09-03 23-23-58" src="https://github.com/user-attachments/assets/ecfd748f-1674-447e-bf83-d9095623b62e" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3422]: https://redhat.atlassian.net/browse/OCMUI-3422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ