### PR TITLE
OCMUI-3712: Update schedule variable to use proper type so we have access to state of upgrade

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
@@ -37,7 +37,7 @@ import { useFetchMachineOrNodePools } from '~/queries/ClusterDetailsQueries/Mach
 import { useEditCluster } from '~/queries/ClusterDetailsQueries/useEditCluster';
 import { invalidateClusterDetailsQueries } from '~/queries/ClusterDetailsQueries/useFetchClusterDetails';
 import { UpgradePolicy, VersionGate } from '~/types/clusters_mgmt.v1';
-import { AugmentedCluster } from '~/types/types';
+import { AugmentedCluster, UpgradePolicyWithState } from '~/types/types';
 
 import getClusterName from '../../../../../common/getClusterName';
 import ButtonWithTooltip from '../../../../common/ButtonWithTooltip';
@@ -209,13 +209,15 @@ const UpgradeSettingsTab = ({ cluster }: UpgradeSettingsTabProps) => {
       schedule.upgrade_type === (isHypershift ? 'ControlPlane' : 'OSD'),
   );
 
-  const scheduledUpgrade = schedules.find(
-    (schedule: UpgradePolicy) =>
+  const scheduledUpgrade: UpgradePolicyWithState | undefined = schedules.find(
+    (schedule: UpgradePolicyWithState) =>
       ['manual', 'automatic'].includes(schedule.schedule_type || '') &&
       schedule.upgrade_type === (isHypershift ? 'ControlPlane' : 'OSD'),
   );
 
-  const upgradeStarted = scheduledUpgrade && scheduledUpgrade.schedule_type === 'manual';
+  const upgradeStarted =
+    scheduledUpgrade &&
+    (scheduledUpgrade.state?.value === 'started' || scheduledUpgrade.state?.value === 'delayed');
 
   // eslint-disable-next-line camelcase
   const availableUpgrades = cluster?.version?.available_upgrades;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/UpgradeSettingsTab.tsx
@@ -515,14 +515,15 @@ const UpgradeSettingsTab = ({ cluster }: UpgradeSettingsTabProps) => {
             {showUpdateButton && (
               <ButtonWithTooltip
                 variant="secondary"
-                onClick={() =>
+                onClick={() => {
+                  setConfirmationModalOpen(false);
                   dispatch(
                     openModal(modals.UPGRADE_WIZARD, {
                       clusterName: getClusterName(cluster),
                       subscriptionID: cluster?.subscription?.id,
                     }),
-                  )
-                }
+                  );
+                }}
                 disableReason={notReadyReason}
               >
                 Update


### PR DESCRIPTION
# Summary

During the conversion of UpgradeSettingsTab.jsx to tsx, the wrong `UpgradePolicy` type was used instead of `UpgradePolicyWithState` on the schedule variable.  This meant the state of the upgrade was not properly being checked later on in the process.  I corrected the type which fixes the issue.

# Jira

OCMUI-3712


# How to Test

1. Install a ROSA hosted cluster that is not up-to-date.
`rosa create cluster --cluster-name test-rosa-upgrade --region=us-west-2 --sts --version 4.19.1 --channel-group candidate
`
2. Once cluster is ready, Go cluster's Settings tab.
3. Select the Update strategy as "Recurring updates"
4. Select the day and time values from respective dropdown fields.
5. Click "Save" button.
6. Select the Update strategy as "Individual updates"
7. Click "Save" button.
8. Click "Update" button.
9. In "Update cluster" model, select version, schedules etc
10. Click "Confirm update" button 
11. There should be no modal that popups up saying "Recurring updates"

# Screen Recording
Before:

https://github.com/user-attachments/assets/783cf075-e01d-4b41-b483-1f2c593730ce

After:

https://github.com/user-attachments/assets/d0cc00ab-dfbd-4d32-bd07-ddd17b9b10aa


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
