### PR TITLE
OCMUI-3102: Hide resizing alert during node scaling in ROSA HCP 

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import { screen } from '@testing-library/react';
+
+import * as utils from '~/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/components/utils';
+import { withState } from '~/testUtils';
+import { MachinePool } from '~/types/clusters_mgmt.v1';
+import { ClusterFromSubscription } from '~/types/types';
+
+import EditNodeCountSection from './EditNodeCountSection';
+
+const defaultMachinePool: MachinePool = {
+  id: 'foo',
+  replicas: 30,
+  availability_zones: ['us-east-1a'],
+  instance_type: 'm5.xlarge',
+} as MachinePool;
+
+const initialState = {
+  userProfile: {
+    organization: {
+      pending: false,
+      fulfilled: true,
+      quotaList: { items: [] },
+    },
+  },
+  clusterAutoscaler: {
+    hasAutoscaler: false,
+  },
+};
+
+const nonHCPCluster: ClusterFromSubscription = {
+  product: { id: 'ROSA' },
+  cloud_provider: { id: 'aws' },
+  hypershift: { enabled: false },
+} as ClusterFromSubscription;
+
+const hcpCluster: ClusterFromSubscription = {
+  product: { id: 'ROSA' },
+  cloud_provider: { id: 'aws' },
+  hypershift: { enabled: true },
+} as ClusterFromSubscription;
+
+describe('<EditNodeCountSection />', () => {
+  describe('Resizing alert', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.spyOn(utils, 'masterResizeAlertThreshold').mockReturnValue(1);
+    });
+
+    it('shows ResizingAlert for non HCP clusters', async () => {
+      withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 30, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={nonHCPCluster}
+            machinePool={defaultMachinePool}
+          />
+        </Formik>,
+      );
+
+      expect(
+        await screen.findByText(/Node scaling is automatic and will be performed immediately/i),
+      ).toBeInTheDocument();
+    });
+
+    it('hides ResizingAlert for HCP clusters', async () => {
+      withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 30, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={defaultMachinePool}
+          />
+        </Formik>,
+      );
+
+      expect(
+        screen.queryByText(/Node scaling is automatic and will be performed immediately/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
@@ -37,8 +37,7 @@ const nonHCPCluster: ClusterFromSubscription = {
 } as ClusterFromSubscription;
 
 const hcpCluster: ClusterFromSubscription = {
-  product: { id: 'ROSA' },
-  cloud_provider: { id: 'aws' },
+  ...nonHCPCluster,
   hypershift: { enabled: true },
 } as ClusterFromSubscription;
 
@@ -49,7 +48,7 @@ describe('<EditNodeCountSection />', () => {
       jest.spyOn(utils, 'masterResizeAlertThreshold').mockReturnValue(1);
     });
 
-    it('shows ResizingAlert for non HCP clusters', async () => {
+    it('shows ResizingAlert for non HCP clusters', () => {
       withState(initialState).render(
         <Formik
           initialValues={{ replicas: 30, instanceType: 'm5.xlarge', autoscaling: false }}
@@ -66,11 +65,11 @@ describe('<EditNodeCountSection />', () => {
       );
 
       expect(
-        await screen.findByText(/Node scaling is automatic and will be performed immediately/i),
+        screen.getByText(/Node scaling is automatic and will be performed immediately/i),
       ).toBeInTheDocument();
     });
 
-    it('hides ResizingAlert for HCP clusters', async () => {
+    it('hides ResizingAlert for HCP clusters', () => {
       withState(initialState).render(
         <Formik
           initialValues={{ replicas: 30, instanceType: 'm5.xlarge', autoscaling: false }}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
@@ -38,6 +38,7 @@ const EditNodeCountSection = ({
 
   const hasClusterAutoScaler = useGlobalState((state) => state.clusterAutoscaler.hasAutoscaler);
   const organization = useGlobalState((state) => state.userProfile.organization);
+  const hcpCluster = isHypershiftCluster(cluster);
 
   const minNodesRequired = getClusterMinNodes({
     cluster,
@@ -108,7 +109,7 @@ const EditNodeCountSection = ({
               options={options}
             />
           )}
-          {!isHypershiftCluster(cluster) && (
+          {!hcpCluster && (
             <MachinePoolsAutoScalingWarning
               hasClusterAutoScaler={hasClusterAutoScaler}
               hasAutoscalingMachinePools={machinePools.some((mp) => !!mp.autoscaling)}
@@ -116,7 +117,7 @@ const EditNodeCountSection = ({
               warningType={machinePool ? 'editMachinePool' : 'addMachinePool'}
             />
           )}
-          {machinePool?.id && (
+          {machinePool?.id && !hcpCluster && (
             <ResizingAlert
               autoscalingEnabled={values.autoscaling}
               autoScaleMaxNodesValue={values.autoscaleMax}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
@@ -38,7 +38,7 @@ const EditNodeCountSection = ({
 
   const hasClusterAutoScaler = useGlobalState((state) => state.clusterAutoscaler.hasAutoscaler);
   const organization = useGlobalState((state) => state.userProfile.organization);
-  const hcpCluster = isHypershiftCluster(cluster);
+  const isHcpCluster = isHypershiftCluster(cluster);
 
   const minNodesRequired = getClusterMinNodes({
     cluster,
@@ -109,7 +109,7 @@ const EditNodeCountSection = ({
               options={options}
             />
           )}
-          {!hcpCluster && (
+          {!isHcpCluster && (
             <MachinePoolsAutoScalingWarning
               hasClusterAutoScaler={hasClusterAutoScaler}
               hasAutoscalingMachinePools={machinePools.some((mp) => !!mp.autoscaling)}
@@ -117,7 +117,7 @@ const EditNodeCountSection = ({
               warningType={machinePool ? 'editMachinePool' : 'addMachinePool'}
             />
           )}
-          {machinePool?.id && !hcpCluster && (
+          {machinePool?.id && !isHcpCluster && (
             <ResizingAlert
               autoscalingEnabled={values.autoscaling}
               autoScaleMaxNodesValue={values.autoscaleMax}


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->
Hide resizing alert during node scaling in ROSA HCP cluster.
Added unit tests for HCP clusters and non HCP clusters.

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->
Fixes [OCMUI-3102](https://issues.redhat.com/browse/OCMUI-3102)

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->
1. Create HCP cluster
2. Go to Details->Machine Pool tab
3. Click on the three dots of the machine pool
4. Choose edit
5. Change Compute node count to 30
6. Make sure the alert doesn't show

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="838" height="736" alt="image" src="https://github.com/user-attachments/assets/b1b6f168-4584-43e0-bfa4-392a1b7be212" /> | <img width="837" height="551" alt="image" src="https://github.com/user-attachments/assets/a1afab37-abd2-4def-847b-47631550da48" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
