### PR TITLE
OCMUI-3614: added spacing between alerts

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
@@ -261,7 +261,7 @@ const ClusterStatusMonitor = (props) => {
         // show spinner on rerun button
         const runningInflightCheck = wasRunClicked || isValidatorRunning;
         return (
-          <Alert variant="warning" isInline title="User action required">
+          <Alert variant="warning" isInline title="User action required" className="pf-v6-u-mt-md">
             <Flex direction={{ default: 'column' }}>
               <FlexItem>{`${reason}`}</FlexItem>
               {inflightTable && <FlexItem>{inflightTable}</FlexItem>}
@@ -346,7 +346,7 @@ const ClusterStatusMonitor = (props) => {
       reason.push(<strong>Compute Security Administrator, </strong>);
       reason.push(<strong>DNS Administrator.</strong>);
       return (
-        <Alert variant="warning" isInline title="Permissions needed:">
+        <Alert variant="warning" isInline title="Permissions needed:" className="pf-v6-u-mt-md">
           <Flex direction={{ default: 'column' }}>
             <FlexItem>{reason}</FlexItem>
             <FlexItem>


### PR DESCRIPTION
# Summary

When installation fails, and there was an inflight checks error two alerts did not have margin between them. The PR simply adds a PF6 utility class that was missing on one of the alerts.

# Jira

[OCMUI-3614](https://issues.redhat.com/browse/OCMUI-3614)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

1. The easiest way to test is to use an existing cluster with ?env=production flag. Cluster name is kim-rosa-multi. It has both alerts present.
2. Confirm that all alerts present on ClusterDetails page have gaps between them.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="2716" height="1208" alt="image" src="https://github.com/user-attachments/assets/a5d56f40-ae3a-49db-b9d2-34eb16c6dc0f" />| <img width="2716" height="1208" alt="image" src="https://github.com/user-attachments/assets/8f438ad9-5781-427d-817a-a4b05381b592" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
