### PR TITLE
OCMUI-797: Changed HTTPS Proxy URL validation

### DIFF
--- a/src/components/clusters/wizards/osd/CreateOsdWizardFooter.test.tsx
+++ b/src/components/clusters/wizards/osd/CreateOsdWizardFooter.test.tsx
@@ -66,7 +66,7 @@ describe('<CreateOsdWizardFooter />', () => {
     expect(screen.getByTestId(wizardPrimaryBtnTestId)).not.toHaveAttribute('aria-disabled');
   });
 
-  it("Doesn't proceed to the next step when validation fails", () => {
+  it("Doesn't proceed to the next step when validation fails", async () => {
     mockedUseFormState.mockReturnValue({
       ...useFormStateReturnValue,
       validateForm: jest.fn().mockResolvedValue({ mockError: 'Mock Error' }),
@@ -75,7 +75,7 @@ describe('<CreateOsdWizardFooter />', () => {
     const { user } = render(<CreateOsdWizardFooter {...props} />);
     const nextButton = screen.getByTestId(wizardPrimaryBtnTestId);
 
-    user.click(nextButton);
+    await user.click(nextButton);
     expect(mockOnNext).not.toHaveBeenCalled();
   });
 

--- a/src/components/clusters/wizards/osd/CreateOsdWizardFooter.test.tsx
+++ b/src/components/clusters/wizards/osd/CreateOsdWizardFooter.test.tsx
@@ -29,6 +29,7 @@ const wizardPrimaryBtnTestId = 'wizard-next-button';
 
 describe('<CreateOsdWizardFooter />', () => {
   const mockedUseFormState = useFormState as jest.Mock;
+  const mockOnNext = jest.fn();
 
   const useFormStateReturnValue = {
     isValidating: false,
@@ -39,6 +40,7 @@ describe('<CreateOsdWizardFooter />', () => {
   };
 
   const props = {
+    onNext: mockOnNext,
     onWizardContextChange: jest.fn(),
     isLoadding: false,
   };
@@ -62,5 +64,31 @@ describe('<CreateOsdWizardFooter />', () => {
     });
     render(<CreateOsdWizardFooter {...props} />);
     expect(screen.getByTestId(wizardPrimaryBtnTestId)).not.toHaveAttribute('aria-disabled');
+  });
+
+  it("Doesn't proceed to the next step when validation fails", () => {
+    mockedUseFormState.mockReturnValue({
+      ...useFormStateReturnValue,
+      validateForm: jest.fn().mockResolvedValue({ mockError: 'Mock Error' }),
+    });
+
+    const { user } = render(<CreateOsdWizardFooter {...props} />);
+    const nextButton = screen.getByTestId(wizardPrimaryBtnTestId);
+
+    user.click(nextButton);
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('Proceeds to the next step when validation succeeds', async () => {
+    mockedUseFormState.mockReturnValue({
+      ...useFormStateReturnValue,
+      validateForm: jest.fn().mockResolvedValue({}),
+    });
+
+    const { user } = render(<CreateOsdWizardFooter {...props} />);
+    const nextButton = screen.getByTestId(wizardPrimaryBtnTestId);
+
+    await user.click(nextButton);
+    expect(mockOnNext).toHaveBeenCalled();
   });
 });

--- a/src/components/clusters/wizards/osd/Networking/ClusterProxy.test.tsx
+++ b/src/components/clusters/wizards/osd/Networking/ClusterProxy.test.tsx
@@ -18,20 +18,21 @@ jest.mock('@patternfly/react-core', () => ({
   })),
 }));
 
-const buildTestComponent = (formValues = {}) => (
-  <Formik
-    initialValues={{
-      [FieldId.HttpProxyUrl]: '',
-      [FieldId.HttpsProxyUrl]: '',
-      [FieldId.NoProxyDomains]: '',
-      [FieldId.AdditionalTrustBundle]: '',
-      ...formValues,
-    }}
-    onSubmit={jest.fn()}
-  >
-    <ClusterProxy />
-  </Formik>
-);
+const renderTestComponent = (formValues = {}) =>
+  render(
+    <Formik
+      initialValues={{
+        [FieldId.HttpProxyUrl]: '',
+        [FieldId.HttpsProxyUrl]: '',
+        [FieldId.NoProxyDomains]: '',
+        [FieldId.AdditionalTrustBundle]: '',
+        ...formValues,
+      }}
+      onSubmit={jest.fn()}
+    >
+      <ClusterProxy />
+    </Formik>,
+  );
 
 describe('<ClusterProxy />', () => {
   afterEach(() => {
@@ -39,26 +40,26 @@ describe('<ClusterProxy />', () => {
   });
 
   it('https URL validation fails when entering http URL', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
 
     const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
     await user.type(textBox, 'http://example.com');
     await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
 
     expect(
-      screen.getByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+      screen.getByText('The URL should include the scheme prefix (https://)', { exact: false }),
     ).toBeInTheDocument();
   });
 
   it('https URL validation succeeds when entering https URL', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
 
     const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
     await user.type(textBox, 'https://example.com');
     await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
 
     expect(
-      screen.queryByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+      screen.queryByText('The URL should include the scheme prefix (https://)', { exact: false }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/clusters/wizards/osd/Networking/ClusterProxy.test.tsx
+++ b/src/components/clusters/wizards/osd/Networking/ClusterProxy.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import {
+  HTTP_PROXY_PLACEHOLDER,
+  HTTPS_PROXY_PLACEHOLDER,
+} from '~/components/clusters/common/networkingConstants';
+import { FieldId } from '~/components/clusters/wizards/osd/constants';
+import { render, screen } from '~/testUtils';
+
+import { ClusterProxy } from './ClusterProxy';
+
+jest.mock('@patternfly/react-core', () => ({
+  ...jest.requireActual('@patternfly/react-core'),
+  useWizardContext: jest.fn(() => ({
+    goToStepByName: jest.fn(),
+    activeStep: { name: 'mockStepId' },
+  })),
+}));
+
+const buildTestComponent = (formValues = {}) => (
+  <Formik
+    initialValues={{
+      [FieldId.HttpProxyUrl]: '',
+      [FieldId.HttpsProxyUrl]: '',
+      [FieldId.NoProxyDomains]: '',
+      [FieldId.AdditionalTrustBundle]: '',
+      ...formValues,
+    }}
+    onSubmit={jest.fn()}
+  >
+    <ClusterProxy />
+  </Formik>
+);
+
+describe('<ClusterProxy />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('https URL validation fails when entering http URL', async () => {
+    const { user } = render(buildTestComponent());
+
+    const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
+    await user.type(textBox, 'http://example.com');
+    await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
+
+    expect(
+      screen.getByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it('https URL validation succeeds when entering https URL', async () => {
+    const { user } = render(buildTestComponent());
+
+    const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
+    await user.type(textBox, 'https://example.com');
+    await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
+
+    expect(
+      screen.queryByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/clusters/wizards/osd/Networking/ClusterProxy.tsx
+++ b/src/components/clusters/wizards/osd/Networking/ClusterProxy.tsx
@@ -62,7 +62,7 @@ export const ClusterProxy = () => {
 
   const validateHttpProxyUrl = (value: string) => validateUrl(value, 'http') || validateAtLeastOne;
   const validateHttpsProxyUrl = (value: string) =>
-    validateUrl(value, ['http', 'https']) || validateAtLeastOne;
+    validateUrl(value, 'https') || validateAtLeastOne;
   const validateAdditionalTrustBundle = (value: string) => validateCA(value) || validateAtLeastOne;
 
   React.useEffect(() => {

--- a/src/components/clusters/wizards/rosa/ClusterProxyScreen.jsx
+++ b/src/components/clusters/wizards/rosa/ClusterProxyScreen.jsx
@@ -65,7 +65,7 @@ function ClusterProxyScreen() {
   };
   const noValues = () => noUrlValues && !additionalTrustBundle;
   const validateUrlHttp = (value) => validateUrl(value, 'http');
-  const validateUrlHttps = (value) => validateUrl(value, ['http', 'https']);
+  const validateUrlHttps = (value) => validateUrl(value, 'https');
   const validateAtLeastOne = () => {
     if (!httpProxyUrl && !httpsProxyUrl && !additionalTrustBundle) {
       return 'Configure at least one of the cluster-wide proxy fields.';

--- a/src/components/clusters/wizards/rosa/ClusterProxyScreen.test.jsx
+++ b/src/components/clusters/wizards/rosa/ClusterProxyScreen.test.jsx
@@ -30,20 +30,21 @@ jest.mock('~/components/common/ReduxFormComponents_deprecated/ReduxFileUpload', 
 ));
 
 // Formik wrapper to provide context for useFormState
-const buildTestComponent = (formValues = {}) => (
-  <Formik
-    initialValues={{
-      [FieldId.HttpProxyUrl]: '',
-      [FieldId.HttpsProxyUrl]: '',
-      [FieldId.NoProxyDomains]: '',
-      [FieldId.AdditionalTrustBundle]: '',
-      ...formValues,
-    }}
-    onSubmit={jest.fn()}
-  >
-    <ClusterProxyScreen />
-  </Formik>
-);
+const renderTestComponent = (formValues = {}) =>
+  render(
+    <Formik
+      initialValues={{
+        [FieldId.HttpProxyUrl]: '',
+        [FieldId.HttpsProxyUrl]: '',
+        [FieldId.NoProxyDomains]: '',
+        [FieldId.AdditionalTrustBundle]: '',
+        ...formValues,
+      }}
+      onSubmit={jest.fn()}
+    >
+      <ClusterProxyScreen />
+    </Formik>,
+  );
 
 describe('<ClusterProxyScreen />', () => {
   afterEach(() => {
@@ -51,7 +52,7 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('renders expected labels and help, including documentation link', async () => {
-    render(buildTestComponent());
+    renderTestComponent();
 
     expect(screen.getByText('Cluster-wide proxy')).toBeInTheDocument();
     expect(screen.getByText('Configure at least 1 of the following fields:')).toBeInTheDocument();
@@ -68,14 +69,14 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('disables No Proxy domains when no HTTP/HTTPS URLs are set and shows disabled placeholder', async () => {
-    render(buildTestComponent());
+    renderTestComponent();
     const noProxy = screen.getByLabelText('No Proxy domains');
     expect(noProxy).toBeDisabled();
     expect(noProxy).toHaveAttribute('placeholder', DISABLED_NO_PROXY_PLACEHOLDER);
   });
 
   it('enables No Proxy domains and changes placeholder when HTTP proxy URL is provided', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
     const httpInput = screen.getByLabelText('HTTP proxy URL');
     const noProxy = screen.getByLabelText('No Proxy domains');
 
@@ -86,7 +87,7 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('shows warning prompting to complete at least one field after a field is blurred empty', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
     const httpInput = screen.getByLabelText('HTTP proxy URL');
 
     // Focus then blur without entering a value to set anyTouched
@@ -97,26 +98,26 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('https URL validation fails when entering http URL', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
 
     const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
     await user.type(textBox, 'http://example.com');
     await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
 
     expect(
-      screen.getByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+      screen.getByText('The URL should include the scheme prefix (https://)', { exact: false }),
     ).toBeInTheDocument();
   });
 
   it('https URL validation succeeds when entering https URL', async () => {
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
 
     const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
     await user.type(textBox, 'https://example.com');
     await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
 
     expect(
-      screen.queryByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+      screen.queryByText('The URL should include the scheme prefix (https://)', { exact: false }),
     ).not.toBeInTheDocument();
   });
 
@@ -124,7 +125,7 @@ describe('<ClusterProxyScreen />', () => {
     const goToStepByName = jest.fn();
     useWizardContext.mockReturnValue({ goToStepByName });
 
-    const { user } = render(buildTestComponent());
+    const { user } = renderTestComponent();
     const httpInput = screen.getByLabelText('HTTP proxy URL');
     await user.click(httpInput);
     await user.tab();
@@ -137,9 +138,9 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('hides the warning when Additional trust bundle has content', async () => {
-    const { user } = render(
-      buildTestComponent({ [FieldId.AdditionalTrustBundle]: 'I am a trust bundle' }),
-    );
+    const { user } = renderTestComponent({
+      [FieldId.AdditionalTrustBundle]: 'I am a trust bundle',
+    });
 
     // Touch a field to trigger anyTouched
     const httpInput = screen.getByLabelText('HTTP proxy URL');
@@ -153,7 +154,7 @@ describe('<ClusterProxyScreen />', () => {
   });
 
   it('is accessible', async () => {
-    const { container } = render(buildTestComponent());
+    const { container } = renderTestComponent();
     await checkAccessibility(container);
   });
 });

--- a/src/components/clusters/wizards/rosa/ClusterProxyScreen.test.jsx
+++ b/src/components/clusters/wizards/rosa/ClusterProxyScreen.test.jsx
@@ -6,6 +6,8 @@ import { useWizardContext } from '@patternfly/react-core';
 import links from '~/common/installLinks.mjs';
 import {
   DISABLED_NO_PROXY_PLACEHOLDER,
+  HTTP_PROXY_PLACEHOLDER,
+  HTTPS_PROXY_PLACEHOLDER,
   NO_PROXY_PLACEHOLDER,
 } from '~/components/clusters/common/networkingConstants';
 import { checkAccessibility, render, screen } from '~/testUtils';
@@ -92,6 +94,30 @@ describe('<ClusterProxyScreen />', () => {
     await user.tab();
 
     expect(screen.getByText(/Complete at least 1 of the fields above\./i)).toBeInTheDocument();
+  });
+
+  it('https URL validation fails when entering http URL', async () => {
+    const { user } = render(buildTestComponent());
+
+    const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
+    await user.type(textBox, 'http://example.com');
+    await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
+
+    expect(
+      screen.getByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+    ).toBeInTheDocument();
+  });
+
+  it('https URL validation succeeds when entering https URL', async () => {
+    const { user } = render(buildTestComponent());
+
+    const textBox = screen.getByPlaceholderText(HTTPS_PROXY_PLACEHOLDER);
+    await user.type(textBox, 'https://example.com');
+    await user.click(screen.getByPlaceholderText(HTTP_PROXY_PLACEHOLDER));
+
+    expect(
+      screen.queryByText(/The URL should include the scheme prefix \(https:\/\/\)/i),
+    ).not.toBeInTheDocument();
   });
 
   it('navigates to Networking > Configuration when clicking the alert action link', async () => {

--- a/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.test.tsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.test.tsx
@@ -80,7 +80,7 @@ describe('<CreateRosaWizardFooter />', () => {
     expect(screen.getByTestId(wizardPrimaryBtnTestId)).not.toHaveAttribute('aria-disabled');
   });
 
-  it("Doesn't proceed to the next step when validation fails", () => {
+  it("Doesn't proceed to the next step when validation fails", async () => {
     mockedUseFormState.mockReturnValue({
       ...useFormStateReturnValue,
       validateForm: jest.fn().mockResolvedValue({ mockError: 'Mock Error' }),
@@ -89,7 +89,7 @@ describe('<CreateRosaWizardFooter />', () => {
     const { user } = render(<CreateRosaWizardFooter {...props} />);
     const nextButton = screen.getByTestId(wizardPrimaryBtnTestId);
 
-    user.click(nextButton);
+    await user.click(nextButton);
     expect(mockGoToNextStep).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Summary

In the OSD and ROSA cluster creation page, in the networking section -> cluster-wide-proxy screen, validation is successful when entering an http URL to the https URL input, there is no error message displayed and the user is able to move to the next screen once the next button is clicked.
The error message should only include the scheme prefix (https://) and the user should not be allowed to go to next screen.

# Jira

Fixes [OCMUI-797](https://issues.redhat.com/browse/OCMUI-797)

# Additional information

Fix:
The fix is in each cluster proxy page of OSD and ROSA cluster.
The issue was 'http' being part of the allowed url starts for https field. 

Unit tests:
The are two related issues to this fix - the URL error message and ability to proceed to the next step.
This PR adds tests for both aspects:
1. URL error message test - for both OSD and ROSA cluster proxy pages.
1. Next button test - for both OSD and ROSA wiizards.

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

How to reproduce:
1. Launch OSD/ROSA wizard
2. In Networking -> Configuration, choose 'Configure a cluster-wide proxy'
3. In the CLuster-wide proxy screen, enter http://www.example.com/ for the text field HTTPS proxy URL and click Next.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1087" height="860" alt="Screenshot From 2025-09-10 13-39-57" src="https://github.com/user-attachments/assets/0b8a4dbd-75a5-4f6a-823c-5c0bea9c0276" />| <img width="1087" height="860" alt="Screenshot From 2025-09-10 13-38-20" src="https://github.com/user-attachments/assets/f5c9578f-d5eb-408b-9f83-a22a3ad10d31"/>|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
