### PR TITLE
OCMUI-3623: fix hide reveal links on CA cert field

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/CAUpload.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/CAUpload.tsx
@@ -6,6 +6,8 @@ import {
   FormGroup,
   InputGroup,
   InputGroupItem,
+  Stack,
+  StackItem,
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
@@ -147,20 +149,23 @@ const CAUpload = ({
       </InputGroup>
 
       {shouldShowCAText ? (
-        <>
-          <Button variant="link" onClick={() => revealValue(false)}>
-            Hide
-          </Button>
-
-          <TextArea
-            value={certValueState as any}
-            id={`${input.name}_text`}
-            name={`${input.name}_text`}
-            onChange={(_event, value) => updateCertificateValue(value)}
-            className="ca-textarea"
-            readOnly
-          />
-        </>
+        <Stack hasGutter>
+          <StackItem>
+            <Button variant="link" onClick={() => revealValue(false)}>
+              Hide
+            </Button>
+          </StackItem>
+          <StackItem>
+            <TextArea
+              value={certValueState as any}
+              id={`${input.name}_text`}
+              name={`${input.name}_text`}
+              onChange={(_event, value) => updateCertificateValue(value)}
+              className="ca-textarea"
+              readOnly
+            />
+          </StackItem>
+        </Stack>
       ) : (
         <div>
           <Button


### PR DESCRIPTION
# Summary

Hide and reveal links positioning was broken due to PF6 upgrade. PR fixes them to be positioned in the same place.

# Jira

[OCMUI-3623](https://issues.redhat.com/browse/OCMUI-3623)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

1. Create or use existing cluster.
2. Navigate to Access Control tab.
3. Click on Identity Providers subtab.
4. Click on Add identity provider dropdown and select Github (it has CA cert field).
5. Upload some cert or a file.
6. Confirm that Hide and Reveal links under upload file field are positioned in the same place to the left.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <img width="2716" height="1208" alt="image" src="https://github.com/user-attachments/assets/fa8fa121-2d8b-4baf-87db-42f2a789e026" /> 
<img width="2716" height="1208" alt="image" src="https://github.com/user-attachments/assets/05f0c529-17ab-4ac8-9bcf-69da74c1bcad" />
 |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
