### PR TITLE
chore: add konflux integration tests for cypress e2e

### DIFF
--- a/.tekton/e2e-cypress-integration-test.yaml
+++ b/.tekton/e2e-cypress-integration-test.yaml
@@ -60,9 +60,10 @@ spec:
             #
             # podman run $containerImage
             #
-            # install node.js 22
+            # dnf install node.js 22
+            #
             # git checkout $revision
-            # cache get node_modules (OPTIONAL)
+            # cache use ./node_modules (optional)
             # yarn install
             # git diff HEAD --exit-code (check for clean working tree. maybe optional, might be replaced with yarn-install's --immutable)
             # make dev-env-setup


### PR DESCRIPTION
> [!important]
> ### DO NOT MERGE
> do not even review.  nothing to see here.  move along.

---

# Summary

experimenting / incrementally writing a tekton integration-test for running E2E in node.js apps.

meant for running our internal cypress suite – i.e. the one currently running via the GH action (not the 'timed' suite that runs daily via jenkins cron).


# Jira

addresses [OCMUI-3303](https://issues.redhat.com/browse/OCMUI-3303)


# Additional information

...


# How to Test

...



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no QE

