### PR TITLE
OCMUI-3715: Check API pipeline is failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "stop-insights-proxy": "run/podman-or-docker.sh kill insightsproxy; run/podman-or-docker.sh rm --force insightsproxy; true",
     "lint": "eslint src 'run/*js' --ext mjs,js,jsx,ts,tsx",
     "lint-prettier": "yarn lint && yarn prettier",
-    "lint-staged": "lint-staged",
+    "lint-staged": "lint-staged --config ./lint-staged.config.js --cwd .",
     "prettier": "prettier --check '{src,cypress,scripts}/**/*.{js,ts,mjs,jsx,tsx}' 'run/*js'",
     "prettier:fix": "prettier --write '{src,cypress,scripts}/**/*.{js,ts,mjs,jsx,tsx}' 'run/*js'",
     "test": "TZ=America/New_York LC_ALL=en_US.utf8 node --no-compilation-cache --expose-gc ./node_modules/.bin/jest --logHeapUsage --coverage ",


### PR DESCRIPTION
# Summary

For some reason lint-staged is picking up configs from node_modules packages and failing because they are not compatible with its version (15).

See example logs here https://github.com/RedHatInsights/uhc-portal/actions/runs/17113736927/job/48540502484

# Jira

Fixes [OCMUI-3715](https://issues.redhat.com/browse/OCMUI-3715)

# Additional information

It seems lint-staged is not able to pick up our configuration file and it is searching it elsewhere.

Explicitly passing the configuration file should solve the issue.

# How to Test

We have to merge it and try.

# Screen Captures

NA

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
