### PR TITLE
OCMUI-3619 On HCP wizard confirm, fix overlapping subnets

### DIFF
--- a/src/components/clusters/wizards/common/ReviewCluster/AwsVpcTable.tsx
+++ b/src/components/clusters/wizards/common/ReviewCluster/AwsVpcTable.tsx
@@ -24,7 +24,7 @@ const AwsVpcTable = ({ vpc, machinePoolsSubnets, hasPublicSubnets }: AwsVpcTable
   const subnetColumns = hasPublicSubnets ? 5 : 9;
 
   return (
-    <Grid>
+    <Grid className="ocm-aws-vpc-table">
       <GridItem md={azColumns}>
         <strong>Availability zone</strong>
       </GridItem>

--- a/src/components/clusters/wizards/rosa/ReviewClusterScreen/ReviewClusterScreen.scss
+++ b/src/components/clusters/wizards/rosa/ReviewClusterScreen/ReviewClusterScreen.scss
@@ -34,4 +34,11 @@
   .review-screen-expandable-section__toggle-wrapper {
     margin-top: 1rem;
   }
+
+  // Fix a weird spacing issue on Safari where the grid items did not expand to
+  // contain the content.
+  .ocm-aws-vpc-table  .pf-v6-l-grid__item {
+    min-height: auto;
+    padding:3px
+  }
 }


### PR DESCRIPTION
# Summary

On the HCP wizard confirmation page on medium to smaller screens, the machine pool subnets overlap on Safari.

Note that this was an issue only on Safari and not seen in other browsers.  There was no code changes and for most users there is an extremely minimal change.

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3619](https://issues.redhat.com/browse/OCMUI-3619) 

# Additional information

This appears to be a weird quirk on Safari with our code base - I couldn't reproduce with a native PF grid.  The review page is complicated with numerous nested items that normally  aren't nested (a grid inside of a list item for example).  While I can't rule out a PF bug - it is most likely due to our nesting of items.

The the "correct" fix would be to completely re-architect and re-design the confirmation page, that seemed a little heavy-handed so a single harmless line of CSS did the trick.  The change is scoped only to the subnet grid on the confirmation page.

Because on smaller screens column content can go right next to each other making it hard to read, I added an extremely small padding.  Yep the words are breaking in weird spots - unfortunately this isn't easily fixed.  Adding no-wrap on the cells just forces them to bleed on top of each other horizontally.

Since this is a CSS only change - there are no new tests.

# How to Test

- In the Safari browser, go to the HCP wizard
- On the Machine Pool step, add at least 2 subnets
- Go to the confirmation page
- Resize the window and ensure that text does not overlap. 
- Do the same steps on Chrome, FireFox, or Edge to ensure this fix didn't cause new issues


# Screen Captures (small screen) - Safari

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="905" height="588" alt="Screenshot 2025-08-14 at 3 38 49 PM" src="https://github.com/user-attachments/assets/1bcecbce-fdf4-4a7c-93f4-26922c4d3adb" /> |  <img width="905" height="588" alt="Screenshot 2025-08-14 at 3 40 08 PM" src="https://github.com/user-attachments/assets/f97f5669-f221-494c-a6b9-cf9c889b61a6" /> |

# Screen Captures (small screen) - Chrome

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="905" height="588" alt="Screenshot 2025-08-14 at 3 43 12 PM" src="https://github.com/user-attachments/assets/3bbb5ee8-08b4-475b-ae33-fae0a2ab40ee" /> | <img width="905" height="588" alt="Screenshot 2025-08-14 at 3 41 39 PM" src="https://github.com/user-attachments/assets/cf4e348e-deb3-4c5e-b6d2-73c67d675253" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
