### PR TITLE
OCMUI-3539: replaced install uninstall stepper in case of an error

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
@@ -144,9 +144,7 @@ describe('<ClusterDetailsTop />', () => {
 
     render(<ClusterDetailsTop {...newProps} />);
 
-    expect(
-      await screen.findByText('An error occured during cluster install or uninstall process.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Cluster is in an error state.')).toBeInTheDocument();
   });
 
   it('should show only Unarchive button if the cluster is archived', async () => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
@@ -33,7 +33,7 @@ import { InflightCheckState } from '~/types/clusters_mgmt.v1/enums';
 
 // TODO: Part of the installation story
 const ClusterStatusMonitor = (props) => {
-  const { cluster, refresh, region, isInstallAlertPresent } = props;
+  const { cluster, refresh, region } = props;
 
   const [refetchInterval, setRefetchInterval] = React.useState(false);
 
@@ -367,12 +367,12 @@ const ClusterStatusMonitor = (props) => {
       const alerts = [];
 
       // Cluster install failure
-      if (clusterStatus.state === clusterStates.error && !isInstallAlertPresent) {
+      if (clusterStatus.state === clusterStates.error) {
         alerts.push(
           <Alert
             variant="danger"
             isInline
-            title={`${errorCode} Cluster installation failed`}
+            title={`${errorCode} An error occured during cluster install or uninstall process.`}
             className="pf-v6-u-mt-md"
           >
             <p>
@@ -414,7 +414,6 @@ const ClusterStatusMonitor = (props) => {
 };
 
 ClusterStatusMonitor.propTypes = {
-  isInstallAlertPresent: PropTypes.bool,
   region: PropTypes.string,
   cluster: PropTypes.shape({
     id: PropTypes.string,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/RecommendedOperatorsAlert/RecommendedOperatorsAlert.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/RecommendedOperatorsAlert/RecommendedOperatorsAlert.tsx
@@ -48,7 +48,7 @@ const STATIC_ALERT_MESSAGES = {
     description: 'Please wake the cluster before considering recommended operators.',
   },
   error: {
-    title: 'Your cluster encountered an error during creation.',
+    title: 'Your cluster encountered an error.',
     description: 'Please address the issue before considering recommended operators.',
   },
 };


### PR DESCRIPTION
# Summary

We have a bug that occurs during uninstallation if said uninstallation results in an error. We show installation stepper during installation, and uninstallation stepper during uninstallation. The bug is that if an error occured during uninstallation, instead of uninstallation stepper it shows installation stepper. The issue is that there is no way to differentiate when the error ocured, during installation or uninstallation. The proposal is to not show install/uninstall stepper and instead show an alert and expandable logs view for the user.

# Jira

[OCMUI-3539](https://issues.redhat.com/browse/OCMUI-3539)

# Additional information

From technical standpoint the fix is very simple. In case of installation we display install stepper, in case of uninstallation we display uninstall stepper, and in case of an error we remove stepper and display alert with a message that an error ocured during installation or uninstallation and display logs for the user to debug reasons why an error ocured.

# How to Test

1. Start installing cluster and make it fail during installation (or there is a cluster ?env=production that has an install failure on it)
2. Confirm that stepper is no longer present and alert is displayed.
3. Same thing with uninstall clluster, but I did not test this scenario, because it is not possible to "mock" uninstall failure.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="2722" height="1496" alt="image" src="https://github.com/user-attachments/assets/20d9a4a4-3a92-4e82-8f4e-1b52da233c84" /> | <img width="2722" height="1496" alt="image" src="https://github.com/user-attachments/assets/2639cdcd-c110-40eb-95a1-cf1baaad8c5a" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
