### PR TITLE
OCMUI-3720: Replace informational modal for recurring upgrades with alert

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeSettingsFields.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeSettingsFields.tsx
@@ -4,7 +4,15 @@
 import React from 'react';
 import { Field } from 'formik';
 
-import { Content, ContentVariants, Divider, Grid, GridItem, Title } from '@patternfly/react-core';
+import {
+  Alert,
+  Content,
+  ContentVariants,
+  Divider,
+  Grid,
+  GridItem,
+  Title,
+} from '@patternfly/react-core';
 
 import links from '~/common/installLinks.mjs';
 import PodDistruptionBudgetGraceSelect from '~/components/clusters/common/Upgrades/PodDistruptionBudgetGraceSelect';
@@ -13,6 +21,7 @@ import { useFormState } from '~/components/clusters/wizards/hooks';
 import { FieldId } from '~/components/clusters/wizards/rosa/constants';
 import ExternalLink from '~/components/common/ExternalLink';
 import RadioButtons from '~/components/common/ReduxFormComponents_deprecated/RadioButtons';
+import { UpgradePolicy } from '~/types/clusters_mgmt.v1';
 
 import './UpgradeSettingsFields.scss';
 
@@ -22,6 +31,7 @@ interface UpgradeSettingsFieldsProps {
   showDivider?: boolean;
   isRosa?: boolean;
   initialScheduleValue?: string;
+  scheduledManualUpgrade?: UpgradePolicy;
 }
 
 interface RadioOption {
@@ -37,6 +47,7 @@ function UpgradeSettingsFields({
   showDivider,
   isRosa,
   initialScheduleValue,
+  scheduledManualUpgrade,
 }: UpgradeSettingsFieldsProps) {
   const {
     setFieldValue, // Set value of form field directly
@@ -74,6 +85,19 @@ function UpgradeSettingsFields({
     description: isHypershift ? recurringUpdateHypershift : recurringUpdateMessage,
     extraField: isAutomatic && (
       <Grid>
+        {scheduledManualUpgrade && (
+          <GridItem>
+            <Alert
+              variant="warning"
+              className="automatic-cluster-updates-alert inline-alert"
+              isInline
+              isPlain
+              title="Scheduled manual update will be cancelled"
+            >
+              By choosing recurring updates, any individually scheduled update will be cancelled.
+            </Alert>
+          </GridItem>
+        )}
         <GridItem md={6}>
           <Field
             component={UpgradeScheduleSelection}


### PR DESCRIPTION
# Summary

Replace informational modal for recurring upgrades with alert.  Currently a popup modal opens when the radio button for "Recurring updates" is selected and there is a manual upgrade already set.  This modal basically acts as an acknowledge that said manual update will be removed.  However, clicking the "Yes" button does nothing other than close the modal.  Additionally, the other button just closes the modal and switches the radio button back to the individual option.  

This is a pointless user interaction as it provides no additional information that a standard alert would not provide and more important it does not remove the scheduled upgrade.  Only pressing save removes the upgrade.

Instead, I have now removed the modal popup all together.  I added an inline alert (that matches the an existing alert) that states the individual upgrade will be removed (just as before), but now the user does not have to response to a NOOP modal window. 

# Jira

OCMUI-3720


# How to Test
1. Build a back level ROSA HCP cluster
2. Go to the cluster details page -> settings
3. Schedule a manual update (go through wizard)
4. Once that is scheduled, click on the "Recurring updates" radio button.  
5. The recurring form with day and time will appear.  Above that input will be a new inline alert that states the manual upgrade will be cancelled, along with the original information alert about control planes.

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="766" height="314" alt="Screenshot From 2025-08-26 16-48-50" src="https://github.com/user-attachments/assets/e2598e6f-ee5a-434b-90f0-e92cf4335b45" /> | <img width="1393" height="798" alt="Screenshot From 2025-08-29 14-47-29" src="https://github.com/user-attachments/assets/02ad22bb-a3a0-4432-b1c6-448561d26a19" /> |

# Video of new process

https://github.com/user-attachments/assets/db90fa01-aa5e-42da-9678-dfed7451f304




# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
