### PR TITLE
OCMUI-3618 - When creating a new htpasswd IDP the confirm password field is misaligned

### DIFF
--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
@@ -80,6 +80,7 @@ const MinusButtonGridItem = ({ index, fields, onClick, minusButtonDisabledMessag
         icon={<MinusCircleIcon />}
         variant="link"
         aria-label="Remove"
+        className="minus-button"
       />
     </GridItem>
   );

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
@@ -80,7 +80,7 @@ const MinusButtonGridItem = ({ index, fields, onClick, minusButtonDisabledMessag
         icon={<MinusCircleIcon />}
         variant="link"
         aria-label="Remove"
-        className="minus-button"
+        className="compound-field-array__minus-button"
       />
     </GridItem>
   );

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
@@ -3,7 +3,7 @@ import { Field, FieldArray } from 'formik';
 import { pullAt } from 'lodash';
 import { PropTypes } from 'prop-types';
 
-import { Button, GridItem } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, GridItem } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons';
 
 import { FieldId } from '~/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/constants';
@@ -33,7 +33,27 @@ LabelGridItem.propTypes = {
   helpText: PropTypes.string,
 };
 
-const AddMoreButtonGridItem = ({
+const LabelFlexItem = ({ label, isRequired, helpText }) => (
+  <GridItem className="field-array-title">
+    <p className="pf-v6-c-form__label-text" id="field-array-label">
+      {label}
+      {isRequired ? <span className="pf-v6-c-form__label-required">*</span> : null}
+    </p>
+    {helpText ? (
+      <p className="pf-v6-c-form__helper-text" id="field-array-help-text">
+        {helpText}
+      </p>
+    ) : null}
+  </GridItem>
+);
+
+LabelFlexItem.propTypes = {
+  label: PropTypes.string,
+  isRequired: PropTypes.bool,
+  helpText: PropTypes.string,
+};
+
+const AddMoreButtonFlexItem = ({
   addNewField,
   areFieldsFilled,
   title = 'Add more',
@@ -44,7 +64,7 @@ const AddMoreButtonGridItem = ({
     !areFieldsFilled?.length || areFieldsFilled?.includes(false) || addMoreButtonDisabled;
 
   return (
-    <GridItem className="field-grid-item">
+    <FlexItem>
       <Button
         label={label}
         onClick={addNewField}
@@ -54,11 +74,11 @@ const AddMoreButtonGridItem = ({
       >
         {title}
       </Button>
-    </GridItem>
+    </FlexItem>
   );
 };
 
-AddMoreButtonGridItem.propTypes = {
+AddMoreButtonFlexItem.propTypes = {
   addNewField: PropTypes.func.isRequired,
   areFieldsFilled: PropTypes.arrayOf(PropTypes.bool).isRequired,
   title: PropTypes.string,
@@ -66,11 +86,11 @@ AddMoreButtonGridItem.propTypes = {
   label: PropTypes.string,
 };
 
-const MinusButtonGridItem = ({ index, fields, onClick, minusButtonDisabledMessage }) => {
+const MinusButtonFlexItem = ({ index, fields, onClick, minusButtonDisabledMessage }) => {
   const isOnlyItem = index === 0 && fields.length === 1;
   const disableReason = minusButtonDisabledMessage || 'To delete the item, add another item first.';
   return (
-    <GridItem data-testid="remove-users" className="field-grid-item minus-button" span={1}>
+    <FlexItem className="field-grid-item minus-button" span={1}>
       <ButtonWithTooltip
         disableReason={isOnlyItem && disableReason}
         tooltipProps={{ position: 'right', distance: 0 }}
@@ -79,38 +99,37 @@ const MinusButtonGridItem = ({ index, fields, onClick, minusButtonDisabledMessag
         variant="link"
         aria-label="Remove"
       />
-    </GridItem>
+    </FlexItem>
   );
 };
 
-MinusButtonGridItem.propTypes = {
+MinusButtonFlexItem.propTypes = {
   index: PropTypes.number.isRequired,
   fields: PropTypes.array.isRequired,
   onClick: PropTypes.func.isRequired,
   minusButtonDisabledMessage: PropTypes.string,
 };
 
-const FieldArrayErrorGridItem = ({ isLast, errorMessage, touched, isGroupError }) => {
+const FieldArrayErrorFlexItem = ({ isLast, errorMessage, touched, isGroupError }) => {
   if (errorMessage && isLast && (touched || isGroupError)) {
     return (
-      <GridItem className="field-grid-item pf-v6-c-form__helper-text pf-m-error">
+      <FlexItem className="field-grid-item pf-v6-c-form__helper-text pf-m-error">
         {errorMessage}
-      </GridItem>
+      </FlexItem>
     );
   }
   return null;
 };
 
-FieldArrayErrorGridItem.propTypes = {
+FieldArrayErrorFlexItem.propTypes = {
   isLast: PropTypes.bool.isRequired,
   errorMessage: PropTypes.string,
   touched: PropTypes.bool,
   isGroupError: PropTypes.bool,
 };
 
-const FieldGridItemComponent = (props) => {
-  const { index, fieldSpan, compoundFields, disabled, onFieldChange } = props;
-  const compoundFieldSpan = Math.max(Math.floor(fieldSpan / compoundFields.length), 1);
+const FieldFlexItemComponent = (props) => {
+  const { index, compoundFields, disabled, onFieldChange } = props;
   const { getFieldProps, getFieldMeta, setFieldValue, values } = useFormState();
 
   React.useEffect(() => {
@@ -119,7 +138,7 @@ const FieldGridItemComponent = (props) => {
 
   return (
     <>
-      <GridItem className="field-grid-item" span={compoundFieldSpan}>
+      <FlexItem>
         <Field
           component={ReduxVerticalFormGroup}
           {...compoundFields[0]}
@@ -150,76 +169,78 @@ const FieldGridItemComponent = (props) => {
             undefined
           }
         />
-      </GridItem>
-      <GridItem className="field-grid-item" span={compoundFieldSpan}>
-        <Field
-          component={ReduxVerticalFormGroup}
-          {...compoundFields[1]}
-          id={`users.${index}.password`}
-          name={`users.${index}.password`}
-          type="password"
-          disabled={disabled}
-          input={{
-            ...getFieldProps(`users.${index}.password`),
-            onChange: (_, value) => {
-              onFieldChange(_, value, index, `users.${index}.password`);
-              setFieldValue(`users.${index}.password`, value);
-            },
-            onBlur: (event) => {
-              const { onBlur } = getFieldProps(`users.${index}.password`);
-              onBlur(event);
-            },
-          }}
-          meta={getFieldMeta(`users.${index}.password`)}
-          placeholder={
-            compoundFields[1].getPlaceholderText
-              ? compoundFields[1].getPlaceholderText(index)
-              : undefined
-          }
-          helpText={
-            compoundFields[1].helpText ||
-            (compoundFields[1].getHelpText && compoundFields[1].getHelpText(index)) ||
-            undefined
-          }
-        />
-      </GridItem>
-      <GridItem className="field-grid-item" span={compoundFieldSpan}>
-        <Field
-          component={ReduxVerticalFormGroup}
-          {...compoundFields[2]}
-          id={`users.${index}.password-confirm`}
-          name={`users.${index}.password-confirm`}
-          type="password"
-          disabled={disabled}
-          input={{
-            ...getFieldProps(`users.${index}.password-confirm`),
-            onChange: (_, value) => {
-              onFieldChange(_, value, index, `users.${index}.password-confirm`);
-              setFieldValue(`users.${index}.password-confirm`, value);
-            },
-            onBlur: (event) => {
-              const { onBlur } = getFieldProps(`users.${index}.password-confirm`);
-              onBlur(event);
-            },
-          }}
-          meta={getFieldMeta(`users.${index}.password-confirm`)}
-          placeholder={
-            compoundFields[2].getPlaceholderText
-              ? compoundFields[2].getPlaceholderText(index)
-              : undefined
-          }
-          helpText={
-            compoundFields[2].helpText ||
-            (compoundFields[2].getHelpText && compoundFields[2].getHelpText(index)) ||
-            undefined
-          }
-        />
-      </GridItem>
+      </FlexItem>
+      <Flex>
+        <FlexItem>
+          <Field
+            component={ReduxVerticalFormGroup}
+            {...compoundFields[1]}
+            id={`users.${index}.password`}
+            name={`users.${index}.password`}
+            type="password"
+            disabled={disabled}
+            input={{
+              ...getFieldProps(`users.${index}.password`),
+              onChange: (_, value) => {
+                onFieldChange(_, value, index, `users.${index}.password`);
+                setFieldValue(`users.${index}.password`, value);
+              },
+              onBlur: (event) => {
+                const { onBlur } = getFieldProps(`users.${index}.password`);
+                onBlur(event);
+              },
+            }}
+            meta={getFieldMeta(`users.${index}.password`)}
+            placeholder={
+              compoundFields[1].getPlaceholderText
+                ? compoundFields[1].getPlaceholderText(index)
+                : undefined
+            }
+            helpText={
+              compoundFields[1].helpText ||
+              (compoundFields[1].getHelpText && compoundFields[1].getHelpText(index)) ||
+              undefined
+            }
+          />
+        </FlexItem>
+        <FlexItem>
+          <Field
+            component={ReduxVerticalFormGroup}
+            {...compoundFields[2]}
+            id={`users.${index}.password-confirm`}
+            name={`users.${index}.password-confirm`}
+            type="password"
+            disabled={disabled}
+            input={{
+              ...getFieldProps(`users.${index}.password-confirm`),
+              onChange: (_, value) => {
+                onFieldChange(_, value, index, `users.${index}.password-confirm`);
+                setFieldValue(`users.${index}.password-confirm`, value);
+              },
+              onBlur: (event) => {
+                const { onBlur } = getFieldProps(`users.${index}.password-confirm`);
+                onBlur(event);
+              },
+            }}
+            meta={getFieldMeta(`users.${index}.password-confirm`)}
+            placeholder={
+              compoundFields[2].getPlaceholderText
+                ? compoundFields[2].getPlaceholderText(index)
+                : undefined
+            }
+            helpText={
+              compoundFields[2].helpText ||
+              (compoundFields[2].getHelpText && compoundFields[2].getHelpText(index)) ||
+              undefined
+            }
+          />
+        </FlexItem>
+      </Flex>
     </>
   );
 };
 
-FieldGridItemComponent.propTypes = {
+FieldFlexItemComponent.propTypes = {
   compoundFields: PropTypes.array.isRequired,
   index: PropTypes.number,
   fieldSpan: PropTypes.number,
@@ -301,7 +322,7 @@ export const CompoundFieldArray = (props) => {
                 isRequired={isRequired}
                 helpText={helpText}
               />
-              <AddMoreButtonGridItem
+              <AddMoreButtonFlexItem
                 addNewField={() => addNewField(insert)}
                 areFieldsFilled={areFieldsFilled}
                 label={addMoreTitle}
@@ -310,34 +331,35 @@ export const CompoundFieldArray = (props) => {
               />
             </>
           )}
-
-          {usersData?.map((_, index) => (
-            <React.Fragment key={`${usersData[index]}`}>
-              <FieldGridItemComponent
-                compoundFields={compoundFields}
-                item={`${usersData[index]}`}
-                index={index}
-                onFieldChange={onFieldChange}
-                setTouched={setTouched}
-                fieldSpan={fieldSpan}
-                {...props}
-              />
-              {onlySingleItem ? null : (
-                <MinusButtonGridItem
+          <Flex>
+            {usersData?.map((_, index) => (
+              <React.Fragment key={`${usersData[index]}`}>
+                <FieldFlexItemComponent
+                  compoundFields={compoundFields}
+                  item={`${usersData[index]}`}
                   index={index}
-                  fields={usersData}
-                  onClick={() => removeField(index, remove)}
-                  minusButtonDisabledMessage={minusButtonDisabledMessage}
+                  onFieldChange={onFieldChange}
+                  setTouched={setTouched}
+                  fieldSpan={fieldSpan}
+                  {...props}
                 />
-              )}
-              <FieldArrayErrorGridItem
-                isLast={index === usersData.length - 1}
-                errorMessage={getFieldMeta('users').error}
-                touched={touched}
-                isGroupError={isGroupError}
-              />
-            </React.Fragment>
-          ))}
+                {onlySingleItem ? null : (
+                  <MinusButtonFlexItem
+                    index={index}
+                    fields={usersData}
+                    onClick={() => removeField(index, remove)}
+                    minusButtonDisabledMessage={minusButtonDisabledMessage}
+                  />
+                )}
+                <FieldArrayErrorFlexItem
+                  isLast={index === usersData.length - 1}
+                  errorMessage={getFieldMeta('users').error}
+                  touched={touched}
+                  isGroupError={isGroupError}
+                />
+              </React.Fragment>
+            ))}
+          </Flex>
         </>
       )}
     />

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.jsx
@@ -3,7 +3,7 @@ import { Field, FieldArray } from 'formik';
 import { pullAt } from 'lodash';
 import { PropTypes } from 'prop-types';
 
-import { Button, Flex, FlexItem, GridItem } from '@patternfly/react-core';
+import { Button, GridItem } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons';
 
 import { FieldId } from '~/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/constants';
@@ -11,6 +11,8 @@ import { useFormState } from '~/components/clusters/wizards/hooks';
 
 import ButtonWithTooltip from '../../ButtonWithTooltip';
 import { ReduxVerticalFormGroup } from '../../ReduxFormComponents_deprecated';
+
+import './CompoundFieldArray.scss';
 
 export const LabelGridItem = ({ fieldSpan, label, isRequired, helpText }) => (
   <GridItem className="field-array-title" span={fieldSpan}>
@@ -33,27 +35,7 @@ LabelGridItem.propTypes = {
   helpText: PropTypes.string,
 };
 
-const LabelFlexItem = ({ label, isRequired, helpText }) => (
-  <GridItem className="field-array-title">
-    <p className="pf-v6-c-form__label-text" id="field-array-label">
-      {label}
-      {isRequired ? <span className="pf-v6-c-form__label-required">*</span> : null}
-    </p>
-    {helpText ? (
-      <p className="pf-v6-c-form__helper-text" id="field-array-help-text">
-        {helpText}
-      </p>
-    ) : null}
-  </GridItem>
-);
-
-LabelFlexItem.propTypes = {
-  label: PropTypes.string,
-  isRequired: PropTypes.bool,
-  helpText: PropTypes.string,
-};
-
-const AddMoreButtonFlexItem = ({
+const AddMoreButtonGridItem = ({
   addNewField,
   areFieldsFilled,
   title = 'Add more',
@@ -64,7 +46,7 @@ const AddMoreButtonFlexItem = ({
     !areFieldsFilled?.length || areFieldsFilled?.includes(false) || addMoreButtonDisabled;
 
   return (
-    <FlexItem>
+    <GridItem className="field-grid-item">
       <Button
         label={label}
         onClick={addNewField}
@@ -74,11 +56,11 @@ const AddMoreButtonFlexItem = ({
       >
         {title}
       </Button>
-    </FlexItem>
+    </GridItem>
   );
 };
 
-AddMoreButtonFlexItem.propTypes = {
+AddMoreButtonGridItem.propTypes = {
   addNewField: PropTypes.func.isRequired,
   areFieldsFilled: PropTypes.arrayOf(PropTypes.bool).isRequired,
   title: PropTypes.string,
@@ -86,11 +68,11 @@ AddMoreButtonFlexItem.propTypes = {
   label: PropTypes.string,
 };
 
-const MinusButtonFlexItem = ({ index, fields, onClick, minusButtonDisabledMessage }) => {
+const MinusButtonGridItem = ({ index, fields, onClick, minusButtonDisabledMessage }) => {
   const isOnlyItem = index === 0 && fields.length === 1;
   const disableReason = minusButtonDisabledMessage || 'To delete the item, add another item first.';
   return (
-    <FlexItem className="field-grid-item minus-button" span={1}>
+    <GridItem data-testid="remove-users" className="field-grid-item minus-button" span={1}>
       <ButtonWithTooltip
         disableReason={isOnlyItem && disableReason}
         tooltipProps={{ position: 'right', distance: 0 }}
@@ -99,37 +81,38 @@ const MinusButtonFlexItem = ({ index, fields, onClick, minusButtonDisabledMessag
         variant="link"
         aria-label="Remove"
       />
-    </FlexItem>
+    </GridItem>
   );
 };
 
-MinusButtonFlexItem.propTypes = {
+MinusButtonGridItem.propTypes = {
   index: PropTypes.number.isRequired,
   fields: PropTypes.array.isRequired,
   onClick: PropTypes.func.isRequired,
   minusButtonDisabledMessage: PropTypes.string,
 };
 
-const FieldArrayErrorFlexItem = ({ isLast, errorMessage, touched, isGroupError }) => {
+const FieldArrayErrorGridItem = ({ isLast, errorMessage, touched, isGroupError }) => {
   if (errorMessage && isLast && (touched || isGroupError)) {
     return (
-      <FlexItem className="field-grid-item pf-v6-c-form__helper-text pf-m-error">
+      <GridItem className="field-grid-item pf-v6-c-form__helper-text pf-m-error">
         {errorMessage}
-      </FlexItem>
+      </GridItem>
     );
   }
   return null;
 };
 
-FieldArrayErrorFlexItem.propTypes = {
+FieldArrayErrorGridItem.propTypes = {
   isLast: PropTypes.bool.isRequired,
   errorMessage: PropTypes.string,
   touched: PropTypes.bool,
   isGroupError: PropTypes.bool,
 };
 
-const FieldFlexItemComponent = (props) => {
-  const { index, compoundFields, disabled, onFieldChange } = props;
+const FieldGridItemComponent = (props) => {
+  const { index, fieldSpan, compoundFields, disabled, onFieldChange } = props;
+  const compoundFieldSpan = Math.max(Math.floor(fieldSpan / compoundFields.length), 1);
   const { getFieldProps, getFieldMeta, setFieldValue, values } = useFormState();
 
   React.useEffect(() => {
@@ -138,7 +121,7 @@ const FieldFlexItemComponent = (props) => {
 
   return (
     <>
-      <FlexItem>
+      <GridItem className="field-grid-item" span={compoundFieldSpan}>
         <Field
           component={ReduxVerticalFormGroup}
           {...compoundFields[0]}
@@ -169,78 +152,77 @@ const FieldFlexItemComponent = (props) => {
             undefined
           }
         />
-      </FlexItem>
-      <Flex>
-        <FlexItem>
-          <Field
-            component={ReduxVerticalFormGroup}
-            {...compoundFields[1]}
-            id={`users.${index}.password`}
-            name={`users.${index}.password`}
-            type="password"
-            disabled={disabled}
-            input={{
-              ...getFieldProps(`users.${index}.password`),
-              onChange: (_, value) => {
-                onFieldChange(_, value, index, `users.${index}.password`);
-                setFieldValue(`users.${index}.password`, value);
-              },
-              onBlur: (event) => {
-                const { onBlur } = getFieldProps(`users.${index}.password`);
-                onBlur(event);
-              },
-            }}
-            meta={getFieldMeta(`users.${index}.password`)}
-            placeholder={
-              compoundFields[1].getPlaceholderText
-                ? compoundFields[1].getPlaceholderText(index)
-                : undefined
-            }
-            helpText={
-              compoundFields[1].helpText ||
-              (compoundFields[1].getHelpText && compoundFields[1].getHelpText(index)) ||
-              undefined
-            }
-          />
-        </FlexItem>
-        <FlexItem>
-          <Field
-            component={ReduxVerticalFormGroup}
-            {...compoundFields[2]}
-            id={`users.${index}.password-confirm`}
-            name={`users.${index}.password-confirm`}
-            type="password"
-            disabled={disabled}
-            input={{
-              ...getFieldProps(`users.${index}.password-confirm`),
-              onChange: (_, value) => {
-                onFieldChange(_, value, index, `users.${index}.password-confirm`);
-                setFieldValue(`users.${index}.password-confirm`, value);
-              },
-              onBlur: (event) => {
-                const { onBlur } = getFieldProps(`users.${index}.password-confirm`);
-                onBlur(event);
-              },
-            }}
-            meta={getFieldMeta(`users.${index}.password-confirm`)}
-            placeholder={
-              compoundFields[2].getPlaceholderText
-                ? compoundFields[2].getPlaceholderText(index)
-                : undefined
-            }
-            helpText={
-              compoundFields[2].helpText ||
-              (compoundFields[2].getHelpText && compoundFields[2].getHelpText(index)) ||
-              undefined
-            }
-          />
-        </FlexItem>
-      </Flex>
+      </GridItem>
+      <GridItem className="field-grid-item" span={compoundFieldSpan}>
+        <Field
+          component={ReduxVerticalFormGroup}
+          {...compoundFields[1]}
+          id={`users.${index}.password`}
+          name={`users.${index}.password`}
+          type="password"
+          disabled={disabled}
+          input={{
+            ...getFieldProps(`users.${index}.password`),
+            onChange: (_, value) => {
+              onFieldChange(_, value, index, `users.${index}.password`);
+              setFieldValue(`users.${index}.password`, value);
+            },
+            onBlur: (event) => {
+              const { onBlur } = getFieldProps(`users.${index}.password`);
+              onBlur(event);
+            },
+          }}
+          meta={getFieldMeta(`users.${index}.password`)}
+          placeholder={
+            compoundFields[1].getPlaceholderText
+              ? compoundFields[1].getPlaceholderText(index)
+              : undefined
+          }
+          helpText={
+            compoundFields[1].helpText ||
+            (compoundFields[1].getHelpText && compoundFields[1].getHelpText(index)) ||
+            undefined
+          }
+        />
+      </GridItem>
+      <GridItem className="field-grid-item" span={compoundFieldSpan}>
+        <Field
+          component={ReduxVerticalFormGroup}
+          {...compoundFields[2]}
+          id={`users.${index}.password-confirm`}
+          name={`users.${index}.password-confirm`}
+          type="password"
+          disabled={disabled}
+          input={{
+            ...getFieldProps(`users.${index}.password-confirm`),
+            onChange: (_, value) => {
+              onFieldChange(_, value, index, `users.${index}.password-confirm`);
+              setFieldValue(`users.${index}.password-confirm`, value);
+            },
+            onBlur: (event) => {
+              const { onBlur } = getFieldProps(`users.${index}.password-confirm`);
+              onBlur(event);
+            },
+          }}
+          meta={getFieldMeta(`users.${index}.password-confirm`)}
+          placeholder={
+            compoundFields[2].getPlaceholderText
+              ? compoundFields[2].getPlaceholderText(index)
+              : undefined
+          }
+          helpText={
+            compoundFields[2].helpText ||
+            (compoundFields[2].getHelpText && compoundFields[2].getHelpText(index)) ||
+            undefined
+          }
+          formGroupClass="confirm-password-field"
+        />
+      </GridItem>
     </>
   );
 };
 
-FieldFlexItemComponent.propTypes = {
+FieldGridItemComponent.propTypes = {
   compoundFields: PropTypes.array.isRequired,
   index: PropTypes.number,
   fieldSpan: PropTypes.number,
@@ -322,7 +304,7 @@ export const CompoundFieldArray = (props) => {
                 isRequired={isRequired}
                 helpText={helpText}
               />
-              <AddMoreButtonFlexItem
+              <AddMoreButtonGridItem
                 addNewField={() => addNewField(insert)}
                 areFieldsFilled={areFieldsFilled}
                 label={addMoreTitle}
@@ -331,35 +313,34 @@ export const CompoundFieldArray = (props) => {
               />
             </>
           )}
-          <Flex>
-            {usersData?.map((_, index) => (
-              <React.Fragment key={`${usersData[index]}`}>
-                <FieldFlexItemComponent
-                  compoundFields={compoundFields}
-                  item={`${usersData[index]}`}
+
+          {usersData?.map((_, index) => (
+            <React.Fragment key={`${usersData[index]}`}>
+              <FieldGridItemComponent
+                compoundFields={compoundFields}
+                item={`${usersData[index]}`}
+                index={index}
+                onFieldChange={onFieldChange}
+                setTouched={setTouched}
+                fieldSpan={fieldSpan}
+                {...props}
+              />
+              {onlySingleItem ? null : (
+                <MinusButtonGridItem
                   index={index}
-                  onFieldChange={onFieldChange}
-                  setTouched={setTouched}
-                  fieldSpan={fieldSpan}
-                  {...props}
+                  fields={usersData}
+                  onClick={() => removeField(index, remove)}
+                  minusButtonDisabledMessage={minusButtonDisabledMessage}
                 />
-                {onlySingleItem ? null : (
-                  <MinusButtonFlexItem
-                    index={index}
-                    fields={usersData}
-                    onClick={() => removeField(index, remove)}
-                    minusButtonDisabledMessage={minusButtonDisabledMessage}
-                  />
-                )}
-                <FieldArrayErrorFlexItem
-                  isLast={index === usersData.length - 1}
-                  errorMessage={getFieldMeta('users').error}
-                  touched={touched}
-                  isGroupError={isGroupError}
-                />
-              </React.Fragment>
-            ))}
-          </Flex>
+              )}
+              <FieldArrayErrorGridItem
+                isLast={index === usersData.length - 1}
+                errorMessage={getFieldMeta('users').error}
+                touched={touched}
+                isGroupError={isGroupError}
+              />
+            </React.Fragment>
+          ))}
         </>
       )}
     />

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
@@ -2,6 +2,6 @@
   white-space: nowrap;
 }
 
-.minus-button {
-  margin-top: 1em;
+.compound-field-array__minus-button {
+  margin-top: 2em;
 }

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
@@ -1,0 +1,3 @@
+.confirm-password-field {
+  white-space: nowrap;
+}

--- a/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
+++ b/src/components/common/FormikFormComponents/FormikFieldArray/CompoundFieldArray.scss
@@ -1,3 +1,7 @@
 .confirm-password-field {
   white-space: nowrap;
 }
+
+.minus-button {
+  margin-top: 1em;
+}


### PR DESCRIPTION
# Summary

In the confirm password field in CompoundFieldArray.jsx, when the label "Confirm password *" was wrapping, it caused the input field to drop a line. To fix it I added a no-wrap css property to the field 

# Jira

Fixes [OCMUI-3618](https://issues.redhat.com/browse/OCMUI-3618)

# How to Test

1. In an existing cluster go to Access control --> htpasswd idp
2. Check the responsiveness of the fields for username, password and confirm password and make sure the fields do not misalign 



# Screen Captures

| Before                                              | After                                   |
|--------------------------------------------------- | --------------------------------------- |
| <img width="565" height="735" alt="ocmui3618_before" src="https://github.com/user-attachments/assets/a1d5f770-1f3f-414b-8a94-d37a3e53b45e" /> | <img width="694" height="478" alt="ocmui3618_new" src="https://github.com/user-attachments/assets/84043a7c-c48b-4be3-b3d3-2aa6780bd266" /> |


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
