### PR TITLE
OCMUI-653: Fixed validator messages for CIDR ranges

### DIFF
--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -979,18 +979,18 @@ const awsMachineCidr = (value?: string, formData?: Record<string, string>): stri
 
   if (prefixLength != null) {
     if (prefixLength < AWS_MACHINE_CIDR_MIN) {
-      return `The subnet mask can't be larger than '/${AWS_MACHINE_CIDR_MIN}'.`;
+      return `The subnet mask can't be smaller than '/${AWS_MACHINE_CIDR_MIN}'.`;
     }
 
     if (
       (isMultiAz || formData?.hypershift === 'true') &&
       prefixLength > AWS_MACHINE_CIDR_MAX_MULTI_AZ
     ) {
-      return `The subnet mask can't be smaller than '/${AWS_MACHINE_CIDR_MAX_MULTI_AZ}'.`;
+      return `The subnet mask can't be larger than '/${AWS_MACHINE_CIDR_MAX_MULTI_AZ}'.`;
     }
 
     if (!isMultiAz && prefixLength > AWS_MACHINE_CIDR_MAX_SINGLE_AZ) {
-      return `The subnet mask can't be smaller than '/${AWS_MACHINE_CIDR_MAX_SINGLE_AZ}'.`;
+      return `The subnet mask can't be larger than '/${AWS_MACHINE_CIDR_MAX_SINGLE_AZ}'.`;
     }
   }
 
@@ -1009,13 +1009,13 @@ const gcpMachineCidr = (value?: string, formData?: Record<string, string>): stri
     if (isMultiAz && prefixLength > GCP_MACHINE_CIDR_MAX) {
       const maxComputeNodes = 2 ** (28 - GCP_MACHINE_CIDR_MAX);
       const multiAZ = (maxComputeNodes - 9) * 3;
-      return `The subnet mask can't be smaller than '/${GCP_MACHINE_CIDR_MAX}', which provides up to ${multiAZ} nodes.`;
+      return `The subnet mask can't be larger than '/${GCP_MACHINE_CIDR_MAX}', which provides up to ${multiAZ} nodes.`;
     }
 
     if (!isMultiAz && prefixLength > GCP_MACHINE_CIDR_MAX) {
       const maxComputeNodes = 2 ** (28 - GCP_MACHINE_CIDR_MAX);
       const singleAZ = maxComputeNodes - 9;
-      return `The subnet mask can't be smaller than '/${GCP_MACHINE_CIDR_MAX}', which provides up to ${singleAZ} nodes.`;
+      return `The subnet mask can't be larger than '/${GCP_MACHINE_CIDR_MAX}', which provides up to ${singleAZ} nodes.`;
     }
   }
 
@@ -1032,7 +1032,7 @@ const serviceCidr = (value?: string): string | undefined => {
   if (prefixLength != null) {
     if (prefixLength > SERVICE_CIDR_MAX) {
       const maxServices = 2 ** (32 - SERVICE_CIDR_MAX) - 2;
-      return `The subnet mask can't be smaller than '/${SERVICE_CIDR_MAX}', which provides up to ${maxServices} services.`;
+      return `The subnet mask can't be larger than '/${SERVICE_CIDR_MAX}', which provides up to ${maxServices} services.`;
     }
   }
 
@@ -1047,7 +1047,7 @@ const podCidr = (value?: string, formData?: Record<string, string>): string | un
   const prefixLength = parseCIDRSubnetLength(value);
   if (prefixLength != null) {
     if (prefixLength > POD_CIDR_MAX) {
-      return `The subnet mask can't be smaller than /${POD_CIDR_MAX}.`;
+      return `The subnet mask can't be larger than /${POD_CIDR_MAX}.`;
     }
 
     const hostPrefix = parseCIDRSubnetLength(formData?.network_host_prefix) || 23;
@@ -1183,11 +1183,11 @@ const hostPrefix = (value?: string): string | undefined => {
   if (prefixLength != null) {
     if (prefixLength < HOST_PREFIX_MIN) {
       const maxPodIPs = 2 ** (32 - HOST_PREFIX_MIN) - 2;
-      return `The subnet mask can't be larger than '/${HOST_PREFIX_MIN}', which provides up to ${maxPodIPs} Pod IP addresses.`;
+      return `The subnet mask can't be smaller than '/${HOST_PREFIX_MIN}', which provides up to ${maxPodIPs} Pod IP addresses.`;
     }
     if (prefixLength > HOST_PREFIX_MAX) {
       const maxPodIPs = 2 ** (32 - HOST_PREFIX_MAX) - 2;
-      return `The subnet mask can't be smaller than '/${HOST_PREFIX_MAX}', which provides up to ${maxPodIPs} Pod IP addresses.`;
+      return `The subnet mask can't be larger than '/${HOST_PREFIX_MAX}', which provides up to ${maxPodIPs} Pod IP addresses.`;
     }
   }
 


### PR DESCRIPTION

# Summary

This PR fixes a bug by swapping the messages for "larger than" and "smaller than" subnet masks within the CIDR ranges form fields, ensuring the error messages accurately describe the invalid condition.

# Jira

Fixes [OCMUI-653](https://issues.redhat.com/browse/OCMUI-653)

# Additional information

I wasn't sure what the description in the Jira ticket was expecting, but there's a video showcasing the incorrect error messages within the CIDR range form based on subnet masks. Try to reproduce the bug in the staging environment. Test both _single_ and _multi_ **Availability Zones** in the **Cluster Settings > Details form** when testing ROSA classic and OSD clusters.

# How to Test

1. Launch the portal and navigate to (Hypershift ROSA, Classic, or OSD) cluster creation wizard.
2. Input all the required details and navigate to the CIDR ranges screen.
3. Uncheck the checkbox "Use default values".
4. Provide custom subnet masks for all the fields on the screen.


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="1627" height="1016" alt="Before" src="https://github.com/user-attachments/assets/cf34b62c-ca67-42de-b0b8-de99117a64bf" />|<img width="1595" height="1017" alt="After" src="https://github.com/user-attachments/assets/3326fbf7-02cf-454b-b09c-d91e59a8540e" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
