### PR TITLE
OCMUI-3749: Remove chalk package

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-imports": "^2.0.0",
-    "chalk": "^5.0.1",
     "cli-progress": "^3.12.0",
     "concurrently": "^9.0.0",
     "copy-webpack-plugin": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,7 +6166,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.1, chalk@^5.3.0, chalk@~5.3.0:
+chalk@^5.3.0, chalk@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==


### PR DESCRIPTION
# Summary

Remove chalk package from package.json as it is no longer used directly.

# Jira


Fixes [OCMUI-3749](https://issues.redhat.com/browse/OCMUI-3749) 


# How to Test

Ensure things build fine and run in general.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
