### PR TITLE
OCMUI-3612: fix padding on prerequisites btn

### DIFF
--- a/src/components/clusters/CreateClusterPage/CloudTab/components/CreateClusterDropDown.tsx
+++ b/src/components/clusters/CreateClusterPage/CloudTab/components/CreateClusterDropDown.tsx
@@ -57,7 +57,7 @@ const CreateClusterDropDown = ({ toggleId, isDisabled }: CreateClusterDropDownPr
   };
 
   return (
-    <Flex>
+    <Flex direction={{ default: 'column' }}>
       <FlexItem>
         <Dropdown
           ref={dropDownRef}


### PR DESCRIPTION
# Summary

Added padding between Create cluster and Prerequisites buttons in ROSA section of Managed Services table.

# Jira

[OCMUI-3612](https://issues.redhat.com/browse/OCMUI-3612)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

1. Click on Create cluster button on Cluster list.
2. Locate ROSA section in the table.
3. Check that Create cluster dropdown and Prerequisites have padding between each other.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <img width="2716" height="286" alt="image" src="https://github.com/user-attachments/assets/50d75a08-8c65-4779-9200-26ee66344ab5" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
