### PR TITLE
OCMUI-3711: Update ClusterUpdateLink to include cluster readiness check

### DIFF
--- a/src/components/clusters/common/ClusterUpdateLink.jsx
+++ b/src/components/clusters/common/ClusterUpdateLink.jsx
@@ -14,7 +14,7 @@ import links from '../../../common/installLinks.mjs';
 import { openModal } from '../../common/Modal/ModalActions';
 import modals from '../../common/Modal/modals';
 
-import { isHibernating } from './clusterStates';
+import clusterStates, { isHibernating } from './clusterStates';
 
 const ClusterUpdateLink = ({ cluster, hideOSDUpdates }) => {
   const dispatch = useDispatch();
@@ -27,6 +27,7 @@ const ClusterUpdateLink = ({ cluster, hideOSDUpdates }) => {
     clusterVersion &&
     !hideOSDUpdates;
   const isStale = cluster?.subscription?.status === SubscriptionCommonFieldsStatus.Stale;
+  const isClusterReady = cluster.state === clusterStates.ready;
 
   // Show which version the cluster is currently updating to
   if (
@@ -51,7 +52,7 @@ const ClusterUpdateLink = ({ cluster, hideOSDUpdates }) => {
     return null;
   }
 
-  if (cluster.managed) {
+  if (cluster.managed && isClusterReady) {
     return (
       <Button
         className="cluster-inline-link pf-v6-u-mt-0"


### PR DESCRIPTION
Update ClusterUpdateLink to include cluster readiness check  before rendering update link

# Summary

Only show link to update cluster version when the cluster is in ready state.  If not, show message stating update is available and direct user to settings tab.

# Jira

[OCMUI-3711](https://issues.redhat.com/browse/OCMUI-3711)

# How to Test

1. Start installing a new ROSA HCP cluster that is back level on the z stream (so like 4.19.1)
2. While it is installing, check on the Cluster Details -> overview tab under the Version section that there is not a link that opens the upgrade wizard.
3. Once the cluster is done installing and in ready state, there should be an Update link to the Upgrade wizard

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="381" height="303" alt="Screenshot From 2025-08-28 16-47-22" src="https://github.com/user-attachments/assets/ad214a93-18bc-49ad-b4b1-ad34452d45b5" /> | <img width="505" height="444" alt="Screenshot From 2025-08-28 16-52-28" src="https://github.com/user-attachments/assets/52b19583-3324-454d-99f3-be465eb63179" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
