### PR TITLE
[OCMUI-3708]E2e tests - Updates on GCP wizard tests to follow the default authentication change(WIF)

### DIFF
--- a/cypress/e2e/osd-gcp/OsdCcsGCPPrivateClusterCreateAdvanced.js
+++ b/cypress/e2e/osd-gcp/OsdCcsGCPPrivateClusterCreateAdvanced.js
@@ -36,6 +36,7 @@ describe(
       CreateOSDWizardPage.isCloudProviderSelectionScreen();
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
       if (clusterProperties.AuthenticationType.includes('Service Account')) {
+        CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
       } else {
         CreateOSDWizardPage.workloadIdentityFederationButton().click();

--- a/cypress/e2e/osd-gcp/OsdCcsGCPPublicClusterCreate.js
+++ b/cypress/e2e/osd-gcp/OsdCcsGCPPublicClusterCreate.js
@@ -33,6 +33,7 @@ describe(
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
 
       if (clusterProperties.AuthenticationType.includes('Service Account')) {
+        CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
       } else {
         CreateOSDWizardPage.workloadIdentityFederationButton().click();

--- a/cypress/e2e/osd-gcp/OsdCcsGCPPublicClusterCreateAdvanced.js
+++ b/cypress/e2e/osd-gcp/OsdCcsGCPPublicClusterCreateAdvanced.js
@@ -36,6 +36,7 @@ describe(
       CreateOSDWizardPage.isCloudProviderSelectionScreen();
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
       if (clusterProperties.AuthenticationType.includes('Service Account')) {
+        CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
       } else {
         CreateOSDWizardPage.workloadIdentityFederationButton().click();

--- a/cypress/e2e/osd/OsdCcsClusterCreation.js
+++ b/cypress/e2e/osd/OsdCcsClusterCreation.js
@@ -51,6 +51,7 @@ describe(
 
         if (clusterProperties.CloudProvider.includes('GCP')) {
           if (clusterProperties.AuthenticationType.includes('Service Account')) {
+            CreateOSDWizardPage.serviceAccountButton().click();
             CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
           } else {
             CreateOSDWizardPage.workloadIdentityFederationButton().click();

--- a/cypress/e2e/osd/OsdCcsWizardValidation.js
+++ b/cypress/e2e/osd/OsdCcsWizardValidation.js
@@ -39,6 +39,7 @@ describe('OSD Wizard validation tests(OCP-54134,OCP-73204)', { tags: ['smoke'] }
 
         if (clusterProperties.CloudProvider.includes('GCP')) {
           if (clusterProperties.AuthenticationType.includes('Service Account')) {
+            CreateOSDWizardPage.serviceAccountButton().click();
             CreateOSDWizardPage.wizardNextButton().click();
             CreateOSDWizardPage.isTextContainsInPage(
               ClustersValidation.ClusterSettings.CloudProvider.GCP.EmptyGCPServiceJSONFieldError,
@@ -61,7 +62,6 @@ describe('OSD Wizard validation tests(OCP-54134,OCP-73204)', { tags: ['smoke'] }
             );
             CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
           } else {
-            CreateOSDWizardPage.workloadIdentityFederationButton().click();
             CreateOSDWizardPage.wizardNextButton().click();
             CreateOSDWizardPage.isTextContainsInPage(
               ClustersValidation.ClusterSettings.CloudProvider.GCP.NoWIFConfigSelectionError,

--- a/cypress/e2e/osd/OsdMarketplaceClusterCreation.js
+++ b/cypress/e2e/osd/OsdMarketplaceClusterCreation.js
@@ -38,6 +38,7 @@ describe('OSD Marketplace cluster creation tests(OCP-67514)', { tags: ['smoke'] 
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
 
       if (clusterProperties.AuthenticationType.includes('Service Account')) {
+        CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
       } else {
         CreateOSDWizardPage.workloadIdentityFederationButton().click();

--- a/cypress/e2e/osd/OsdTrialClusterCreation.js
+++ b/cypress/e2e/osd/OsdTrialClusterCreation.js
@@ -32,6 +32,7 @@ describe(`OSDTrial cluster creation tests(OCP-39415)`, { tags: ['smoke'] }, () =
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
       CreateOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
       if (clusterProperties.CloudProvider.includes('GCP')) {
+        CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
       } else {
         CreateOSDWizardPage.awsAccountIDInput().type(awsAccountID);


### PR DESCRIPTION
# Summary

E2e tests - Updates on GCP wizard tests to follow the default authentication change(WIF)

# Jira

Fixes [OCMUI-3708](https://issues.redhat.com/browse/OCMUI-3708) 

# Additional information

The recent feature changes in [OCMUI-3604](https://issues.redhat.com/browse/OCMUI-3604) makes the default authentication as "Workload identity feature" in GCP wizard. This breaks e2e tests especially related to various GCP wizard tests. The PR will fix the same.

# How to Test

Run the random test ex:


# Screen Captures

nil

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
