### PR TITLE
OCMUI-3718 Add coverage to ClusterStatusMonitor

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
@@ -217,9 +217,8 @@ const ClusterStatusMonitor = (props) => {
           if (hasMore && !isExpanded) subnets = subnets.slice(0, 1);
           const columns = [{ title: 'Subnet' }, { title: 'URLs' }];
           const subnetRow = ({ name, egressErrors }) => (
-            <Tbody>
+            <Tbody key={name}>
               <Tr>
-                <Td />
                 <Td modifier="nowrap">{name}</Td>
                 <Td style={{ whiteSpace: 'break-spaces' }}>{egressErrors.join(',   ')}</Td>
               </Tr>
@@ -234,7 +233,6 @@ const ClusterStatusMonitor = (props) => {
               >
                 <Thead>
                   <Tr>
-                    <Th />
                     {columns.map((column) => (
                       <Th key={column.title}>{column.title}</Th>
                     ))}
@@ -261,7 +259,13 @@ const ClusterStatusMonitor = (props) => {
         // show spinner on rerun button
         const runningInflightCheck = wasRunClicked || isValidatorRunning;
         return (
-          <Alert variant="warning" isInline title="User action required" className="pf-v6-u-mt-md">
+          <Alert
+            variant="warning"
+            isInline
+            title="User action required"
+            className="pf-v6-u-mt-md"
+            key="missing-urls-list"
+          >
             <Flex direction={{ default: 'column' }}>
               <FlexItem>{`${reason}`}</FlexItem>
               {inflightTable && <FlexItem>{inflightTable}</FlexItem>}
@@ -336,17 +340,25 @@ const ClusterStatusMonitor = (props) => {
       ) : (
         <strong>unknown</strong>
       );
-      const reason = [];
-      reason.push('To continue cluster installation, contact the VPC owner of the ');
-      reason.push(<strong>{hostProjectId}</strong>);
-      reason.push(' host project, who must grant the ');
-      reason.push(serviceAccounts);
-      reason.push(` service account${serviceAccountsLength > 1 ? 's' : ''} the following roles: `);
-      reason.push(<strong>Compute Network Administrator, </strong>);
-      reason.push(<strong>Compute Security Administrator, </strong>);
-      reason.push(<strong>DNS Administrator.</strong>);
+
+      const reason = (
+        <>
+          To continue cluster installation, contact the VPC owner of the{' '}
+          <strong>{hostProjectId}</strong> host project, who must grant the {serviceAccounts}{' '}
+          service account{serviceAccountsLength > 1 ? 's' : ''} the following roles:{' '}
+          <strong>
+            Compute Network Administrator, Compute Security Administrator, DNS Administrator.
+          </strong>
+        </>
+      );
       return (
-        <Alert variant="warning" isInline title="Permissions needed:" className="pf-v6-u-mt-md">
+        <Alert
+          variant="warning"
+          isInline
+          title="Permissions needed:"
+          className="pf-v6-u-mt-md"
+          key="show-required-GCP-roles"
+        >
           <Flex direction={{ default: 'column' }}>
             <FlexItem>{reason}</FlexItem>
             <FlexItem>
@@ -374,6 +386,7 @@ const ClusterStatusMonitor = (props) => {
             isInline
             title={`${errorCode} An error occured during cluster install or uninstall process.`}
             className="pf-v6-u-mt-md"
+            key="cluster-install-failed"
           >
             <p>
               This cluster cannot be recovered, however you can use the logs and network validation
@@ -401,6 +414,7 @@ const ClusterStatusMonitor = (props) => {
             isInline
             title={`${errorCode} Installation is taking longer than expected`}
             data-testid="alert-long-install"
+            key="alert-long-install"
           >
             <ClusterStatusErrorDisplay clusterStatus={clusterStatus} />
           </Alert>,


### PR DESCRIPTION
# Summary

The unit test coverage of ClusterStatusMonitor was fairly low.  The goal of this PR was to add a unit test that covered the subnet table which is conditionally displayed.

In the process of writing this unit test, it was discovered that there was an empty table column (header and data cell) so it was removed.  This change did not result in any visual change for users on Chrome, Safari, or FireFox.

Lastly the unit tests was logging a error due to invalid/missing key attribute.  Numerous items were given unique keys.  In addition, it was discovered that the way the `showReuiredGCPRoles` text was created (using an array of strings) was causing on of the "key attribute errors".  I changed the way this this was constructed to use a more straightforward approach.  The resulting HTML is equivalent and there is no impact to the user.  

In the end, there is no changes for users.  

# Jira

Fixes [OCMUI-3718](https://issues.redhat.com/browse/OCMUI-3718) 


# How to Test

Getting a cluster into a proper error state is not easy nor straightforward.  In order to test the code, I suggest just putting in fake data into the code itself.

**To test the subnet table**


In the `ClusterStatusMonitor.jsx` file, on line ~175, set the `inflightError` constant to be this:
```
const inflightError = {   details: {
        'subnet-12345': {
          'egress_url_errors-0':
            'egressURL error: https://registry.redhat.io:443 (Proxy CONNECT aborted)',
          'egress_url_errors-1':
            'egressURL error: https://api.openshift.com:443 (Connection timeout)',
        },
        'subnet-67890': {
          'egress_url_errors-3':
            'egressURL error: https://console.redhat.com:443 (DNS resolution failed)',
          'egress_url_errors-4':
            'egressURL error: https://access.redhat.com:443 (Connection refused)',
        },
        documentation_link: 'https://docs.openshift.com/rosa/egress-requirements',
      }}
      
      // const inflightError = inflightChecks?.data?.items?.find(
      //   (check) => check.state === InflightCheckState.failed,
      // );
```
Then verifying with any cluster that has networking validation failures - for example: https://prod.foo.redhat.com:1337/openshift/details/s/329Gdqp9lbicmSrv3YDmSP0y3WI#overview

**To test GCP reason message**
In the `ClusterStatusMonitor.jsx` file, on line ~327, ensure that the if `isOSDGCPWaitingForRolesOnHostProject` always return true, set the if statement to be this:
```
 if (true || isOSDGCPWaitingForRolesOnHostProject(cluster)) {
```
Then verifying with any cluster that has networking validation failures - for example: https://prod.foo.redhat.com:1337/openshift/details/s/329Gdqp9lbicmSrv3YDmSP0y3WI#overview


**Otherwise run `yarn test` :-)**

# Screenshots (no change)
| Before | After |
| ------ | ------ |
| <img width="837" height="415" alt="Screenshot 2025-09-03 at 9 41 19 AM" src="https://github.com/user-attachments/assets/bf5804d7-b225-419e-8355-d0a828387650" />  | <img width="837" height="415" alt="Screenshot 2025-09-03 at 9 40 05 AM" src="https://github.com/user-attachments/assets/16ded4d0-5878-4ff2-b175-60397203cff7" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
