### PR TITLE
[OCMUI-1694] E2E test automation - Roles And Access

### DIFF
--- a/cypress/e2e/rosa/RosaClassicRolesAndAccess.js
+++ b/cypress/e2e/rosa/RosaClassicRolesAndAccess.js
@@ -1,0 +1,113 @@
+import ClusterListPage from '../../pageobjects/ClusterList.page';
+import ClusterDetails from '../../pageobjects/ClusterDetails.page';
+import ClusterRolesAndAccess from '../../pageobjects/ClusterRolesAndAccess.page';
+
+const clusterProfiles = require('../../fixtures/rosa/RosaClusterClassicCreatePublic.json');
+const userDetails = clusterProfiles['rosa-classic-public']['day2-profile']['RolesAndAccess'];
+const ClusterName = clusterProfiles['rosa-classic-public']['day1-profile']['ClusterName'];
+
+describe(
+  'Rosa Classic Cluster - Cluster Roles and Access validation - OCP-29399',
+  { tags: ['day2', 'rosa', 'public'] },
+  () => {
+    before(() => {
+      cy.visit('/cluster-list');
+      ClusterListPage.waitForDataReady();
+      ClusterListPage.isClusterListScreen();
+      ClusterListPage.filterTxtField().should('be.visible').click();
+      ClusterListPage.filterTxtField().clear().type(ClusterName);
+      ClusterListPage.waitForDataReady();
+      ClusterListPage.openClusterDefinition(ClusterName);
+      ClusterDetails.waitForInstallerScreenToLoad();
+      ClusterDetails.accessControlTab().click();
+      ClusterRolesAndAccess.clusterRolesAndAccessTab().click();
+    });
+
+    it(`Step - Validate the Add cluster user modal of ${ClusterName} for multiple errors`, () => {
+      ClusterRolesAndAccess.addRoleButton().click();
+      ClusterRolesAndAccess.addUserModalTitle().should('be.visible');
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput().type(' ').clear().blur();
+      ClusterRolesAndAccess.getUserIDErrorText().should(
+        'contain.text',
+        userDetails.Validations.UserID.EmptyError,
+      );
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput()
+        .clear()
+        .type(userDetails.Validations.UserID.InvalidScenarios[0].input)
+        .blur();
+      ClusterRolesAndAccess.getUserIDErrorText().should(
+        'contain.text',
+        userDetails.Validations.UserID.InvalidScenarios[0].error,
+      );
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput()
+        .clear()
+        .type(userDetails.Validations.UserID.InvalidScenarios[1].input)
+        .blur();
+      ClusterRolesAndAccess.getUserIDErrorText().should(
+        'contain.text',
+        userDetails.Validations.UserID.InvalidScenarios[1].error,
+      );
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput()
+        .clear()
+        .type(userDetails.Validations.UserID.InvalidScenarios[2].input)
+        .blur();
+      ClusterRolesAndAccess.getUserIDErrorText().should(
+        'contain.text',
+        userDetails.Validations.UserID.InvalidScenarios[2].error,
+      );
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput()
+        .clear()
+        .type(userDetails.Validations.UserID.InvalidScenarios[3].input)
+        .blur();
+      ClusterRolesAndAccess.getUserIDErrorText().should(
+        'contain.text',
+        userDetails.Validations.UserID.InvalidScenarios[3].error,
+      );
+      ClusterRolesAndAccess.addUserModalButton().should('be.disabled');
+
+      ClusterRolesAndAccess.userIDInput().clear().type(userDetails['dedicated-admin-user'].UserID);
+      ClusterRolesAndAccess.addUserModalButton().should('be.enabled');
+
+      ClusterRolesAndAccess.cancelModalButton().click();
+    });
+
+    it(`Step - Add a new dedicated admin user for ${ClusterName} and verify it appear in the list`, () => {
+      ClusterRolesAndAccess.addRoleButton().click();
+      ClusterRolesAndAccess.userIDInput().type(userDetails['dedicated-admin-user'].UserID);
+      ClusterRolesAndAccess.dedicatedAdminsCheck().should('be.checked');
+      ClusterRolesAndAccess.addUserModalButton().click();
+      ClusterRolesAndAccess.waitForClosingModal();
+      ClusterRolesAndAccess.verifyUserInList(
+        userDetails['dedicated-admin-user'].UserID,
+        userDetails['dedicated-admin-user'].Group,
+      );
+
+      ClusterRolesAndAccess.deleteUser(userDetails['dedicated-admin-user'].UserID);
+      ClusterRolesAndAccess.verifyUserNotInList(userDetails['dedicated-admin-user'].UserID);
+    });
+
+    it(`Step - Add and then delete cluster admin user for ${ClusterName}`, () => {
+      ClusterRolesAndAccess.addRoleButton().click();
+      ClusterRolesAndAccess.userIDInput().type(userDetails['cluster-admin-user'].UserID);
+      ClusterRolesAndAccess.clusterAdminsCheck().check();
+      ClusterRolesAndAccess.addUserModalButton().click();
+      ClusterRolesAndAccess.waitForClosingModal();
+      ClusterRolesAndAccess.verifyUserInList(
+        userDetails['cluster-admin-user'].UserID,
+        userDetails['cluster-admin-user'].Group,
+      );
+      ClusterRolesAndAccess.deleteUser(userDetails['cluster-admin-user'].UserID);
+      ClusterRolesAndAccess.verifyUserNotInList(userDetails['cluster-admin-user'].UserID);
+    });
+  },
+);

