### PR TITLE
OCMUI-3740 - Typo in HCP machine pool

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/RefreshClusterVPCAlert.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/RefreshClusterVPCAlert.test.tsx
@@ -39,7 +39,7 @@ describe('RefreshClusterVPCAlert', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole('button', {
-          name: /refretch cluster's vpc/i,
+          name: /refetch cluster's vpc/i,
         }),
       ).toBeInTheDocument();
     },
@@ -51,7 +51,7 @@ describe('RefreshClusterVPCAlert', () => {
       <RefreshClusterVPCAlert isLoading={false} refreshVPC={refreshVPCMock} />,
     );
     const button = screen.getByRole('button', {
-      name: /refretch cluster's vpc/i,
+      name: /refetch cluster's vpc/i,
     });
     expect(refreshVPCMock).toHaveBeenCalledTimes(0);
 
@@ -69,7 +69,7 @@ describe('RefreshClusterVPCAlert', () => {
     // Assert
     expect(
       screen.getByRole('button', {
-        name: /loading\.\.\. refretch cluster's vpc/i,
+        name: /loading\.\.\. refetch cluster's vpc/i,
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/common/RefreshClusterVPCAlert.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/common/RefreshClusterVPCAlert.tsx
@@ -27,7 +27,7 @@ const RefreshClusterVPCAlert = ({
       onClick={refreshVPC}
       isLoading={isLoading}
     >
-      Refretch Cluster&apos;s VPC
+      Refetch Cluster&apos;s VPC
     </Button>
   </Alert>
 );

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/SecurityGroups/EditSecurityGroupField.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/SecurityGroups/EditSecurityGroupField.test.tsx
@@ -50,7 +50,7 @@ describe('EditSecurityGroupsField', () => {
     expect(refreshVPCMock).toHaveBeenCalledTimes(0);
     await user.click(
       screen.getByRole('button', {
-        name: /refretch Cluster's VPC/i,
+        name: /refetch Cluster's VPC/i,
       }),
     );
     expect(refreshVPCMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Summary

Simple typo fix change in Refresh VPC Alert from "Refretch" to "Refetch"

# Jira

Fixes [OCMUI-3740](https://issues.redhat.com/browse/OCMUI-3740)



# How to Test

You can test this by navigating to this cluster --> https://prod.foo.redhat.com:1337/openshift/details/s/2oOBXvQlqKzyNdynmMFLNIQ5ib4#machinePools

1. Once your on the cluster details page of the above cluster, go to the machine pools tab
2. Click Add machine pool
3. Check that the button on the alert "Refetch" is spelled correctly 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="825" height="290" alt="ocmui3740_before" src="https://github.com/user-attachments/assets/a402fd8a-512e-4a23-95e2-9d7028d30c69" /> | <img width="826" height="475" alt="ocmui3740_after" src="https://github.com/user-attachments/assets/a0d70f92-8833-4657-bbaa-38caddcb4e11" /> |




# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
