### PR TITLE
OCMUI-3613: fixed aws drawer layout bug

### DIFF
--- a/src/components/clusters/wizards/rosa/AccountsRolesScreen/AssociateAWSAccountDrawer/common/ToggleGroupTabs.tsx
+++ b/src/components/clusters/wizards/rosa/AccountsRolesScreen/AssociateAWSAccountDrawer/common/ToggleGroupTabs.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useState } from 'react';
 
 import {
-  Flex,
-  FlexItem,
+  Stack,
+  StackItem,
   ToggleGroup,
   ToggleGroupItem,
   ToggleGroupItemProps,
@@ -27,8 +27,8 @@ const ToggleGroupTabs = ({ tabs }: ToggleGroupTabsProps) => {
   };
 
   return (
-    <Flex>
-      <FlexItem>
+    <Stack hasGutter>
+      <StackItem>
         <ToggleGroup>
           {tabs.map((tab) => (
             <ToggleGroupItem
@@ -40,9 +40,9 @@ const ToggleGroupTabs = ({ tabs }: ToggleGroupTabsProps) => {
             />
           ))}
         </ToggleGroup>
-      </FlexItem>
-      <FlexItem className="ocm-instruction-block">{activeTab.body}</FlexItem>
-    </Flex>
+      </StackItem>
+      <StackItem className="ocm-instruction-block">{activeTab.body}</StackItem>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
# Summary

In the Wizard on the Accounts and Roles step in the How to associate new AWS account drawer when resizing OCM role and User role steps were getting misaligned. 

# Jira

[OCMUI-3613](https://issues.redhat.com/browse/OCMUI-3613)

# Additional information

On a technical level it was due to usage of Flex. I replaced Flex with Stack to keep items stacked on top of each other regardless of the screen size.

# How to Test

1. On the cluster list click on Create cluster button.
2. Navigate to the Accounts and Roles step.
3. Click on How to associate a new AWS account button and open the drawer.
4. Resize the screen and confirm that all items in the drawer keep stacked on top of each other.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1332" height="1480" alt="image" src="https://github.com/user-attachments/assets/015021ee-09c1-44e0-a0e6-a491260b3905" /> | <img width="880" height="1364" alt="image" src="https://github.com/user-attachments/assets/a644c378-e5e9-441c-b1b5-134dfdec3d46" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
