### PR TITLE
[OCMUI-3708]Update failing test case based on the new definition on GCP authentication.

### DIFF
--- a/cypress/e2e/osd/OsdCcsWizardValidation.js
+++ b/cypress/e2e/osd/OsdCcsWizardValidation.js
@@ -40,10 +40,16 @@ describe('OSD Wizard validation tests(OCP-54134,OCP-73204)', { tags: ['smoke'] }
         if (clusterProperties.CloudProvider.includes('GCP')) {
           if (clusterProperties.AuthenticationType.includes('Service Account')) {
             CreateOSDWizardPage.serviceAccountButton().click();
+
             CreateOSDWizardPage.wizardNextButton().click();
             CreateOSDWizardPage.isTextContainsInPage(
               ClustersValidation.ClusterSettings.CloudProvider.GCP.EmptyGCPServiceJSONFieldError,
             );
+            CreateOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.Common.AcknowledgementUncheckedError,
+            );
+            CreateOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+
             CreateOSDWizardPage.uploadGCPServiceAccountJSON(
               ClustersValidation.ClusterSettings.CloudProvider.GCP
                 .InvalidFormatGCPServiceJSONValues,
@@ -66,14 +72,10 @@ describe('OSD Wizard validation tests(OCP-54134,OCP-73204)', { tags: ['smoke'] }
             CreateOSDWizardPage.isTextContainsInPage(
               ClustersValidation.ClusterSettings.CloudProvider.GCP.NoWIFConfigSelectionError,
             );
-            CreateOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.ClusterSettings.CloudProvider.Common.AcknowledgementUncheckedError,
-            );
             CreateOSDWizardPage.gcpWIFCommandInput().should(
               'have.value',
               ClustersValidation.ClusterSettings.CloudProvider.GCP.WIFCommandValue,
             );
-            CreateOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
             CreateOSDWizardPage.selectWorkloadIdentityConfiguration(
               Cypress.env('QE_GCP_WIF_CONFIG'),
             );

--- a/cypress/e2e/osd/OsdTrialClusterCreation.js
+++ b/cypress/e2e/osd/OsdTrialClusterCreation.js
@@ -30,7 +30,6 @@ describe(`OSDTrial cluster creation tests(OCP-39415)`, { tags: ['smoke'] }, () =
     it(`OSD - ${clusterProperties.CloudProvider} wizard - Cluster Settings - Cloud provider definitions`, () => {
       CreateOSDWizardPage.isCloudProviderSelectionScreen();
       CreateOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
-      CreateOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
       if (clusterProperties.CloudProvider.includes('GCP')) {
         CreateOSDWizardPage.serviceAccountButton().click();
         CreateOSDWizardPage.uploadGCPServiceAccountJSON(JSON.stringify(QE_GCP));
@@ -39,6 +38,7 @@ describe(`OSDTrial cluster creation tests(OCP-39415)`, { tags: ['smoke'] }, () =
         CreateOSDWizardPage.awsAccessKeyInput().type(awsAccessKey);
         CreateOSDWizardPage.awsSecretKeyInput().type(awsSecretKey);
       }
+      CreateOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
       cy.get(CreateOSDWizardPage.primaryButton).click();
     });
     it(`OSD - ${clusterProperties.CloudProvider} wizard - Cluster Settings - Cluster details definitions`, () => {


### PR DESCRIPTION
# Summary
Update failing test case based on the new definition on GCP authentication


# Jira

Fixes [OCMUI-3708](https://issues.redhat.com/browse/OCMUI-3708) 

# Additional information

The recent feature revision changes in [OCMUI-3604](https://issues.redhat.com/browse/OCMUI-3604) i.e. regarding the default authentication as "Workload identity feature" in GCP wizard including layout. This breaks e2e tests especially related to various GCP wizard tests. The PR will fix the same.

# How to Test

Run the local server from PR https://github.com/RedHatInsights/uhc-portal/pull/41 i.e. reviewx 41
Run the random test ex:

`yarn cypress run --browser chrome --config baseUrl='https://console.dev.redhat.com/openshift/' --spec cypress/e2e/osd/OsdTrialClusterCreation.js`

# Screen Captures

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
