### PR TITLE
OCMUI-3611 - Extra space between form titles and help icon

### DIFF
--- a/src/components/common/PopoverHint.tsx
+++ b/src/components/common/PopoverHint.tsx
@@ -42,6 +42,7 @@ const PopoverHint = ({
       className="popover-hint-button"
       aria-label={buttonAriaLabel || (isError ? 'Error' : 'More information')}
       variant="plain"
+      hasNoPadding
     />
   </Popover>
 );

--- a/src/components/common/PopoverHintWithTitle.tsx
+++ b/src/components/common/PopoverHintWithTitle.tsx
@@ -45,6 +45,7 @@ const PopoverHintWithTitle = ({
           className="popover-with-title-button"
           aria-label={`More information on ${title}`}
           variant="plain"
+          hasNoPadding
         />
       </Popover>
     </Content>


### PR DESCRIPTION
# Summary

Simple PR that removes the extra space between labels and their help icon. Turns out there is a very simple prop  in the Button component built for this sort of thing.

# Jira

Fixes [OCMUI-3611](https://issues.redhat.com/browse/OCMUI-3611)


# How to Test

1. The easiest place to check the difference in the popover now is in the Cluster settings page of the wizard or in the Accounts and roles page of the rosa wizard 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1056" height="734" alt="ocmui3611_before" src="https://github.com/user-attachments/assets/3fe70998-06b6-4199-858c-69e37d08b2bd" /> | <img width="603" height="545" alt="ocmui3611_after" src="https://github.com/user-attachments/assets/94673b21-976e-444b-a26a-e6f1d6a19dae" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
