### PR TITLE
OCMUI-3642: fixed redundant api calls for hcp

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
@@ -90,7 +90,6 @@ import AccessControl from './components/AccessControl/AccessControl';
 import usersActions from './components/AccessControl/UsersSection/UsersActions';
 import AccessRequest from './components/AccessRequest';
 import AddOns from './components/AddOns';
-import { getAddOns, getClusterAddOns } from './components/AddOns/AddOnsActions';
 import ClusterDetailsTop from './components/ClusterDetailsTop/ClusterDetailsTop';
 import ClusterLogs from './components/ClusterLogs/ClusterLogs';
 import { ClusterTabsId } from './components/common/ClusterTabIds';
@@ -296,8 +295,6 @@ const ClusterDetails = (props) => {
 
     if (isManaged) {
       // All managed-cluster-specific requests
-      dispatch(getAddOns(clusterID));
-      dispatch(getClusterAddOns(clusterID));
       dispatch(usersActions.getUsers(clusterID));
       dispatch(getClusterRouters(clusterID));
       refreshIDP();

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOns.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOns.jsx
@@ -36,18 +36,17 @@ const AddOns = ({ clusterID, region, cluster, isHypershift }) => {
   const dispatch = useDispatch();
   const organization = useGlobalState((state) => state.userProfile.organization);
   const quota = useGlobalState((state) => state.userProfile.organization.quotaList);
-
   const {
     data: addOnsData,
     isError: isFetchAddOnsError,
     error: addOnsError,
-  } = useFetchAddOns(clusterID, region);
+  } = useFetchAddOns(clusterID, region, isHypershift);
   const {
     data: clusterAddOnsData,
     isLoading: isFetchClusterAddOnsLoading,
     isError: isFetchClusterAddOnsError,
     error: clusterAddOnsError,
-  } = useFetchClusterAddOns(clusterID, region);
+  } = useFetchClusterAddOns(clusterID, region, isHypershift);
   const {
     isPending: isAddClusterAddOnPending,
     isError: isAddClusterAddOnError,
@@ -72,7 +71,7 @@ const AddOns = ({ clusterID, region, cluster, isHypershift }) => {
   } = useDeleteClusterAddOn(region);
 
   React.useEffect(() => {
-    if (!isFetchClusterAddOnsLoading) {
+    if (!isFetchClusterAddOnsLoading && !isHypershift) {
       refetchAddOns();
       refetchClusterAddOns();
     }

--- a/src/queries/ClusterDetailsQueries/AddOnsTab/useFetchAddOns.ts
+++ b/src/queries/ClusterDetailsQueries/AddOnsTab/useFetchAddOns.ts
@@ -12,7 +12,7 @@ export const refetchAddOns = () => {
   queryClient.invalidateQueries({ queryKey: ['addOns'] });
 };
 
-export const useFetchAddOns = (clusterID: string, region?: string) => {
+export const useFetchAddOns = (clusterID: string, region?: string, isHypershift?: boolean) => {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY, 'addOns'],
     queryFn: async () => {
@@ -39,7 +39,7 @@ export const useFetchAddOns = (clusterID: string, region?: string) => {
 
       return response;
     },
-    enabled: !!clusterID,
+    enabled: !!clusterID && !isHypershift,
   });
 
   if (isError) {

--- a/src/queries/ClusterDetailsQueries/AddOnsTab/useFetchClusterAddOns.ts
+++ b/src/queries/ClusterDetailsQueries/AddOnsTab/useFetchClusterAddOns.ts
@@ -14,7 +14,11 @@ export const refetchClusterAddOns = () => {
   });
 };
 
-export const useFetchClusterAddOns = (clusterID: string, region?: string) => {
+export const useFetchClusterAddOns = (
+  clusterID: string,
+  region?: string,
+  isHypershift?: boolean,
+) => {
   const { data, isError, error, isLoading } = useQuery({
     queryKey: [queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY, 'clusterAddOns', clusterID],
     queryFn: async () => {
@@ -39,7 +43,7 @@ export const useFetchClusterAddOns = (clusterID: string, region?: string) => {
       });
       return response;
     },
-    enabled: !!clusterID,
+    enabled: !!clusterID && !isHypershift,
   });
 
   if (isError) {


### PR DESCRIPTION
# Summary

In the HCP clusters there were some API calls made for AddOns which do not exist for HCP clusters.

# Jira

[OCMUI-3642](https://issues.redhat.com/browse/OCMUI-3642)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

1. Open developer console and open network tab. In search type /addon
2. Navigate to ROSA classic cluster and confirm that API calls are being made for AddOns.
3. Empty the network tab and navigate to ROSA HCP cluster and confirm that API calls for AddOns are not being made.

# Screen Captures

No visual change

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
