### PR TITLE
OCMUI-3675 Clear mocks before every unit test

### DIFF
--- a/docs/unit-testing.md
+++ b/docs/unit-testing.md
@@ -371,6 +371,8 @@ In order to achieve this, it is important to ensure that actions taken in one te
 
 See [Avoid Nesting when you’re Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing)
 
+In addition, jest will automatically clear mocks after each test to ensure that mocks aren't bleed between tests.  See [jest documentation](https://jestjs.io/docs/configuration#clearmocks-boolean) for more information.  While manually calling `jest.clearAllMocks()` in a beforeEach or afterEach block is not necessary, it causes no harm and can be added to remind future coders of a given unit test file that clearing mocks is important between tests.
+
 ## Use `user` helper object
 
 When testing user interactions like typing or clicking, use the user helper method that is returned on render. This object has a configuration that works best with the code base. Do not directly use `userEvent` or `fireEvent`.

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ const config = {
   testEnvironmentOptions: {
     customExportConditions: [''],
   },
+  clearMocks: true,
   transform: {
     '^.+\\.(js|jsx|mjs)$': 'babel-jest',
   },

--- a/src/components/clusters/common/TransferClusterOwnershipDialog/utils/__tests__/transferClusterOwnershipDialogSelectors.test.ts
+++ b/src/components/clusters/common/TransferClusterOwnershipDialog/utils/__tests__/transferClusterOwnershipDialogSelectors.test.ts
@@ -84,7 +84,12 @@ describe('Utility functions', () => {
       const result = canTransferClusterOwnershipMultiRegion(cluster);
       expect(result).toBe(true);
       expect(hasCapability).toHaveBeenCalledWith(
-        { capabilities: [subscriptionCapabilities.RELEASE_OCP_CLUSTERS] },
+        {
+          capabilities: [
+            { name: subscriptionCapabilities.RELEASE_OCP_CLUSTERS, inherited: false, value: '' },
+          ],
+          managed: false,
+        },
         subscriptionCapabilities.RELEASE_OCP_CLUSTERS,
       );
     });
@@ -102,7 +107,7 @@ describe('Utility functions', () => {
       const result = canTransferClusterOwnershipMultiRegion(cluster);
       expect(result).toBe(false);
       expect(hasCapability).toHaveBeenCalledWith(
-        { capabilities: [] },
+        { capabilities: [], managed: false },
         subscriptionCapabilities.RELEASE_OCP_CLUSTERS,
       );
     });

--- a/src/components/clusters/common/TransferClusterOwnershipDialog/utils/__tests__/transferClusterOwnershipDialogSelectors.test.ts
+++ b/src/components/clusters/common/TransferClusterOwnershipDialog/utils/__tests__/transferClusterOwnershipDialogSelectors.test.ts
@@ -84,12 +84,7 @@ describe('Utility functions', () => {
       const result = canTransferClusterOwnershipMultiRegion(cluster);
       expect(result).toBe(true);
       expect(hasCapability).toHaveBeenCalledWith(
-        {
-          capabilities: [
-            { name: subscriptionCapabilities.RELEASE_OCP_CLUSTERS, inherited: false, value: '' },
-          ],
-          managed: false,
-        },
+        cluster.subscription,
         subscriptionCapabilities.RELEASE_OCP_CLUSTERS,
       );
     });


### PR DESCRIPTION
# Summary

To prevent mocking bleed-over from one test to another,  this PR changes the jest config so mocks are cleared before each test.  See: https://jestjs.io/docs/configuration#clearmocks-boolean

Note: No application code has changed

# Jira

Fixes [OCMUI-3675](https://issues.redhat.com/browse/OCMUI-3675) 

# Additional information

This PR also fixes tests that were broken with config change.

# How to Test

Run `yarn test` :-) 


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
