### PR TITLE
OCMUI-3739: Make Rosa Architecture Renaming Alert an Inline Alert

### DIFF
--- a/src/components/clusters/wizards/rosa/common/Banners/RosaArchitectureRenamingAlert.tsx
+++ b/src/components/clusters/wizards/rosa/common/Banners/RosaArchitectureRenamingAlert.tsx
@@ -15,6 +15,7 @@ const RosaArchitectureRenamingAlert = ({ className }: { className?: string }) =>
   return allowAlert ? (
     <Alert
       variant="info"
+      isInline
       title="Red Hat OpenShift Service on AWS (ROSA) architectures are being renamed"
       actionLinks={<ExternalLink href={learnMoreLink}>Learn more</ExternalLink>}
       className={className}


### PR DESCRIPTION
# Summary

There is a slight difference in appearance between the ROSA Architecture Renaming Alert component and other alerts we are using on our application. This Alert component looks a little lifted from the background (like it has a box shadow)

In order to align it with other Alert components, the ROSA Architecture Renaming Alert Banner should also be an `isInLine` PF Alert

The purpose of this PR is to add the `isinLine` property to it's implementation.

# Jira

Link to issue: https://issues.redhat.com/browse/OCMUI-3739

# Additional information

# How to Test

_This can also be tested on the mockdata environment_ 😄
You can go to it by adding the `env=mockdata` query parameter to the url, when running the application locally.
There is a ROSA cluster entitled 'hypershift-ready' you can use - [hypershift-ready cluster details page](https://prod.foo.redhat.com:1337/openshift/details/s/2KBhQVMVQx0CEoXuYZUMBQrQG8y#overview) (be sure to click the link after entering the mock env 😇)

See that the background shadow of the alert component is no longer visible on all the location it is presented:
1. 1st step of the ROSA Wizard: https://prod.foo.redhat.com:1337/openshift/create/rosa/wizard
2. ROSA Getting Started page: https://prod.foo.redhat.com:1337/openshift/create/rosa/getstarted
3. ClusterDetails page of any ROSA cluster: https://prod.foo.redhat.com:1337/openshift/details/s/32BnOUvwlrrRnuJZqPRZKvlDQnM#overview

# Screen Captures

## Before

1st step of the ROSA Wizard: 
<img width="1913" height="856" alt="Before: 1st step of the ROSA Wizard" src="https://github.com/user-attachments/assets/b4d8e924-93b7-48f4-9ec3-13bd685707f7" />

ROSA Getting Started page:
![Before: ROSA Getting Started page](https://github.com/user-attachments/assets/979289b3-5a06-463d-9430-22ea80c20797)

ClusterDetails page of a ROSA Cluster:
<img width="1917" height="944" alt="Before: ClusterDetails page of a ROSA Cluster" src="https://github.com/user-attachments/assets/b9139c4d-e9e2-4eba-9fb0-cc27f7363fab" />

## After

1st step of the ROSA Wizard: 
<img width="1916" height="883" alt="After - 1st step of the ROSA Wizard" src="https://github.com/user-attachments/assets/56406405-6dda-49bb-8c07-a014f6904e69" />

ROSA Getting Started page:
<img width="1916" height="883" alt="After - ROSA Getting Started page" src="https://github.com/user-attachments/assets/bbdca200-7e09-4103-a326-99ed8be58ea0" />

ClusterDetails page of a ROSA Cluster:
<img width="1916" height="883" alt="After - ClusterDetails page of a ROSA Cluster" src="https://github.com/user-attachments/assets/eb03469f-74e6-4b03-9266-2460f7a29fd0" />

On the mockdata env:
<img width="1923" height="1014" alt="image" src="https://github.com/user-attachments/assets/e413bd13-43b3-43ac-bd07-9d5779648e88" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
