### PR TITLE
OCMUI-3597: replaced hardcoded capabilities with constants

### DIFF
--- a/src/common/__tests__/externalAuthHelper.fixtures.ts
+++ b/src/common/__tests__/externalAuthHelper.fixtures.ts
@@ -1,19 +1,21 @@
 import { Capability } from '~/types/accounts_mgmt.v1';
 
+import { subscriptionCapabilities } from '../subscriptionCapabilities';
+
 const capabilitiesWithExternalAuthentication: Capability[] = [
   {
     inherited: false,
-    name: 'capability.organization.hcp_allow_external_authentication',
+    name: subscriptionCapabilities.HCP_ALLOW_EXTERNAL_AUTHENTICATION,
     value: 'true',
   },
   {
     inherited: false,
-    name: 'capability.organization.restrict_offline_tokens',
+    name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
     value: 'true',
   },
   {
     inherited: false,
-    name: 'capability.cluster.subscribed_ocp',
+    name: subscriptionCapabilities.SUBSCRIBED_OCP,
     value: 'true',
   },
 ];
@@ -21,12 +23,12 @@ const capabilitiesWithExternalAuthentication: Capability[] = [
 const capabilitiesWithoutExternalAuthentication: Capability[] = [
   {
     inherited: false,
-    name: 'capability.organization.enable_data_sovereign_regions',
+    name: subscriptionCapabilities.ENABLE_DATA_SOVEREIGN_REGIONS,
     value: 'true',
   },
   {
     inherited: false,
-    name: 'capability.cluster.subscribed_ocp',
+    name: subscriptionCapabilities.SUBSCRIBED_OCP,
     value: 'true',
   },
 ];

--- a/src/common/__tests__/restrictTokensHelper.test.ts
+++ b/src/common/__tests__/restrictTokensHelper.test.ts
@@ -1,21 +1,22 @@
 import { hasRestrictTokensCapability } from '../restrictTokensHelper';
+import { subscriptionCapabilities } from '../subscriptionCapabilities';
 
 describe('restrict tokens capability', () => {
   it('should return true if org has restrict offline tokens capability', () => {
     const capabilities = [
       {
         inherited: false,
-        name: 'capability.organization.enable_data_sovereign_regions',
+        name: subscriptionCapabilities.ENABLE_DATA_SOVEREIGN_REGIONS,
         value: 'true',
       },
       {
         inherited: false,
-        name: 'capability.organization.restrict_offline_tokens',
+        name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
         value: 'true',
       },
       {
         inherited: false,
-        name: 'capability.cluster.subscribed_ocp',
+        name: subscriptionCapabilities.SUBSCRIBED_OCP,
         value: 'true',
       },
     ];
@@ -26,12 +27,12 @@ describe('restrict tokens capability', () => {
     const capabilities = [
       {
         inherited: false,
-        name: 'capability.organization.enable_data_sovereign_regions',
+        name: subscriptionCapabilities.ENABLE_DATA_SOVEREIGN_REGIONS,
         value: 'true',
       },
       {
         inherited: false,
-        name: 'capability.cluster.subscribed_ocp',
+        name: subscriptionCapabilities.SUBSCRIBED_OCP,
         value: 'true',
       },
     ];

--- a/src/common/externalAuthHelper.ts
+++ b/src/common/externalAuthHelper.ts
@@ -1,9 +1,11 @@
 import { Capability } from '~/types/accounts_mgmt.v1';
 
+import { subscriptionCapabilities } from './subscriptionCapabilities';
+
 export const hasExternalAuthenticationCapability = (capabilities?: Capability[]) =>
   !!capabilities?.length &&
   capabilities.some(
     (capability) =>
-      capability.name === 'capability.organization.hcp_allow_external_authentication' &&
+      capability.name === subscriptionCapabilities.HCP_ALLOW_EXTERNAL_AUTHENTICATION &&
       capability.value === 'true',
   );

--- a/src/common/restrictTokensHelper.ts
+++ b/src/common/restrictTokensHelper.ts
@@ -1,5 +1,7 @@
 import { Capability } from '~/types/accounts_mgmt.v1';
 
+import { subscriptionCapabilities } from './subscriptionCapabilities';
+
 // in case of error when checking if using offline tokens is restricted, default to showing offline tokens.
 const defaultToOfflineTokens = true;
 
@@ -7,7 +9,7 @@ const hasRestrictTokensCapability = (capabilities: Array<Capability>) =>
   !!capabilities?.length &&
   capabilities.some(
     (capability) =>
-      capability.name === 'capability.organization.restrict_offline_tokens' &&
+      capability.name === subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS &&
       capability.value === 'true',
   );
 

--- a/src/common/subscriptionCapabilities.ts
+++ b/src/common/subscriptionCapabilities.ts
@@ -17,6 +17,16 @@ const subscriptionCapabilities = {
   BARE_METAL_INSTALLER_ADMIN: 'capability.account.bare_metal_installer_admin',
   RELEASE_OCP_CLUSTERS: 'capability.cluster.release_ocp_clusters',
   CREATE_GCP_NON_CCS_CLUSTER: 'capability.organization.create_gcp_non_ccs_cluster',
+  HCP_ALLOW_EXTERNAL_AUTHENTICATION: 'capability.organization.hcp_allow_external_authentication',
+  RESTRICT_OFFLINE_TOKENS: 'capability.organization.restrict_offline_tokens',
+  AUTOSCALE_CLUSTERS: 'capability.cluster.autoscale_clusters',
+  NON_STABLE_CHANNEL_GROUP: 'capability.organization.non_stable_channel_group',
+  HIBERNATE_CLUSTER: 'capability.organization.hibernate_cluster',
+  BYPASS_PIDS_LIMITS: 'capability.organization.bypass_pids_limits',
+  ENABLE_DATA_SOVEREIGN_REGIONS: 'capability.organization.enable_data_sovereign_regions',
+  ALLOW_ETCD_ENCRYPTION: 'capability.account.allow_etcd_encryption',
+  ENABLE_ACCESS_PROTECTION: 'capability.cluster.enable_access_protection',
+  ENABLE_TERMS_ENFORCEMENT: 'capability.account.enable_terms_enforcement',
 };
 
 const hasCapability = (subscription: Subscription | undefined, name: string): boolean => {

--- a/src/components/CLILoginPage/CLILoginPage.test.tsx
+++ b/src/components/CLILoginPage/CLILoginPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { CLI_SSO_AUTHORIZATION } from '~/queries/featureGates/featureConstants';
 import {
   checkAccessibility,
@@ -41,7 +42,7 @@ describe('CLILoginPage tests', () => {
         capabilities: [
           {
             inherited: false,
-            name: 'capability.organization.restrict_offline_tokens',
+            name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
             value: 'false',
           },
         ],
@@ -62,7 +63,7 @@ describe('CLILoginPage tests', () => {
       organization: {
         capabilities: [
           {
-            name: 'capability.organization.restrict_offline_tokens',
+            name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
             value: 'true',
           },
         ],

--- a/src/components/clusters/ClusterDetailsMultiRegion/__tests__/ClusterDetails.fixtures.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/__tests__/ClusterDetails.fixtures.js
@@ -1,5 +1,6 @@
 import { produce } from 'immer';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
 import { normalizedProducts } from '../../../../common/subscriptionTypes';
@@ -303,12 +304,12 @@ const clusterDetails = {
       console_url: 'https://console-openshift-console.apps.test-liza.wiex.s1.devshift.org',
       capabilities: [
         {
-          name: 'capability.cluster.subscribed_ocp',
+          name: subscriptionCapabilities.SUBSCRIBED_OCP,
           value: 'true',
           inherited: true,
         },
         {
-          name: 'capability.cluster.manage_cluster_admin',
+          name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
           value: 'true',
           inherited: true,
         },

--- a/src/components/clusters/ClusterDetailsMultiRegion/__tests__/SubscriptionCompliancy.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/__tests__/SubscriptionCompliancy.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { checkAccessibility, render, screen } from '~/testUtils';
 
 import { subscriptionSettings } from '../../../../common/subscriptionTypes';
@@ -30,7 +31,7 @@ describe('<SubscriptionCompliancy />', () => {
     cluster.subscription[SUPPORT_LEVEL] = SubscriptionCommonFieldsSupportLevel.Eval;
     cluster.subscription.capabilities = [
       {
-        name: 'capability.cluster.subscribed_ocp',
+        name: subscriptionCapabilities.SUBSCRIBED_OCP,
         value: 'true',
         inherited: true,
       },
@@ -53,7 +54,7 @@ describe('<SubscriptionCompliancy />', () => {
     cluster.subscription[SUPPORT_LEVEL] = SubscriptionCommonFieldsSupportLevel.Eval;
     cluster.subscription.capabilities = [
       {
-        name: 'capability.cluster.subscribed_ocp',
+        name: subscriptionCapabilities.SUBSCRIBED_OCP,
         value: 'true',
         inherited: true,
       },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/UsersHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/UsersHelper.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { AugmentedCluster } from '~/types/types';
 
 import { normalizedProducts } from '../../../../../../common/subscriptionTypes';
@@ -17,7 +18,7 @@ const canAllowAdminHelper = (cluster: AugmentedCluster) => {
 
   const capabilites = cluster.subscription?.capabilities || [];
   const manageClusterAdminCapability = capabilites.find(
-    (capability) => capability.name === 'capability.cluster.manage_cluster_admin',
+    (capability) => capability.name === subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
   );
 
   return !!(manageClusterAdminCapability && manageClusterAdminCapability.value === 'true');

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/UsersSelector.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/UsersSelector.js
@@ -1,5 +1,7 @@
 import get from 'lodash/get';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
+
 import { normalizedProducts } from '../../../../../../common/subscriptionTypes';
 import clusterStates from '../../../../common/clusterStates';
 
@@ -21,7 +23,7 @@ const canAllowAdminSelector = (state) => {
 
   const capabilites = get(state, 'clusters.details.cluster.subscription.capabilities', []);
   const manageClusterAdminCapability = capabilites.find(
-    (capability) => capability.name === 'capability.cluster.manage_cluster_admin',
+    (capability) => capability.name === subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
   );
 
   return !!(manageClusterAdminCapability && manageClusterAdminCapability.value === 'true');

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/__tests__/UsersSelectors.test.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/__tests__/UsersSelectors.test.js
@@ -1,3 +1,5 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
+
 import { normalizedProducts } from '../../../../../../../common/subscriptionTypes';
 import clusterStates from '../../../../../common/clusterStates';
 import canAllowAdminSelector from '../UsersSelector';
@@ -15,9 +17,9 @@ describe('canAllowAdminSelector', () => {
             subscription: {
               plan: { id: normalizedProducts.OSD },
               capabilities: [
-                { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: true },
+                { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: true },
                 {
-                  name: 'capability.cluster.manage_cluster_admin',
+                  name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
                   value: 'false',
                   inherited: false,
                 },
@@ -66,9 +68,9 @@ describe('canAllowAdminSelector', () => {
             subscription: {
               plan: { id: normalizedProducts.RHMI },
               capabilities: [
-                { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: true },
+                { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: true },
                 {
-                  name: 'capability.cluster.manage_cluster_admin',
+                  name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
                   value: 'false',
                   inherited: false,
                 },
@@ -96,9 +98,9 @@ describe('canAllowAdminSelector', () => {
             subscription: {
               plan: { id: normalizedProducts.OSD },
               capabilities: [
-                { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: true },
+                { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: true },
                 {
-                  name: 'capability.cluster.manage_cluster_admin',
+                  name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
                   value: 'true',
                   inherited: false,
                 },
@@ -126,9 +128,9 @@ describe('canAllowAdminSelector', () => {
             subscription: {
               plan: { id: normalizedProducts.OSD },
               capabilities: [
-                { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: true },
+                { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: true },
                 {
-                  name: 'capability.cluster.manage_cluster_admin',
+                  name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
                   value: 'true',
                   inherited: false,
                 },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/MachinePools.fixtures.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/MachinePools.fixtures.js
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { defaultClusterFromSubscription } from '~/components/clusters/common/__tests__/defaultClusterFromSubscription.fixtures';
 import { baseRequestState } from '~/redux/reduxHelpers';
 
@@ -63,12 +64,12 @@ const baseState = {
           console_url: 'https://console-openshift-console.apps.test-liza.uhqs.s1.devshift.org',
           capabilities: [
             {
-              name: 'capability.cluster.subscribed_ocp',
+              name: subscriptionCapabilities.SUBSCRIBED_OCP,
               value: 'true',
               inherited: true,
             },
             {
-              name: 'capability.cluster.manage_cluster_admin',
+              name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
               value: 'true',
               inherited: true,
             },
@@ -425,32 +426,32 @@ const baseState = {
         updated_at: '2021-01-20T11:16:15.568987Z',
         capabilities: [
           {
-            name: 'capability.organization.hibernate_cluster',
+            name: subscriptionCapabilities.HIBERNATE_CLUSTER,
             value: 'true',
             inherited: false,
           },
           {
-            name: 'capability.cluster.manage_cluster_admin',
+            name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
             value: 'true',
             inherited: false,
           },
           {
-            name: 'capability.account.allow_etcd_encryption',
+            name: subscriptionCapabilities.ALLOW_ETCD_ENCRYPTION,
             value: 'true',
             inherited: false,
           },
           {
-            name: 'capability.account.enable_terms_enforcement',
+            name: subscriptionCapabilities.ENABLE_TERMS_ENFORCEMENT,
             value: 'true',
             inherited: false,
           },
           {
-            name: 'capability.account.create_moa_clusters',
+            name: subscriptionCapabilities.CREATE_MOA_CLUSTERS,
             value: 'true',
             inherited: false,
           },
           {
-            name: 'capability.cluster.subscribed_ocp',
+            name: subscriptionCapabilities.SUBSCRIBED_OCP,
             value: 'true',
             inherited: false,
           },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsSelectors.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsSelectors.test.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { OrganizationState } from '~/redux/reducers/userReducer';
 import { baseRequestState } from '~/redux/reduxHelpers';
 import { PromiseReducerState } from '~/redux/stateTypes';
@@ -18,10 +19,14 @@ describe('machinePoolsSelector', () => {
       organization: {
         details: {
           capabilities: [
-            { name: 'capability.account.create_moa_clusters', value: 'true', inherited: false },
-            { name: 'capability.account.allow_etcd_encryption', value: 'false', inherited: false },
-            { name: 'capability.cluster.autoscale_clusters', value: 'false', inherited: false },
-            { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: false },
+            { name: subscriptionCapabilities.CREATE_MOA_CLUSTERS, value: 'true', inherited: false },
+            {
+              name: subscriptionCapabilities.ALLOW_ETCD_ENCRYPTION,
+              value: 'false',
+              inherited: false,
+            },
+            { name: subscriptionCapabilities.AUTOSCALE_CLUSTERS, value: 'false', inherited: false },
+            { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: false },
           ],
         },
       },
@@ -33,10 +38,14 @@ describe('machinePoolsSelector', () => {
       organization: {
         details: {
           capabilities: [
-            { name: 'capability.account.create_moa_clusters', value: 'true', inherited: false },
-            { name: 'capability.account.allow_etcd_encryption', value: 'false', inherited: false },
-            { name: 'capability.cluster.autoscale_clusters', value: 'true', inherited: false },
-            { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: false },
+            { name: subscriptionCapabilities.CREATE_MOA_CLUSTERS, value: 'true', inherited: false },
+            {
+              name: subscriptionCapabilities.ALLOW_ETCD_ENCRYPTION,
+              value: 'false',
+              inherited: false,
+            },
+            { name: subscriptionCapabilities.AUTOSCALE_CLUSTERS, value: 'true', inherited: false },
+            { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: false },
           ],
         },
       },
@@ -85,7 +94,7 @@ describe('machinePoolsSelector', () => {
       const organization = {
         capabilities: [
           {
-            name: 'capability.organization.bypass_pids_limits',
+            name: subscriptionCapabilities.BYPASS_PIDS_LIMITS,
             value: capabilityValue,
             inherited: false,
           },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsSelectors.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsSelectors.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { QuotaParams, QuotaTypes } from '~/components/clusters/common/quotaModel';
 import { OrganizationState } from '~/redux/reducers/userReducer';
 import { PromiseReducerState } from '~/redux/stateTypes';
@@ -69,7 +70,7 @@ const hasMachinePoolsQuotaSelector = <E extends ClusterFromSubscription>(
 const hasOrgLevelAutoscaleCapability = (organization?: Organization) => {
   const capabilities = organization?.capabilities ?? [];
   const autoScaleClusters = capabilities.find(
-    (capability) => capability.name === 'capability.cluster.autoscale_clusters',
+    (capability) => capability.name === subscriptionCapabilities.AUTOSCALE_CLUSTERS,
   );
 
   return !!(autoScaleClusters && autoScaleClusters.value === 'true');
@@ -78,7 +79,7 @@ const hasOrgLevelAutoscaleCapability = (organization?: Organization) => {
 const hasOrgLevelBypassPIDsLimitCapability = (organization?: Organization) =>
   (organization?.capabilities ?? []).some(
     (capability) =>
-      capability.name === 'capability.organization.bypass_pids_limits' &&
+      capability.name === subscriptionCapabilities.BYPASS_PIDS_LIMITS &&
       capability.value === 'true',
   );
 

--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.fixtures.js
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.fixtures.js
@@ -1,3 +1,5 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
+
 const transfers = [
   {
     cluster_uuid: '19a65d3e-0603-406b-9cc8-6fe9541bbe46',
@@ -16,22 +18,22 @@ const transfers = [
       capabilities: [
         {
           inherited: false,
-          name: 'capability.cluster.manage_cluster_admin',
+          name: subscriptionCapabilities.MANAGE_CLUSTER_ADMIN,
           value: 'true',
         },
         {
           inherited: true,
-          name: 'capability.cluster.enable_access_protection',
+          name: subscriptionCapabilities.ENABLE_ACCESS_PROTECTION,
           value: 'true',
         },
         {
           inherited: true,
-          name: 'capability.cluster.subscribed_ocp',
+          name: subscriptionCapabilities.SUBSCRIBED_OCP,
           value: 'true',
         },
         {
           inherited: true,
-          name: 'capability.cluster.autoscale_clusters',
+          name: subscriptionCapabilities.AUTOSCALE_CLUSTERS,
           value: 'true',
         },
       ],

--- a/src/components/clusters/RegisterCluster/__tests__/registerClusterSelectors.test.ts
+++ b/src/components/clusters/RegisterCluster/__tests__/registerClusterSelectors.test.ts
@@ -1,3 +1,5 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
+
 import { hasOrgLevelsubscribeOCPCapability } from '../registerClusterSelectors'; // Replace 'yourModule' with the actual module name
 
 describe('hasOrgLevelsubscribeOCPCapability', () => {
@@ -6,7 +8,7 @@ describe('hasOrgLevelsubscribeOCPCapability', () => {
       userProfile: {
         organization: {
           details: {
-            capabilities: [{ name: 'capability.cluster.subscribed_ocp', value: 'true' }],
+            capabilities: [{ name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true' }],
           },
         },
       },
@@ -24,7 +26,7 @@ describe('hasOrgLevelsubscribeOCPCapability', () => {
         userProfile: {
           organization: {
             details: {
-              capabilities: [{ name: 'capability.cluster.subscribed_ocp', value: 'false' }],
+              capabilities: [{ name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'false' }],
             },
           },
         },

--- a/src/components/clusters/RegisterCluster/registerClusterSelectors.ts
+++ b/src/components/clusters/RegisterCluster/registerClusterSelectors.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { GlobalState } from '~/redux/stateTypes';
 import { Capability } from '~/types/accounts_mgmt.v1';
 
@@ -10,7 +11,7 @@ const hasOrgLevelsubscribeOCPCapability = (state: GlobalState): boolean => {
     [],
   );
   const subscribeOCP = capabilites.find(
-    (capability) => capability.name === 'capability.cluster.subscribed_ocp',
+    (capability) => capability.name === subscriptionCapabilities.SUBSCRIBED_OCP,
   );
 
   return !!(subscribeOCP && subscribeOCP.value === 'true');

--- a/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.test.tsx
+++ b/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as reactRedux from 'react-redux';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { defaultSubscription } from '~/components/clusters/common/__tests__/defaultClusterFromSubscription.fixtures';
 import * as useEditSubscription from '~/queries/common/useEditSubscription';
 import { checkAccessibility, screen, withState } from '~/testUtils';
@@ -152,7 +153,7 @@ describe('<EditSubscriptionSettingsDialog />', () => {
             subscription: {
               ...defaultSubscription,
               id: 'mySubscriptionId',
-              capabilities: [{ name: 'capability.cluster.subscribed_ocp', value: 'true' }],
+              capabilities: [{ name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true' }],
             },
             name: 'myClusterName',
             shouldDisplayClusterName: true,
@@ -196,7 +197,7 @@ describe('<EditSubscriptionSettingsDialog />', () => {
             subscription: {
               ...defaultSubscription,
               support_level: 'Self-Support',
-              capabilities: [{ name: 'capability.cluster.subscribed_ocp', value: 'true' }],
+              capabilities: [{ name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true' }],
               socket_total: 20,
               cpu_total: 10,
               system_units: 'Sockets',
@@ -252,7 +253,7 @@ describe('<EditSubscriptionSettingsDialog />', () => {
             subscription: {
               ...defaultSubscription,
               support_level: 'Self-Support',
-              capabilities: [{ name: 'capability.cluster.subscribed_ocp', value: 'true' }],
+              capabilities: [{ name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true' }],
               socket_total: 20,
               cpu_total: 10,
               system_units: 'Cores/vCPU',

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModalSelectors.js
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModalSelectors.js
@@ -1,11 +1,12 @@
 import get from 'lodash/get';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { useGlobalState } from '~/redux/hooks';
 
 const userCanHibernateClustersSelector = (state) => {
   const capabilities = get(state, 'userProfile.organization.details.capabilities', []);
   const canHibernateCluster = capabilities.find(
-    (capability) => capability.name === 'capability.organization.hibernate_cluster',
+    (capability) => capability.name === subscriptionCapabilities.HIBERNATE_CLUSTER,
   );
   return canHibernateCluster?.value === 'true';
 };

--- a/src/components/clusters/common/Upgrades/UpgradeAcknowledge/__tests__/UpgradeAcknowledgeHelpers.test.ts
+++ b/src/components/clusters/common/Upgrades/UpgradeAcknowledge/__tests__/UpgradeAcknowledgeHelpers.test.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import type { UpgradePolicy } from '~/types/clusters_mgmt.v1';
 import type { AugmentedCluster } from '~/types/types';
 
@@ -25,17 +26,17 @@ const mockGCPCluster = {
     capabilities: [
       {
         inherited: true,
-        name: 'capability.cluster.enable_access_protection',
+        name: subscriptionCapabilities.ENABLE_ACCESS_PROTECTION,
         value: 'true',
       },
       {
         inherited: true,
-        name: 'capability.cluster.subscribed_ocp',
+        name: subscriptionCapabilities.SUBSCRIBED_OCP,
         value: 'true',
       },
       {
         inherited: true,
-        name: 'capability.cluster.autoscale_clusters',
+        name: subscriptionCapabilities.AUTOSCALE_CLUSTERS,
         value: 'true',
       },
     ],

--- a/src/components/clusters/wizards/common/ClusterSettings/Details/versionSelectHelper.test.ts
+++ b/src/components/clusters/wizards/common/ClusterSettings/Details/versionSelectHelper.test.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { Version } from '~/types/clusters_mgmt.v1';
 
 import {
@@ -133,19 +134,19 @@ const stableExpected = {
 
 const stateWithNonStableChannelGroupCapability = {
   capabilities: [
-    { name: 'capability.organization.non_stable_channel_group', value: 'true', inherited: false },
-    { name: 'capability.account.allow_etcd_encryption', value: 'false', inherited: false },
-    { name: 'capability.cluster.autoscale_clusters', value: 'true', inherited: false },
-    { name: 'capability.cluster.subscribed_ocp', value: 'false', inherited: false },
+    { name: subscriptionCapabilities.NON_STABLE_CHANNEL_GROUP, value: 'true', inherited: false },
+    { name: subscriptionCapabilities.ALLOW_ETCD_ENCRYPTION, value: 'false', inherited: false },
+    { name: subscriptionCapabilities.AUTOSCALE_CLUSTERS, value: 'true', inherited: false },
+    { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'false', inherited: false },
   ],
 };
 
 const stateWithoutNonStableChannelGroupCapability = {
   capabilities: [
-    { name: 'capability.organization.non_stable_channel_group', value: 'false', inherited: false },
-    { name: 'capability.account.allow_etcd_encryption', value: 'false', inherited: false },
-    { name: 'capability.cluster.autoscale_clusters', value: 'true', inherited: false },
-    { name: 'capability.cluster.subscribed_ocp', value: 'false', inherited: false },
+    { name: subscriptionCapabilities.NON_STABLE_CHANNEL_GROUP, value: 'false', inherited: false },
+    { name: subscriptionCapabilities.ALLOW_ETCD_ENCRYPTION, value: 'false', inherited: false },
+    { name: subscriptionCapabilities.AUTOSCALE_CLUSTERS, value: 'true', inherited: false },
+    { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'false', inherited: false },
   ],
 };
 

--- a/src/components/clusters/wizards/common/ClusterSettings/Details/versionSelectHelper.ts
+++ b/src/components/clusters/wizards/common/ClusterSettings/Details/versionSelectHelper.ts
@@ -1,5 +1,6 @@
 import semver from 'semver';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { FuzzyEntryType } from '~/components/common/FuzzySelect/types';
 import { Organization } from '~/types/accounts_mgmt.v1';
 import { Version } from '~/types/clusters_mgmt.v1';
@@ -107,7 +108,7 @@ const getVersionsData = (
 const hasUnstableVersionsCapability = (organization?: Organization) =>
   (organization?.capabilities ?? []).some(
     (capability) =>
-      capability.name === 'capability.organization.non_stable_channel_group' &&
+      capability.name === subscriptionCapabilities.NON_STABLE_CHANNEL_GROUP &&
       capability.value === 'true',
   );
 

--- a/src/components/clusters/wizards/rosa/CreateRosaGetStarted/StepCreateAWSAccountRoles/StepCreateAWSAccountRoles.test.tsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaGetStarted/StepCreateAWSAccountRoles/StepCreateAWSAccountRoles.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { CLI_SSO_AUTHORIZATION } from '~/queries/featureGates/featureConstants';
 import accountsService from '~/services/accountsService';
 import { mockRestrictedEnv, mockUseChrome, mockUseFeatureGate, render, screen } from '~/testUtils';
@@ -17,7 +18,7 @@ describe('<StepCreateAWSAccountRoles />', () => {
         organization: {
           capabilities: [
             {
-              name: 'capability.organization.restrict_offline_tokens',
+              name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
               value: 'false',
             },
           ],

--- a/src/components/clusters/wizards/rosa/ReviewClusterScreen/ReviewClusterScreen.test.jsx
+++ b/src/components/clusters/wizards/rosa/ReviewClusterScreen/ReviewClusterScreen.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import useOrganization from '~/components/CLILoginPage/useOrganization';
 import { render, screen, waitFor } from '~/testUtils';
 
@@ -416,7 +417,7 @@ describe('<ReviewClusterScreen />', () => {
           organization: {
             capabilities: [
               {
-                name: 'capability.organization.hcp_allow_external_authentication',
+                name: subscriptionCapabilities.HCP_ALLOW_EXTERNAL_AUTHENTICATION,
                 value: 'true',
                 inherited: false,
               },

--- a/src/components/downloads/DownloadsPage/__tests__/DownloadsPage.test.tsx
+++ b/src/components/downloads/DownloadsPage/__tests__/DownloadsPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import accountsService from '~/services/accountsService';
 import { checkAccessibility, mockRestrictedEnv, render, screen, waitFor } from '~/testUtils';
 
@@ -80,17 +81,17 @@ describe('<DownloadsPage>', () => {
           capabilities: [
             {
               inherited: false,
-              name: 'capability.organization.enable_data_sovereign_regions',
+              name: subscriptionCapabilities.ENABLE_DATA_SOVEREIGN_REGIONS,
               value: 'true',
             },
             {
               inherited: false,
-              name: 'capability.organization.restrict_offline_tokens',
+              name: subscriptionCapabilities.RESTRICT_OFFLINE_TOKENS,
               value: 'true',
             },
             {
               inherited: false,
-              name: 'capability.cluster.subscribed_ocp',
+              name: subscriptionCapabilities.SUBSCRIBED_OCP,
               value: 'true',
             },
           ],

--- a/src/hooks/__tests__/useCanClusterAutoscale.test.ts
+++ b/src/hooks/__tests__/useCanClusterAutoscale.test.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { normalizedProducts } from '~/common/subscriptionTypes';
 import * as reduxHooks from '~/redux/hooks';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
@@ -72,7 +73,7 @@ describe('canAutoScale', () => {
   it('should allow autoscaling when there is a cluster level autosacle capability', () => {
     useGlobalStateMock.mockReturnValue(false);
     const mockCapabilites = [
-      { name: 'capability.cluster.subscribed_ocp', value: 'true', inherited: true },
+      { name: subscriptionCapabilities.SUBSCRIBED_OCP, value: 'true', inherited: true },
       { name: 'capability.cluster.cluster', value: 'true', inherited: false },
     ];
     const result = useCanClusterAutoscale(

--- a/src/hooks/useCanClusterAutoscale.ts
+++ b/src/hooks/useCanClusterAutoscale.ts
@@ -1,3 +1,4 @@
+import { subscriptionCapabilities } from '~/common/subscriptionCapabilities';
 import { normalizedProducts } from '~/common/subscriptionTypes';
 import { hasOrgLevelAutoscaleCapability } from '~/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsSelectors';
 import { useGlobalState } from '~/redux/hooks';
@@ -13,7 +14,7 @@ const useCanClusterAutoscale = (
   clusterLevelCapabilities?: Array<Capability>,
 ) => {
   const hasClusterLevelAutoscaleCapability = !!clusterLevelCapabilities?.find(
-    (capability) => capability.name === 'capability.cluster.autoscale_clusters',
+    (capability) => capability.name === subscriptionCapabilities.AUTOSCALE_CLUSTERS,
   );
 
   const hasAutoScaleCapability = useGlobalState(


### PR DESCRIPTION
# Summary

There were lots of places where capabilities were hardcoded as strings creating confusion. This PR replaces them with constant values which all reside in one place for consistency.

# Jira

[OCMUI-3597](https://issues.redhat.com/browse/OCMUI-3597)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

To be fair not sure how to test it. It is a very simple replacement of string values with constant values.

# Screen Captures

No visualchanges.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
