### PR TITLE
OCMUI-3717: update tekton schedule in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,5 +23,8 @@
   "ignoreDeps": ["monaco-editor", "react-monaco-editor", "@types/react"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
-  "reviewersFromCodeOwners": true
+  "reviewersFromCodeOwners": true,
+  "tekton": {
+    "schedule": ["at any time"]
+  }
 }


### PR DESCRIPTION
# Summary

update timing for tekton schedule to "any time" in renovate config.


# Jira

addresses [OCMUI-3717](https://issues.redhat.com/browse/OCMUI-3717), related to [OCMUI-2236](https://issues.redhat.com/browse/OCMUI-2236)


# Additional information

currently, and since the move to a new repo, we don't get package updates (via renovate).  this PR is part of the attempts to fix it.

renovate should work out of the box when onboarding to konflux (via 'mintmaker', its wrapper), but it currently doesn't for our repo, even tho we're already onboarded.

after consulting with the konflux help forum, this change was suggested to ease on the investigation.  
since the default schedule of mintmaker is every 1 week, it'd be hard to test any fixing-attempts we make, so we wanna change the schedule to "any time" which means every 4 hours, to check if our attempts work.


# how to test

no functional testing, and no way to test this before merge.

after merge, we should see mintmaker requests being created against our repo



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no QE.