### PR TITLE
OCMUI-3748: bypass fedramp billing

### DIFF
--- a/src/components/clusters/wizards/rosa/AccountsRolesScreen/AccountsRolesScreen.tsx
+++ b/src/components/clusters/wizards/rosa/AccountsRolesScreen/AccountsRolesScreen.tsx
@@ -16,6 +16,7 @@ import ErrorBox from '~/components/common/ErrorBox';
 import useAnalytics from '~/hooks/useAnalytics';
 import { clearMachineTypesByRegion } from '~/redux/actions/machineTypesActions';
 import { GlobalState } from '~/redux/stateTypes';
+import { isRestrictedEnv } from '~/restrictedEnv';
 
 import { FieldId } from '../constants';
 
@@ -77,6 +78,15 @@ function AccountsRolesScreen({
     () => getAWSAccountIDsResponse.pending || getAWSAccountRolesARNsResponse.pending,
     [getAWSAccountIDsResponse.pending, getAWSAccountRolesARNsResponse.pending],
   );
+
+  // TODO: Remove after billing issues resolved in FedRAMP
+  // FedRAMP Billing account bypass
+  React.useEffect(() => {
+    if (isRestrictedEnv()) {
+      setFieldValue(selectedAWSBillingAccountID, '');
+    }
+    // eslint-disable-next-line  react-hooks/exhaustive-deps
+  }, []);
 
   const openDrawerButtonRef = useRef(null);
   const hasAWSAccounts = AWSAccountIDs.length > 0;
@@ -236,7 +246,7 @@ function AccountsRolesScreen({
           </Button>
         </GridItem>
         <GridItem span={7} />
-        {isHypershiftSelected && (
+        {isHypershiftSelected && !isRestrictedEnv() && (
           <AWSBillingAccount
             selectedAWSBillingAccountID={selectedAWSBillingAccountID || ''}
             selectedAWSAccountID={selectedAWSAccountID || ''}


### PR DESCRIPTION
# Summary

Billing is currently not working in FedRAMP HCP. to allow QE to start testing bypass was implemented on the backend and this PR addresses that issue on the UI side.

# Jira

[OCMUI-3748](https://issues.redhat.com/browse/OCMUI-3748)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