--- a/cypress/fixtures/rosa/RosaClusterClassicCreatePublic.json
+++ b/cypress/fixtures/rosa/RosaClusterClassicCreatePublic.json
@@ -2,8 +2,7 @@
   "rosa-classic-public": {
     "day1-profile": {
       "Description": "rosa classic public cluster with base configuration",
-
-      "ClusterName": "cyp-rosa-classic-default-sz-public-profile",
+      "ClusterName": "apechaclassicrosa",
       "ControlPlaneType": "Classic architecture",
       "Type": "ROSA",
       "Region": "us-west-2, US West, Oregon",
@@ -67,13 +66,45 @@
             "InvalidOrganizationIDError": "Organization ID must be an alpha numeric with no symbols"
           }
         }
+      },
+      "RolesAndAccess": {
+        "dedicated-admin-user": {
+          "UserID": "ocmcypress1",
+          "Group": "dedicated-admins"
+        },
+        "cluster-admin-user": {
+          "UserID": "ocmcypress2",
+          "Group": "cluster-admins"
+        },
+        "Validations": {
+          "UserID": {
+            "EmptyError": "User ID cannot be empty.",
+            "InvalidScenarios": [
+              {
+                "input": " ",
+                "error": "User ID cannot contain leading and trailing spaces"
+              },
+              {
+                "input": "user/with/slashes",
+                "error": "User ID cannot contain '/'."
+              },
+              {
+                "input": "OsdR%%",
+                "error": "User ID cannot contain '%'."
+              },
+              {
+                "input": "Osd%Rosa:asd",
+                "error": "User ID cannot contain ':'."
+              }
+            ]
+          }
+        }
       }
     }
   },
   "rosa-classic-public-advanced": {
     "day1-profile": {
       "Description": "rosa classic public cluster with advanced configuration",
-
       "ControlPlaneType": "Classic architecture",
       "Type": "ROSA",
       "ClusterName": "cyp-rosa-classic-advanced-mz-public-profile",

--- a/cypress/pageobjects/ClusterRolesAndAccess.page.js
+++ b/cypress/pageobjects/ClusterRolesAndAccess.page.js
@@ -1,0 +1,57 @@
+import Page from './page';
+
+class ClusterRolesAndAccess extends Page {
+  addRoleButton = () => cy.get('button').contains('Add user');
+  rolesTab = () => cy.get('butotn[aria-constrols="rolesTabContent"]');
+  clusterRolesAndAccessTab = () => cy.get('button[role="tab"').contains('Cluster Roles and Access');
+
+  addUserModalTitle = () => cy.contains('h1', 'Add cluster user');
+  userIDInput = () => cy.get('input[id="user-id"]');
+
+  dedicatedAdminsCheck = () => cy.get('input[name="dedicated-admins"]');
+  clusterAdminsCheck = () => cy.get('input[name="cluster-admins"]');
+  addUserModalButton = () => cy.get('div[role="dialog"]').find('button[data-testid="btn-primary"]');
+  cancelModalButton = () =>
+    cy.get('div[role="dialog"]').find('button[data-testid="btn-secondary"]');
+
+  getUserIDErrorText = () => {
+    return cy.get('div[role="dialog"]').find('[class*="helper-text__item"][class*="pf-m-error"]');
+  };
+
+  verifyUserInList(userID, group) {
+    cy.contains('tr', userID).within(() => {
+      cy.contains('td', group).should('be.visible');
+    });
+  }
+
+  verifyUserNotInList(userID) {
+    cy.get('#pf-tab-section-1-cluster-roles-access', { timeout: 10000 })
+      .contains(userID)
+      .should('not.exist');
+  }
+
+  deleteUser(userID) {
+    cy.contains('tr', userID).within(() => {
+      cy.get('button[aria-label="Kebab toggle"]').click({ force: true });
+    });
+    cy.get('button[role="menuitem"]').contains('Delete').click({ force: true });
+    //cy.get('button[data-testid="btn-pirmary"]').contains('Delete').click({force: true});
+  }
+
+  isTextContainsInPage(text, present = true) {
+    if (present) {
+      cy.contains(text).should('exist');
+    } else {
+      cy.contains(text).should('not.exist');
+    }
+  }
+
+  selectPermissionsCheckbox = (permissions) =>
+    cy.get(`input[type="checkbox"][name="${permissions}"]`);
+
+  waitForClosingModal = () => {
+    cy.get('div[role="dialog"]', { timeout: 10000 }).should('not.exist');
+  };
+}
+
+export default new ClusterRolesAndAccess();


### PR DESCRIPTION
# Summary

E2E automation based on [OCP-29399 - [SDA-2070] Add/delete users in the 'cluster-admins' group on UI](https://polarion.engineering.redhat.com/polarion/redirect/project/OSE/workitem?id=OCP-29399)

# Jira

[OCMUI-1694](https://issues.redhat.com/browse/OCMUI-1694)

# Additional information

- Check user ID creation errors
- Create user ID
-  Delete user ID

# How to Test

- Rosa Classic cluster needs to be prepared before running test
- Name of the cluster needs to be manually added into fixture from this PR (`ClusterName`)

Run interactive cypress command
`yarn cypress-ui`

or

Run headless cypress command
`yarn cypress-headless --spec 'cypress/e2e/rosa/RosaClassicRolesAndAccess.js'`

# Screen Captures

<img width="954" height="501" alt="RosaClassicRolesAndAccess" src="https://github.com/user-attachments/assets/fac65686-6c58-4dd4-a77b-4eaf5ede3d62" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
