### PR TITLE
chore: revert corepack's package-manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,5 @@
   "engines": {
     "node": ">= 18.12.0",
     "yarn": ">= 1.22.19"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }


### PR DESCRIPTION
# Summary

remove the `packageManager` field from _package.json_.


# Jira

N/A


# Additional information

`packageManager` gets added automatically when yarn is being installed using corepack, and not via npm or e.g. brew.

[corepack][3] is an experimental version-manager for package-managers.   it is [meant for installing later yarn versions][2] (v2 onwards), and should not be used to [install yarn-classic][1] – which we use (v1.22.22).

(side note - adding `packageManager` for yarn was actually [proposed in the past][4] and got rejected, but then [slipped in][5] unnoticed with the PF6 migration).


# How to Test

no functional testing.  CI should pass.


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no QE.



[1]: https://classic.yarnpkg.com/en/docs/install
[2]: https://yarnpkg.com/corepack
[3]: https://nodejs.org/download/release/v22.12.0/docs/api/corepack.html
[4]: https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/6212
[5]: https://github.com/RedHatInsights/uhc-portal-internal-archive/pull/200/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R254
