### PR TITLE
OCMUI-3603: deprecated modals update

### DIFF
--- a/src/common/modals/ConfirmationDialog.tsx
+++ b/src/common/modals/ConfirmationDialog.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 
-import { Button } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 
 type ConfirmationDialogProps = {
   title: string;
@@ -43,21 +42,22 @@ const ConfirmationDialog = ({
   // otherwise keypress event could collide with parent modal in case of modal opening modal
   return isOpen ? (
     <Modal
-      id="confirmation-dialog"
-      title={title}
       onClose={closeCallback}
       variant={variant}
       isOpen
-      actions={[
+      aria-labelledby="confirmation-dialog-modal"
+      aria-describedby="modal-box-confirmation-dialog"
+    >
+      <ModalHeader title={title} labelId="confirmation-dialog" />
+      <ModalBody>{content}</ModalBody>
+      <ModalFooter>
         <Button key="confirm" variant="primary" onClick={handlePrimaryAction}>
           {primaryActionLabel}
-        </Button>,
+        </Button>
         <Button key="cancel" variant="link" onClick={handleSecondaryAction}>
           {secondaryActionLabel}
-        </Button>,
-      ]}
-    >
-      {content}
+        </Button>
+      </ModalFooter>
     </Modal>
   ) : null;
 };

--- a/src/components/SyncEditor/SyncEditorModal.tsx
+++ b/src/components/SyncEditor/SyncEditorModal.tsx
@@ -7,6 +7,10 @@ import {
   Button,
   Flex,
   FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
   Panel,
   PanelMain,
   PanelMainBody,
@@ -19,7 +23,6 @@ import {
   Title,
   Tooltip,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { DownloadIcon } from '@patternfly/react-icons/dist/esm/icons/download-icon';
 
 import { ConfirmationDialog } from '~/common/modals/ConfirmationDialog';
@@ -116,14 +119,82 @@ const SyncEditorModal = ({
 
   return (
     <Modal
-      title="Edit YAML"
       isOpen={isOpen}
-      variant={ModalVariant.large}
+      variant="large"
       onClose={handleClose}
-      id="sync-editor-modal"
-      showClose={!isRequestPending}
       onEscapePress={onEscapePress}
-      footer={
+      aria-labelledby="sync-editor-modal"
+      aria-describedby="modal-sync-yaml-editor"
+    >
+      <ModalHeader title="Edit YAML" />
+      <ModalBody>
+        <>
+          <Sidebar hasBorder isPanelRight>
+            <SidebarContent>
+              <SyncEditorToolbar
+                {...{
+                  isRequestPending,
+                  requestPendingMessage,
+                  requestErrorMessage,
+                  isContentValid,
+                }}
+                isSideBarVisible={isSideBarVisible}
+                toggleSideBar={toggleSideBar}
+              />
+            </SidebarContent>
+
+            {isSideBarVisible ? (
+              <SidebarPanel width={{ default: 'width_25' }} variant="sticky">
+                <Title headingLevel="h2" className="pf-v6-u-pl-sm">
+                  ROSA cluster creation
+                </Title>
+              </SidebarPanel>
+            ) : null}
+          </Sidebar>
+          <Sidebar style={{ overflow: 'auto' }} tabIndex={0} hasBorder isPanelRight>
+            <SidebarContent style={{ height: '600px' }}>
+              <SyncEditor
+                content={editorContent}
+                onChange={setEditorContent}
+                isReadOnly={isRequestPending}
+                readOnlyMessage={{ value: readOnlyMessage }}
+                schemas={[schema]}
+                isSideBarVisible={isSideBarVisible}
+                isDarkTheme
+                language={Language.yaml}
+                setValidationErrors={(validationErrors) =>
+                  setIsContentValid(validationErrors.length === 0)
+                }
+              />
+            </SidebarContent>
+            {isSideBarVisible ? (
+              <SidebarPanel width={{ default: 'width_25' }} variant="sticky">
+                <Tabs activeKey={0}>
+                  <Tab eventKey={0} title={<TabTitleText>Schema</TabTitleText>}>
+                    <Panel>
+                      <PanelMain>
+                        <PanelMainBody>
+                          <SyncEditorSchema schema={JSON.stringify(schema)} />
+                        </PanelMainBody>
+                      </PanelMain>
+                    </Panel>
+                  </Tab>
+                </Tabs>
+              </SidebarPanel>
+            ) : null}
+          </Sidebar>
+          <ConfirmationDialog
+            title="Close editor without saving?"
+            content="All changes will be lost."
+            primaryActionLabel="Close"
+            primaryAction={closeCallback}
+            secondaryActionLabel="Cancel"
+            isOpen={isConfirmationDialogOpen}
+            closeCallback={() => setIsConfirmationDialogOpen(false)}
+          />
+        </>
+      </ModalBody>
+      <ModalFooter>
         <Flex>
           <FlexItem>
             <Tooltip
@@ -141,10 +212,11 @@ const SyncEditorModal = ({
                 {submitButtonLabel}
               </Button>
             </Tooltip>
-
-            <Button variant="secondary" onClick={handleClose} isDisabled={isRequestPending}>
-              Cancel
-            </Button>
+            {!isRequestPending && (
+              <Button variant="secondary" onClick={handleClose} isDisabled={isRequestPending}>
+                Cancel
+              </Button>
+            )}
           </FlexItem>
           <FlexItem align={{ default: 'alignRight' }}>
             {closeWarningMessage ? (
@@ -162,68 +234,7 @@ const SyncEditorModal = ({
             </Button>
           </FlexItem>
         </Flex>
-      }
-    >
-      <>
-        <Sidebar hasBorder isPanelRight>
-          <SidebarContent>
-            <SyncEditorToolbar
-              {...{ isRequestPending, requestPendingMessage, requestErrorMessage, isContentValid }}
-              isSideBarVisible={isSideBarVisible}
-              toggleSideBar={toggleSideBar}
-            />
-          </SidebarContent>
-
-          {isSideBarVisible ? (
-            <SidebarPanel width={{ default: 'width_25' }} variant="sticky">
-              <Title headingLevel="h2" className="pf-v6-u-pl-sm">
-                ROSA cluster creation
-              </Title>
-            </SidebarPanel>
-          ) : null}
-        </Sidebar>
-        <Sidebar style={{ overflow: 'auto' }} tabIndex={0} hasBorder isPanelRight>
-          <SidebarContent style={{ height: '600px' }}>
-            <SyncEditor
-              content={editorContent}
-              onChange={setEditorContent}
-              isReadOnly={isRequestPending}
-              readOnlyMessage={{ value: readOnlyMessage }}
-              schemas={[schema]}
-              isSideBarVisible={isSideBarVisible}
-              isDarkTheme
-              language={Language.yaml}
-              setValidationErrors={(validationErrors) =>
-                setIsContentValid(validationErrors.length === 0)
-              }
-            />
-          </SidebarContent>
-          {isSideBarVisible ? (
-            <SidebarPanel width={{ default: 'width_25' }} variant="sticky">
-              <Tabs activeKey={0}>
-                <Tab eventKey={0} title={<TabTitleText>Schema</TabTitleText>}>
-                  <Panel>
-                    <PanelMain>
-                      <PanelMainBody>
-                        <SyncEditorSchema schema={JSON.stringify(schema)} />
-                      </PanelMainBody>
-                    </PanelMain>
-                  </Panel>
-                </Tab>
-              </Tabs>
-            </SidebarPanel>
-          ) : null}
-        </Sidebar>
-        <ConfirmationDialog
-          title="Close editor without saving?"
-          content="All changes will be lost."
-          primaryActionLabel="Close"
-          primaryAction={closeCallback}
-          secondaryActionLabel="Cancel"
-          isOpen={isConfirmationDialogOpen}
-          closeCallback={() => setIsConfirmationDialogOpen(false)}
-        />
-      </>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/SyncEditor/SyncEditorModal.tsx
+++ b/src/components/SyncEditor/SyncEditorModal.tsx
@@ -11,6 +11,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalVariant,
   Panel,
   PanelMain,
   PanelMainBody,
@@ -120,7 +121,7 @@ const SyncEditorModal = ({
   return (
     <Modal
       isOpen={isOpen}
-      variant="large"
+      variant={ModalVariant.large}
       onClose={handleClose}
       onEscapePress={onEscapePress}
       aria-labelledby="sync-editor-modal"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/BreakGlassCredentialDetailsModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/BreakGlassCredentialDetailsModal.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 
-import { Button, ClipboardCopy, ClipboardCopyVariant, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  StackItem,
+} from '@patternfly/react-core';
 
 import ErrorBox from '~/components/common/ErrorBox';
 import { useFetchBreakGlassCredentialDetails } from '~/queries/ClusterDetailsQueries/AccessControlTab/ExternalAuthenticationQueries/useFetchBreakGlassCredentialDetails';
@@ -59,38 +67,44 @@ export function BreakGlassCredentialDetailsModal(props: BreakGlassCredentialDeta
 
   return (
     <Modal
-      id="edit-mp-modal"
-      title={`${credential?.username} credentials`}
       onClose={handleClose}
       variant="medium"
-      description="Use these temporary credentials to access your cluster."
       isOpen={isOpen}
-      actions={[
+      ouiaId="BreakGlassCredentialDetailsModal"
+      aria-labelledby="breakglass-credential-details-modal"
+      aria-describedby="Use these temporary credentials to access your cluster."
+    >
+      <ModalHeader
+        title={`${credential?.username} credentials`}
+        labelId="breakglass-credential-details-modal-id"
+      />
+      <ModalBody>
+        {statusMessage()}
+        {isError && (
+          <StackItem>
+            <ErrorBox
+              message="A problem occurred while retrieving credential"
+              response={{
+                errorMessage: error.error.reason,
+                operationID: error.error.operationID,
+              }}
+            />
+          </StackItem>
+        )}
+
+        <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+          {isLoading ? 'Loading...' : credentialData?.kubeconfig || 'No kubeconfig'}
+        </ClipboardCopy>
+      </ModalBody>
+      <ModalFooter>
         <DownloadButton
           textOutput={credentialData?.kubeconfig || ''}
           disabled={isLoading || !credentialData?.kubeconfig}
-        />,
+        />
         <Button key="cancel" variant="secondary" onClick={handleClose}>
           Cancel
-        </Button>,
-      ]}
-    >
-      {statusMessage()}
-      {isError && (
-        <StackItem>
-          <ErrorBox
-            message="A problem occurred while retrieving credential"
-            response={{
-              errorMessage: error.error.reason,
-              operationID: error.error.operationID,
-            }}
-          />
-        </StackItem>
-      )}
-
-      <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
-        {isLoading ? 'Loading...' : credentialData?.kubeconfig || 'No kubeconfig'}
-      </ClipboardCopy>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/DeleteExternalAuthProviderModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/DeleteExternalAuthProviderModal.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
 
-import { Button, Flex, Form, Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Flex,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  StackItem,
+  TextInput,
+} from '@patternfly/react-core';
 
 import ErrorBox from '~/components/common/ErrorBox';
 import { useDeleteExternalAuth } from '~/queries/ClusterDetailsQueries/AccessControlTab/ExternalAuthenticationQueries/useDeleteExternalAuth';
@@ -44,11 +54,49 @@ export const DeleteExternalAuthProviderModal = (props: DeleteExternalAuthProvide
 
   return (
     <Modal
-      title={`Delete provider: ${externalAuthProvider?.id}`}
       onClose={closeDialog}
       isOpen={isOpen}
-      variant="medium"
-      actions={[
+      ouiaId="DeleteExternalAuthProviderModal"
+      aria-labelledby="delete-external-auth-provider"
+    >
+      <ModalHeader
+        title={`Delete provider: ${externalAuthProvider?.id}`}
+        labelId="delete-external-auth-provider-title"
+      />
+      <ModalBody>
+        <Flex direction={{ default: 'column' }}>
+          <p>
+            This action cannot be undone. It will permanently remove the external authentication
+            provider {externalAuthProvider?.id}.
+          </p>
+          <p>
+            Confirm deletion by typing <strong>{externalAuthProvider?.id}</strong> below:
+          </p>
+          <Form onSubmit={submitForm}>
+            <TextInput
+              type="text"
+              value={providerNameInput}
+              placeholder="Enter name"
+              onChange={(_event, newInput) => setProviderNameInput(newInput)}
+              aria-label="provider name to delete"
+            />
+          </Form>
+        </Flex>
+        {isError && (
+          <Stack hasGutter>
+            <StackItem>
+              <ErrorBox
+                message={`Failed to delete external auth provider: ${externalAuthProvider?.id}`}
+                response={{
+                  errorMessage: error.error.errorMessage,
+                  operationID: error.error.operationID,
+                }}
+              />
+            </StackItem>
+          </Stack>
+        )}
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="delete"
           variant="primary"
@@ -64,43 +112,11 @@ export const DeleteExternalAuthProviderModal = (props: DeleteExternalAuthProvide
           }}
         >
           Delete
-        </Button>,
+        </Button>
         <Button key="cancel" variant="secondary" onClick={closeDialog}>
           Cancel
-        </Button>,
-      ]}
-    >
-      <Flex direction={{ default: 'column' }}>
-        <p>
-          This action cannot be undone. It will permanently remove the external authentication
-          provider {externalAuthProvider?.id}.
-        </p>
-        <p>
-          Confirm deletion by typing <strong>{externalAuthProvider?.id}</strong> below:
-        </p>
-        <Form onSubmit={submitForm}>
-          <TextInput
-            type="text"
-            value={providerNameInput}
-            placeholder="Enter name"
-            onChange={(_event, newInput) => setProviderNameInput(newInput)}
-            aria-label="provider name to delete"
-          />
-        </Form>
-      </Flex>
-      {isError && (
-        <Stack hasGutter>
-          <StackItem>
-            <ErrorBox
-              message={`Failed to delete external auth provider: ${externalAuthProvider?.id}`}
-              response={{
-                errorMessage: error.error.errorMessage,
-                operationID: error.error.operationID,
-              }}
-            />
-          </StackItem>
-        </Stack>
-      )}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
@@ -9,6 +9,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalVariant,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -182,7 +183,7 @@ export function ExternalAuthProviderModal(props: ExternalAuthProviderModalProps)
         <Modal
           id="edit-ext-auth-provider-modal"
           onClose={onClose}
-          variant="medium"
+          variant={ModalVariant.medium}
           isOpen={isOpen}
           aria-labelledby="edit-ext-auth-provider-modal"
           aria-describedby="modal-box-edit-ext-auth-provider"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { Field, Formik } from 'formik';
 import * as Yup from 'yup';
 
-import { Button, Form, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 
 import { getErrorMessage } from '~/common/errors';
 import { validateSecureURL } from '~/common/validators';
@@ -83,7 +91,6 @@ export function ExternalAuthProviderModal(props: ExternalAuthProviderModalProps)
     mutate,
   } = useAddEditExternalAuth(clusterID, region);
 
-  // find the first client with component name console
   const consoleClient = externalAuthProvider?.clients?.find(
     (client) => client.component?.name === 'console',
   );
@@ -174,85 +181,93 @@ export function ExternalAuthProviderModal(props: ExternalAuthProviderModalProps)
       {(formik) => (
         <Modal
           id="edit-ext-auth-provider-modal"
-          title={
-            isEdit
-              ? `Edit provider ${externalAuthProvider?.id}`
-              : 'Add external authentication provider'
-          }
           onClose={onClose}
-          isOpen={isOpen}
           variant="medium"
-          description={!isEdit && modalDescription}
-          actions={[
+          isOpen={isOpen}
+          aria-labelledby="edit-ext-auth-provider-modal"
+          aria-describedby="modal-box-edit-ext-auth-provider"
+        >
+          <ModalHeader
+            title={
+              isEdit
+                ? `Edit provider ${externalAuthProvider?.id}`
+                : 'Add external authentication provider'
+            }
+            description={!isEdit ? modalDescription : undefined}
+            labelId="edit-ext-auth-provider-modal"
+          />
+          <ModalBody>
+            <Form>
+              {!isEdit && <TextField fieldId="id" label="Name" isRequired />}
+              <TextField fieldId="issuer" label="Issuer URL" isRequired />
+              <TextField
+                fieldId="audiences"
+                label="Audiences"
+                isRequired
+                helpText="The audience IDs that this authentication provider issues tokens for. Use commas to separate multiple audiences."
+              />
+              <TextField fieldId="groups" label="Groups mapping" isRequired />
+              <TextField fieldId="username" label="Username mapping" isRequired />
+              <TextField
+                fieldId="consoleClientID"
+                label="Console client ID"
+                helpText="The console identifier of the OIDC client from the OIDC provider. Once set, a client ID can be modified by not removed."
+              />
+              <TextField
+                fieldId="consoleClientSecret"
+                label="Console client secret"
+                helpText="The console secret of the OIDC client from the OIDC provider."
+                placeHolderText={
+                  consoleClient?.id && formik.values.consoleClientID === consoleClient?.id
+                    ? 'Secret not displayed'
+                    : ''
+                }
+              />
+              <Field
+                component={CAUpload}
+                onChange={(value: string) => formik.setFieldValue('provider_ca', value)}
+                input={{
+                  name: 'provider_ca',
+                  value: formik.values.provider_ca,
+                  onChange: (value: string) => formik.setFieldValue('provider_ca', value),
+                  onBlur: formik.handleBlur,
+                }}
+                fieldName="provider_ca"
+                name="provider_ca"
+                label="CA file"
+                helpText="PEM encoded certificate bundle to use to validate server certificates for the configured issuer URL."
+                certValue={isEdit ? formik.values.provider_ca : ''}
+              />
+            </Form>
+            {isError && (
+              <Stack hasGutter>
+                <StackItem>
+                  <ErrorBox
+                    message={isEdit ? 'Error editing provider' : 'Error adding provider'}
+                    response={{
+                      errorDetails: submitError.error.errorDetails,
+                      errorMessage: getErrorMessage({ payload: submitError.error as any }),
+                      operationID: submitError.error.operationID,
+                    }}
+                  />
+                </StackItem>
+              </Stack>
+            )}
+          </ModalBody>
+          <ModalFooter>
             <Button
               key="add-ext-auth-provider"
+              variant="primary"
               isDisabled={isPending}
               isLoading={isPending}
               onClick={formik.submitForm}
             >
               {isEdit ? 'Save' : 'Add'}
-            </Button>,
+            </Button>
             <Button key="cancel" variant="secondary" onClick={onClose}>
               Cancel
-            </Button>,
-          ]}
-        >
-          <Form>
-            {!isEdit && <TextField fieldId="id" label="Name" isRequired />}
-            <TextField fieldId="issuer" label="Issuer URL" isRequired />
-            <TextField
-              fieldId="audiences"
-              label="Audiences"
-              isRequired
-              helpText="The audience IDs that this authentication provider issues tokens for. Use commas to separate multiple audiences."
-            />
-            <TextField fieldId="groups" label="Groups mapping" isRequired />
-            <TextField fieldId="username" label="Username mapping" isRequired />
-            <TextField
-              fieldId="consoleClientID"
-              label="Console client ID"
-              helpText="The console identifier of the OIDC client from the OIDC provider. Once set, a client ID can be modified by not removed."
-            />
-            <TextField
-              fieldId="consoleClientSecret"
-              label="Console client secret"
-              helpText="The console secret of the OIDC client from the OIDC provider."
-              placeHolderText={
-                consoleClient?.id && formik.values.consoleClientID === consoleClient?.id
-                  ? 'Secret not displayed'
-                  : ''
-              }
-            />
-            <Field
-              component={CAUpload}
-              onChange={(value: string) => formik.setFieldValue('provider_ca', value)}
-              input={{
-                name: 'provider_ca',
-                value: formik.values.provider_ca,
-                onChange: (value: string) => formik.setFieldValue('provider_ca', value),
-                onBlur: formik.handleBlur,
-              }}
-              fieldName="provider_ca"
-              name="provider_ca"
-              label="CA file"
-              helpText="PEM encoded certificate bundle to use to validate server certificates for the configured issuer URL."
-              certValue={isEdit ? formik.values.provider_ca : ''}
-            />
-          </Form>
-          {isError && (
-            <Stack hasGutter>
-              <StackItem>
-                <ErrorBox
-                  message={isEdit ? 'Error editing provider' : 'Error adding provider'}
-                  response={{
-                    errorDetails: submitError.error.errorDetails,
-                    errorMessage: getErrorMessage({ payload: submitError.error as any }),
-                    operationID: submitError.error.operationID,
-                  }}
-                />
-              </StackItem>
-            </Stack>
-          )}
+            </Button>
+          </ModalFooter>
         </Modal>
       )}
     </Formik>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/RevokeBreakGlassCredentialsModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/RevokeBreakGlassCredentialsModal.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import ErrorBox from '~/components/common/ErrorBox';
 import { useRevokeBreakGlassCredentials } from '~/queries/ClusterDetailsQueries/AccessControlTab/ExternalAuthenticationQueries/useRevokeBreakGlassCredentials';
@@ -32,7 +40,7 @@ export const RevokeBreakGlassCredentialsModal = (props: RevokeBreakGlassCredenti
       id="revoke-break-glass-modal"
       onClose={handleClose}
       isOpen={isOpen}
-      variant="medium"
+      variant={ModalVariant.medium}
       aria-labelledby="revoke-break-glass-modal"
       aria-describedby="modal-box-revoke-break-glass"
     >

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/RevokeBreakGlassCredentialsModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/RevokeBreakGlassCredentialsModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Button, Flex } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 
 import ErrorBox from '~/components/common/ErrorBox';
 import { useRevokeBreakGlassCredentials } from '~/queries/ClusterDetailsQueries/AccessControlTab/ExternalAuthenticationQueries/useRevokeBreakGlassCredentials';
@@ -30,11 +29,30 @@ export const RevokeBreakGlassCredentialsModal = (props: RevokeBreakGlassCredenti
 
   return (
     <Modal
-      title="Revoke all credentials for cluster"
+      id="revoke-break-glass-modal"
       onClose={handleClose}
       isOpen={isOpen}
       variant="medium"
-      actions={[
+      aria-labelledby="revoke-break-glass-modal"
+      aria-describedby="modal-box-revoke-break-glass"
+    >
+      <ModalHeader title="Revoke all credentials for cluster" labelId="revoke-break-glass-modal" />
+      <ModalBody>
+        {isError ? (
+          <ErrorBox
+            message="A problem occurred while deleting the credentials."
+            response={{
+              errorMessage: error.error.errorMessage,
+              operationID: error.error.operationID,
+            }}
+          />
+        ) : (
+          <Flex direction={{ default: 'column' }}>
+            <p>This action cannot be undone. It will permanently revoke all credentials.</p>
+          </Flex>
+        )}
+      </ModalBody>
+      <ModalFooter>
         <Button
           key="revoke"
           variant="primary"
@@ -46,25 +64,11 @@ export const RevokeBreakGlassCredentialsModal = (props: RevokeBreakGlassCredenti
           }}
         >
           Revoke all
-        </Button>,
+        </Button>
         <Button key="cancel" variant="secondary" onClick={handleClose}>
           Cancel
-        </Button>,
-      ]}
-    >
-      {isError ? (
-        <ErrorBox
-          message="A problem occurred while deleting the credentials."
-          response={{
-            errorMessage: error.error.errorMessage,
-            operationID: error.error.operationID,
-          }}
-        />
-      ) : (
-        <Flex direction={{ default: 'column' }}>
-          <p>This action cannot be undone. It will permanently revoke all credentials.</p>
-        </Flex>
-      )}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/toolbar/ClusterLogsDownload.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/toolbar/ClusterLogsDownload.tsx
@@ -9,6 +9,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalVariant,
   Radio,
   Stack,
   StackItem,
@@ -112,7 +113,7 @@ const ClusterLogsDownload = ({
       {isOpen && (
         <Modal
           id="download-cluster-history-modal"
-          variant="small"
+          variant={ModalVariant.small}
           isOpen
           onClose={isDownloading ? undefined : close}
           aria-labelledby="download-cluster-history-modal"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/toolbar/ClusterLogsDownload.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/toolbar/ClusterLogsDownload.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import dayjs from 'dayjs';
 
-import { Alert, Button, FormGroup, Radio, Stack, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  Button,
+  FormGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Radio,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 
 import { createServiceLogQueryObject } from '~/common/queryHelpers';
 import { serviceLogService } from '~/services';
@@ -38,8 +48,8 @@ const ClusterLogsDownload = ({
     const query = createServiceLogQueryObject(
       {
         ...viewOptions,
-        currentPage: 1, // Start from beginning
-        pageSize: -1, // All data, no pagination
+        currentPage: 1,
+        pageSize: -1,
       },
       format,
     );
@@ -101,11 +111,44 @@ const ClusterLogsDownload = ({
       </Button>
       {isOpen && (
         <Modal
+          id="download-cluster-history-modal"
           variant="small"
-          title="Download cluster history"
           isOpen
           onClose={isDownloading ? undefined : close}
-          actions={[
+          aria-labelledby="download-cluster-history-modal"
+          aria-describedby="modal-box-download-cluster-history"
+        >
+          <ModalHeader title="Download cluster history" labelId="download-cluster-history-modal" />
+          <ModalBody>
+            <Stack hasGutter>
+              <StackItem>
+                <FormGroup label="Choose a file type">
+                  <Radio
+                    id="json-format"
+                    isChecked={format === 'json'}
+                    name="format"
+                    onChange={(_event, checked) => checked && setFormat('json')}
+                    label="JSON"
+                    isDisabled={isDownloading}
+                  />
+                  <Radio
+                    id="csv-format"
+                    isChecked={format === 'csv'}
+                    name="format"
+                    onChange={(_event, checked) => checked && setFormat('csv')}
+                    label="CSV"
+                    isDisabled={isDownloading}
+                  />
+                </FormGroup>
+              </StackItem>
+              {error && (
+                <StackItem>
+                  <Alert variant="danger" title="Unable to download records" isInline />
+                </StackItem>
+              )}
+            </Stack>
+          </ModalBody>
+          <ModalFooter>
             <Button
               data-testid="submit-btn"
               key="download"
@@ -116,39 +159,11 @@ const ClusterLogsDownload = ({
               spinnerAriaLabel="Loading cluster logs"
             >
               Download
-            </Button>,
+            </Button>
             <Button key="close" variant="link" onClick={close} isDisabled={isDownloading}>
               Cancel
-            </Button>,
-          ]}
-        >
-          <Stack hasGutter>
-            <StackItem>
-              <FormGroup label="Choose a file type">
-                <Radio
-                  id="json-format"
-                  isChecked={format === 'json'}
-                  name="format"
-                  onChange={(_event, checked) => checked && setFormat('json')}
-                  label="JSON"
-                  isDisabled={isDownloading}
-                />
-                <Radio
-                  id="csv-format"
-                  isChecked={format === 'csv'}
-                  name="format"
-                  onChange={(_event, checked) => checked && setFormat('csv')}
-                  label="CSV"
-                  isDisabled={isDownloading}
-                />
-              </FormGroup>
-            </StackItem>
-            {error && (
-              <StackItem>
-                <Alert variant="danger" title="Unable to download records" isInline />
-              </StackItem>
-            )}
-          </Stack>
+            </Button>
+          </ModalFooter>
         </Modal>
       )}
     </>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { Formik } from 'formik';
 import { useDispatch } from 'react-redux';
 
-import { Button, Form, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import {
+  Button,
+  Form,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import { DefaultIngressFieldsFormik } from '~/components/clusters/wizards/rosa/NetworkScreen/DefaultIngressFieldsFormik';
 import ErrorBox from '~/components/common/ErrorBox';
@@ -106,7 +114,7 @@ const EditApplicationIngressDialog: React.FC<EditApplicationIngressDialogProps> 
       {({ dirty, handleSubmit, values }) => (
         <Modal
           id="edit-application-ingress-modal"
-          variant="medium"
+          variant={ModalVariant.medium}
           onClose={onClose}
           isOpen
           aria-labelledby="edit-application-ingress-modal"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { Formik } from 'formik';
 import { useDispatch } from 'react-redux';
 
-import { Form } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Form, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 
 import { DefaultIngressFieldsFormik } from '~/components/clusters/wizards/rosa/NetworkScreen/DefaultIngressFieldsFormik';
 import ErrorBox from '~/components/common/ErrorBox';
-import Modal from '~/components/common/Modal/Modal';
 import { modalActions } from '~/components/common/Modal/ModalActions';
 import modals from '~/components/common/Modal/modals';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
@@ -105,30 +103,43 @@ const EditApplicationIngressDialog: React.FC<EditApplicationIngressDialogProps> 
         );
       }}
     >
-      {({ dirty, errors, handleSubmit, values }) => (
+      {({ dirty, handleSubmit, values }) => (
         <Modal
-          variant={ModalVariant.medium}
-          primaryText="Save"
-          secondaryText="Cancel"
-          title="Edit application ingress"
+          id="edit-application-ingress-modal"
+          variant="medium"
           onClose={onClose}
-          onPrimaryClick={handleSubmit as () => void}
-          onSecondaryClick={onClose}
-          isPending={isPending}
-          isPrimaryDisabled={!errors || !dirty}
+          isOpen
+          aria-labelledby="edit-application-ingress-modal"
+          aria-describedby="modal-box-edit-application-ingress"
         >
-          {editRoutersError}
-          <Form>
-            <DefaultIngressFieldsFormik
-              isDay2
-              hasSufficientIngressEditVersion={hasSufficientIngressEditVersion}
-              canEditLoadBalancer={canEditLoadBalancer}
-              canShowLoadBalancer={canShowLoadBalancer}
-              areFieldsDisabled={isHypershiftCluster}
-              isHypershiftCluster={isHypershiftCluster}
-              values={values}
-            />
-          </Form>
+          <ModalHeader title="Edit application ingress" labelId="edit-application-ingress-modal" />
+          <ModalBody>
+            {editRoutersError}
+            <Form>
+              <DefaultIngressFieldsFormik
+                isDay2
+                hasSufficientIngressEditVersion={hasSufficientIngressEditVersion}
+                canEditLoadBalancer={canEditLoadBalancer}
+                canShowLoadBalancer={canShowLoadBalancer}
+                areFieldsDisabled={isHypershiftCluster}
+                isHypershiftCluster={isHypershiftCluster}
+                values={values}
+              />
+            </Form>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="primary"
+              onClick={handleSubmit as unknown as () => void}
+              isDisabled={!dirty || isPending}
+              isLoading={isPending}
+            >
+              Save
+            </Button>
+            <Button variant="link" onClick={onClose} isDisabled={isPending}>
+              Cancel
+            </Button>
+          </ModalFooter>
         </Modal>
       )}
     </Formik>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { Formik } from 'formik';
 
-import { Button, StackItem } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  StackItem,
+} from '@patternfly/react-core';
 
 import { queryClient } from '~/components/App/queryClient';
 import ErrorBox from '~/components/common/ErrorBox';
@@ -28,7 +34,6 @@ export function OverviewBillingAccountModal(props: OverviewBillingAccountModalPr
     isError: isClusterEditError,
     error: clusterEditError,
     mutate: mutateClusterEdit,
-    // reset: resetEditClusterResponse,
   } = useEditCluster(region);
 
   const handleClose = () => {
@@ -70,12 +75,35 @@ export function OverviewBillingAccountModal(props: OverviewBillingAccountModalPr
       {(formik) => (
         <Modal
           id="edit-billing-aws-account-modal"
-          title="Edit AWS billing account"
           onClose={handleClose}
           variant="small"
-          description="Updating the billing marketplace account changes the account that is charged for your subscription usage. There might be a delay in updating the account."
           isOpen={isOpen}
-          actions={[
+          aria-labelledby="edit-billing-aws-account-modal"
+          aria-describedby="modal-box-edit-billing-aws-account"
+        >
+          <ModalHeader
+            title="Edit AWS billing account"
+            description="Updating the billing marketplace account changes the account that is charged for your subscription usage. There might be a delay in updating the account."
+            labelId="edit-billing-aws-account-modal"
+          />
+          <ModalBody>
+            <AWSBillingAccountForm
+              name="billingAccountId"
+              selectedAWSBillingAccountID={formik.values.billingAccountId}
+            />
+            {isClusterEditError && (
+              <StackItem>
+                <ErrorBox
+                  message="A problem occurred updating the billing account."
+                  response={{
+                    errorMessage: clusterEditError?.message || clusterEditError?.errorMessage,
+                    operationID: clusterEditError?.operationID,
+                  }}
+                />
+              </StackItem>
+            )}
+          </ModalBody>
+          <ModalFooter>
             <Button
               data-testid="Update"
               key="update"
@@ -84,30 +112,14 @@ export function OverviewBillingAccountModal(props: OverviewBillingAccountModalPr
               isDisabled={
                 !formik.isValid || !formik.dirty || formik.isSubmitting || isClusterEditPending
               }
+              isLoading={isClusterEditPending}
             >
               Update
-            </Button>,
+            </Button>
             <Button key="cancel" variant="secondary" onClick={handleClose}>
               Cancel
-            </Button>,
-          ]}
-        >
-          {' '}
-          <AWSBillingAccountForm
-            name="billingAccountId"
-            selectedAWSBillingAccountID={formik.values.billingAccountId}
-          />
-          {isClusterEditError && (
-            <StackItem>
-              <ErrorBox
-                message="A problem occurred updating the billing account."
-                response={{
-                  errorMessage: clusterEditError?.message || clusterEditError?.errorMessage,
-                  operationID: clusterEditError?.operationID,
-                }}
-              />
-            </StackItem>
-          )}
+            </Button>
+          </ModalFooter>
         </Modal>
       )}
     </Formik>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
@@ -7,6 +7,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalVariant,
   StackItem,
 } from '@patternfly/react-core';
 
@@ -76,7 +77,7 @@ export function OverviewBillingAccountModal(props: OverviewBillingAccountModalPr
         <Modal
           id="edit-billing-aws-account-modal"
           onClose={handleClose}
-          variant="small"
+          variant={ModalVariant.small}
           isOpen={isOpen}
           aria-labelledby="edit-billing-aws-account-modal"
           aria-describedby="modal-box-edit-billing-aws-account"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
@@ -19,6 +19,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalVariant,
 } from '@patternfly/react-core';
 
 import { knownProducts } from '~/common/subscriptionTypes';
@@ -376,7 +377,7 @@ const UpgradeSettingsTab = ({ cluster }: UpgradeSettingsTabProps) => {
                     {confirmationModalOpen && scheduledManualUpgrade && (
                       <Modal
                         id="recurring-updates-confirm-modal"
-                        variant="small"
+                        variant={ModalVariant.small}
                         isOpen
                         onClose={() => {
                           closeConfirmationModal();

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
@@ -375,27 +375,28 @@ const UpgradeSettingsTab = ({ cluster }: UpgradeSettingsTabProps) => {
                   <CardBody>
                     {confirmationModalOpen && scheduledManualUpgrade && (
                       <Modal
+                        id="recurring-updates-confirm-modal"
                         variant="small"
                         isOpen
                         onClose={() => {
                           closeConfirmationModal();
                           formik.resetForm();
                         }}
+                        aria-labelledby="recurring-updates-confirm-modal"
+                        aria-describedby="modal-box-recurring-updates-confirm"
                       >
                         <ModalHeader
                           title="Recurring updates"
-                          labelId="recurring-updates-modal-title"
+                          labelId="recurring-updates-confirm-modal"
                         />
-                        <ModalBody id="recurring-updates-modal-body">
+                        <ModalBody>
                           By choosing recurring updates, any individually scheduled update will be
                           cancelled. Are you sure you want to continue?
                         </ModalBody>
                         <ModalFooter>
-                          {' '}
                           <Button key="confirm" variant="primary" onClick={closeConfirmationModal}>
                             Yes, cancel scheduled update
                           </Button>
-                          ,
                           <Button
                             key="cancel"
                             variant="secondary"
@@ -406,7 +407,6 @@ const UpgradeSettingsTab = ({ cluster }: UpgradeSettingsTabProps) => {
                           >
                             No, keep scheduled update
                           </Button>
-                          ,
                         </ModalFooter>
                       </Modal>
                     )}

--- a/src/components/clusters/ClusterTransfer/AcceptDeclineTransferModal.tsx
+++ b/src/components/clusters/ClusterTransfer/AcceptDeclineTransferModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Button, Flex } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 import ErrorBox from '~/components/common/ErrorBox';
@@ -71,59 +70,61 @@ export const AcceptDeclineClusterTransferModal = (
         Accept/Decline
       </Button>
       <Modal
-        title="Complete cluster transfer"
+        id="complete-cluster-transfer-modal"
         onClose={() => handleClose()}
         isOpen={isOpen}
         variant="small"
-        actions={[
+        aria-labelledby="complete-cluster-transfer-modal"
+        aria-describedby="modal-box-complete-cluster-transfer"
+      >
+        <ModalHeader title="Complete cluster transfer" labelId="complete-cluster-transfer-modal" />
+        <ModalBody>
+          {isError ? (
+            <ErrorBox
+              message="A problem occurred while processing the transfer."
+              response={error?.error as ErrorState}
+            />
+          ) : (
+            <Flex direction={{ default: 'column' }}>
+              <p>
+                Accepting this transfer will change the ownership of cluster {displayName} to you.
+                Declining the transfer will end the transfer process and the cluster will not be
+                transferred.
+              </p>
+            </Flex>
+          )}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key={`approve-${transferId}`}
             aria-label="Accept Transfer"
             onClick={() => approveTransfer(transferId)}
             isDisabled={isPending}
             isLoading={isPending}
-            isInline
           >
             Accept Transfer
-          </Button>,
-
+          </Button>
           <Button
             key={`decline-${transferId}`}
             aria-label="Decline Transfer"
             onClick={() => declineTransfer(transferId)}
             isDisabled={isPending}
             isLoading={isPending}
-            isInline
             variant="danger"
           >
             Decline Transfer
-          </Button>,
+          </Button>
           <Button
             key={`cancel-${transferId}`}
             variant="secondary"
-            isInline
             component="span"
             aria-label="Cancel"
+            isInline
             onClick={() => handleClose()}
           >
             Cancel
-          </Button>,
-        ]}
-      >
-        {isError ? (
-          <ErrorBox
-            message="A problem occurred while processing the transfer."
-            response={error?.error as ErrorState}
-          />
-        ) : (
-          <Flex direction={{ default: 'column' }}>
-            <p>
-              Accepting this transfer will change the ownership of cluster {displayName} to you.
-              Declining the transfer will end the transfer process and the cluster will not be
-              transferred.
-            </p>
-          </Flex>
-        )}
+          </Button>
+        </ModalFooter>
       </Modal>
     </>
   );

--- a/src/components/clusters/ClusterTransfer/AcceptDeclineTransferModal.tsx
+++ b/src/components/clusters/ClusterTransfer/AcceptDeclineTransferModal.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 import ErrorBox from '~/components/common/ErrorBox';
@@ -73,7 +81,7 @@ export const AcceptDeclineClusterTransferModal = (
         id="complete-cluster-transfer-modal"
         onClose={() => handleClose()}
         isOpen={isOpen}
-        variant="small"
+        variant={ModalVariant.small}
         aria-labelledby="complete-cluster-transfer-modal"
         aria-describedby="modal-box-complete-cluster-transfer"
       >

--- a/src/components/clusters/ClusterTransfer/CancelClusterTransferModal.tsx
+++ b/src/components/clusters/ClusterTransfer/CancelClusterTransferModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Button, Flex } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
@@ -48,11 +47,30 @@ export const CancelClusterTransferModal = (props: CancelClusterTransferModalProp
       </ButtonWithTooltip>
 
       <Modal
-        title="Cancel cluster transfer"
+        id="cancel-cluster-transfer-modal"
         onClose={handleClose}
         isOpen={isOpen}
         variant="small"
-        actions={[
+        aria-labelledby="cancel-cluster-transfer-modal"
+        aria-describedby="modal-box-cancel-cluster-transfer"
+      >
+        <ModalHeader title="Cancel cluster transfer" labelId="cancel-cluster-transfer-modal" />
+        <ModalBody>
+          {isError ? (
+            <ErrorBox
+              message="A problem occurred while canceling the transfer."
+              response={error?.error as ErrorState}
+            />
+          ) : (
+            <Flex direction={{ default: 'column' }}>
+              <p>
+                This action cannot be undone. It will cancel the impending transfer for cluster{' '}
+                {displayName}.
+              </p>
+            </Flex>
+          )}
+        </ModalBody>
+        <ModalFooter>
           <Button
             key="rescind-transfer"
             variant="primary"
@@ -79,7 +97,7 @@ export const CancelClusterTransferModal = (props: CancelClusterTransferModalProp
             }}
           >
             Cancel Transfer
-          </Button>,
+          </Button>
           <Button
             key="close-cancel"
             variant="secondary"
@@ -87,22 +105,8 @@ export const CancelClusterTransferModal = (props: CancelClusterTransferModalProp
             aria-label="Close Cancel Button"
           >
             Close
-          </Button>,
-        ]}
-      >
-        {isError ? (
-          <ErrorBox
-            message="A problem occurred while canceling the transfer."
-            response={error?.error as ErrorState}
-          />
-        ) : (
-          <Flex direction={{ default: 'column' }}>
-            <p>
-              This action cannot be undone. It will cancel the impending transfer for cluster{' '}
-              {displayName}.
-            </p>
-          </Flex>
-        )}
+          </Button>
+        </ModalFooter>
       </Modal>
     </>
   );

--- a/src/components/clusters/ClusterTransfer/CancelClusterTransferModal.tsx
+++ b/src/components/clusters/ClusterTransfer/CancelClusterTransferModal.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 
-import { Button, Flex, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
@@ -50,7 +58,7 @@ export const CancelClusterTransferModal = (props: CancelClusterTransferModalProp
         id="cancel-cluster-transfer-modal"
         onClose={handleClose}
         isOpen={isOpen}
-        variant="small"
+        variant={ModalVariant.small}
         aria-labelledby="cancel-cluster-transfer-modal"
         aria-describedby="modal-box-cancel-cluster-transfer"
       >

--- a/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
+++ b/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
@@ -6,6 +6,9 @@ import {
   ClipboardCopyVariant,
   Content,
   ContentVariants,
+  Modal,
+  ModalBody,
+  ModalHeader,
   Stack,
   StackItem,
   Tab,
@@ -13,7 +16,6 @@ import {
   Tabs,
   TabTitleText,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 import { MULTIREGION_PREVIEW_ENABLED } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
@@ -200,14 +202,22 @@ function ActionRequiredModal({ cluster, isOpen, onClose, regionalInstance }) {
 
   return (
     <Modal
-      title="Action required to continue installation"
+      id="action-required-installation-modal"
       isOpen={isOpen}
       onClose={onClose}
-      variant={ModalVariant.medium}
+      variant="medium"
+      aria-labelledby="action-required-installation-modal"
+      aria-describedby="modal-box-action-required-installation"
     >
-      {isWaitingAndROSAManual && createInteractively}
-      {isWaitingForOIDCProviderOrOperatorRoles && createByOIDCId(cluster)}
-      {isBadSharedGCPVPCValues && showGCPVPCSharedError}
+      <ModalHeader
+        title="Action required to continue installation"
+        labelId="action-required-installation-modal"
+      />
+      <ModalBody>
+        {isWaitingAndROSAManual && createInteractively}
+        {isWaitingForOIDCProviderOrOperatorRoles && createByOIDCId(cluster)}
+        {isBadSharedGCPVPCValues && showGCPVPCSharedError}
+      </ModalBody>
     </Modal>
   );
 }

--- a/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
+++ b/src/components/clusters/common/InstallProgress/ActionRequiredModal.jsx
@@ -9,6 +9,7 @@ import {
   Modal,
   ModalBody,
   ModalHeader,
+  ModalVariant,
   Stack,
   StackItem,
   Tab,
@@ -205,7 +206,7 @@ function ActionRequiredModal({ cluster, isOpen, onClose, regionalInstance }) {
       id="action-required-installation-modal"
       isOpen={isOpen}
       onClose={onClose}
-      variant="medium"
+      variant={ModalVariant.medium}
       aria-labelledby="action-required-installation-modal"
       aria-describedby="modal-box-action-required-installation"
     >

--- a/src/components/clusters/common/MachineConfiguration/components/MachineConfigurationModal.tsx
+++ b/src/components/clusters/common/MachineConfiguration/components/MachineConfigurationModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader } from '@patternfly/react-core';
 
 interface MachineConfigurationModalProps {
   children: React.ReactNode;
@@ -11,13 +11,19 @@ export const MachineConfigurationModal: React.FC<MachineConfigurationModalProps>
 
   return (
     <Modal
-      title="Edit machine configuration"
-      description="Make custom edits to your machine configuration"
-      variant={ModalVariant.medium}
+      id="edit-machine-configuration-modal"
+      variant="medium"
       isOpen
       onClose={onClose}
+      aria-labelledby="edit-machine-configuration-modal"
+      aria-describedby="modal-box-edit-machine-configuration"
     >
-      {children}
+      <ModalHeader
+        title="Edit machine configuration"
+        description="Make custom edits to your machine configuration"
+        labelId="edit-machine-configuration-modal"
+      />
+      <ModalBody>{children}</ModalBody>
     </Modal>
   );
 };

--- a/src/components/clusters/common/MachineConfiguration/components/MachineConfigurationModal.tsx
+++ b/src/components/clusters/common/MachineConfiguration/components/MachineConfigurationModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Modal, ModalBody, ModalHeader } from '@patternfly/react-core';
+import { Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
 
 interface MachineConfigurationModalProps {
   children: React.ReactNode;
@@ -12,7 +12,7 @@ export const MachineConfigurationModal: React.FC<MachineConfigurationModalProps>
   return (
     <Modal
       id="edit-machine-configuration-modal"
-      variant="medium"
+      variant={ModalVariant.medium}
       isOpen
       onClose={onClose}
       aria-labelledby="edit-machine-configuration-modal"

--- a/src/components/clusters/common/Upgrades/UpgradeAcknowledge/UpgradeAcknowledgeModal/UpgradeAcknowledgeModal.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeAcknowledge/UpgradeAcknowledgeModal/UpgradeAcknowledgeModal.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import { modalActions } from '~/components/common/Modal/ModalActions';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
@@ -129,7 +136,7 @@ const UpgradeAcknowledgeModal = ({
       id="acknowledge-upgrade-modal"
       onClose={() => onCancel()}
       isOpen
-      variant="medium"
+      variant={ModalVariant.medium}
       aria-labelledby="acknowledge-upgrade-modal"
       aria-describedby="modal-box-acknowledge-upgrade"
       className="ocm-upgrade-ack-modal"

--- a/src/components/clusters/common/Upgrades/UpgradeAcknowledge/UpgradeAcknowledgeModal/UpgradeAcknowledgeModal.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeAcknowledge/UpgradeAcknowledgeModal/UpgradeAcknowledgeModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 
 import { modalActions } from '~/components/common/Modal/ModalActions';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
@@ -14,7 +14,6 @@ import { useGlobalState } from '~/redux/hooks';
 import { UpgradePolicy, VersionGate } from '~/types/clusters_mgmt.v1';
 
 import ErrorBox from '../../../../../common/ErrorBox';
-import Modal from '../../../../../common/Modal/Modal';
 import { setAutomaticUpgradePolicy } from '../../clusterUpgradeActions';
 import UpgradeAcknowledgeStep from '../UpgradeAcknowledgeStep';
 
@@ -127,34 +126,47 @@ const UpgradeAcknowledgeModal = ({
   if (!isOpen) return null;
   return (
     <Modal
-      title="Administrator acknowledgement"
+      id="acknowledge-upgrade-modal"
       onClose={() => onCancel()}
-      primaryText="Approve and continue"
-      secondaryText="Cancel"
-      onPrimaryClick={() => postClusterAcknowledge()}
-      onSecondaryClick={() => onCancel()}
-      isPrimaryDisabled={!confirmed}
-      isPending={pending}
+      isOpen
+      variant="medium"
+      aria-labelledby="acknowledge-upgrade-modal"
+      aria-describedby="modal-box-acknowledge-upgrade"
       className="ocm-upgrade-ack-modal"
-      modalSize={ModalVariant.medium}
     >
-      {errors.length === 0 ? (
-        <UpgradeAcknowledgeStep
-          fromVersion={fromVersion}
-          toVersion={toVersion}
-          unmetAcknowledgements={unmetAcknowledgements}
-          confirmed={(isConfirmed: boolean) => setConfirmed(isConfirmed)}
-        />
-      ) : (
-        errors.map((error, index) => (
-          <ErrorBox
-            /* eslint-disable-next-line react/no-array-index-key */
-            key={`err-${index}`}
-            message="Failed to save administrator acknowledgement."
-            response={error?.error}
+      <ModalHeader title="Administrator acknowledgement" labelId="acknowledge-upgrade-modal" />
+      <ModalBody>
+        {errors.length === 0 ? (
+          <UpgradeAcknowledgeStep
+            fromVersion={fromVersion}
+            toVersion={toVersion}
+            unmetAcknowledgements={unmetAcknowledgements}
+            confirmed={(isConfirmed) => setConfirmed(isConfirmed)}
           />
-        ))
-      )}
+        ) : (
+          errors.map((error, index) => (
+            <ErrorBox
+              /* eslint-disable-next-line react/no-array-index-key */
+              key={`err-${index}`}
+              message="Failed to save administrator acknowledgement."
+              response={error?.error}
+            />
+          ))
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={() => postClusterAcknowledge()}
+          isDisabled={!confirmed}
+          isLoading={pending}
+        >
+          Approve and continue
+        </Button>
+        <Button variant="link" onClick={() => onCancel()} isDisabled={pending}>
+          Cancel
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };


### PR DESCRIPTION
# Summary

Update for the deprecated PF5 modals to align with the modern modular approach of PF6 Modal.

Assisted by: Cursor/GPT-5
<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
[OCMUI-3603](https://issues.redhat.com/browse/OCMUI-3603)

# Additional information

There were 19 deprecated components. 2 Tile components, Wizard component and 16 modals.
This PR addresses 15 out of 16 Modal components. 16th modal is the wrapper that we utilize around ALL modals in the application. To address this particular component discussion is required, as it will be a much larger effort to update all the custom modals that we utilize.

# How to Test

I divided PR into 15 commits.
1 commit for each modal.
Please, look at the commit -> It should have the file name in the title.
Locate in the UI the modal mentioned in the commit and simply confirm that it looks and works as expected.

# Screen Captures

No visual changes expected.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
