### PR TITLE
OCMUI-3696: switch on test-coverage for konflux' "pull-request" PL

### DIFF
--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
       # causing the OS to kill the process due to out-of-memory errors
       NODE_OPTIONS='--max-old-space-size=4096' yarn lint
       yarn prettier
-      yarn test-no-coverage --run-in-band --no-cache
+      yarn test --run-in-band --no-cache
   pipelineRef:
     name: docker-build
   taskRunTemplate:


### PR DESCRIPTION
# Summary

add unit-test coverage in konflux' 'pull-request' pipelines.


# Jira

addresses [OCMUI-3696](https://issues.redhat.com/browse/OCMUI-3696)


# Additional information

considering the current status of test-coverage across the different CI systems:

|  | pull-requests | pushes to 'main' |
| --- | --- | --- |
| jenkins | ✅ |  |
| GH action | ✅ | ✅ |
| konflux |  | ✅ |

... and considering konflux is gonna replace both jenkins and GH actions, we want to be on the safe side, and just add coverage to any konflux PL.

this PR and discussion were spawned from [this comment][1] on the PR which initially added unit-tests to konflux/pull-request PL (#45).


# How to Test

just ensure CI is still ok:

- verify the konflux-pipeline PR check passes, and pipeline-run logs (under the 'run-unit-tests' task) show that test coverage ran
- verify the jenkins job PR check is still passing


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no QE.




[1]: https://github.com/RedHatInsights/uhc-portal/pull/45#discussion_r2285277500