### PR TITLE
OCMUI-3683 Modal.tsx refactoring

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/BreakGlassCredentialNewModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/BreakGlassCredentialNewModal.tsx
@@ -71,6 +71,7 @@ export function BreakGlassCredentialNewModal(props: BreakGlassCredentialNewModal
           onClose={handleClose}
           modalSize="small"
           description="Add a break glass credential to access the cluster."
+          hideDefaultFooter
           footer={
             <Stack hasGutter>
               {isError && (

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.jsx
@@ -5,13 +5,13 @@ import { useDispatch } from 'react-redux';
 import { Form, FormGroup, Radio, TextInput } from '@patternfly/react-core';
 
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
 import { refetchGrants } from '~/queries/ClusterDetailsQueries/AccessControlTab/NetworkSelfServiceQueries/useFetchGrants';
 import { useGlobalState } from '~/redux/hooks';
 
 import { validateUserOrGroupARN } from '../../../../../../../common/validators';
 import ErrorBox from '../../../../../../common/ErrorBox';
-import Modal from '../../../../../../common/Modal/Modal';
 import { modalActions } from '../../../../../../common/Modal/ModalActions';
 import PopoverHint from '../../../../../../common/PopoverHint';
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/__tests__/NetworkSelfServiceSection.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/__tests__/NetworkSelfServiceSection.test.jsx
@@ -170,7 +170,7 @@ describe('<NetworkSelfServiceSection />', () => {
     jest.runAllTimers();
     expect(
       await screen.findByRole('dialog', {
-        name: 'Grant AWS infrastructure role Grant AWS infrastructure role',
+        name: 'Grant AWS infrastructure role',
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/OCMRolesSection/OCMRolesDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/OCMRolesSection/OCMRolesDialog.tsx
@@ -16,12 +16,12 @@ import {
 } from '@patternfly/react-core';
 
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
 import { MutationFormattedErrorType } from '~/queries/types';
 import { useGlobalState } from '~/redux/hooks';
 
 import { ocmRoles } from '../../../../../../common/subscriptionTypes';
-import Modal from '../../../../../common/Modal/Modal';
 import { closeModal } from '../../../../../common/Modal/ModalActions';
 import modals from '../../../../../common/Modal/modals';
 import PopoverHint from '../../../../../common/PopoverHint';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/AddUserDialog.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/UsersSection/AddUserDialog.jsx
@@ -5,13 +5,13 @@ import { useDispatch } from 'react-redux';
 import { Form, FormGroup, Radio, TextInput } from '@patternfly/react-core';
 
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import { refetchUsers } from '~/queries/ClusterDetailsQueries/AccessControlTab/UserQueries/useFetchUsers';
 
 import links from '../../../../../../common/installLinks.mjs';
 import { checkUserID } from '../../../../../../common/validators';
 import ErrorBox from '../../../../../common/ErrorBox';
 import ExternalLink from '../../../../../common/ExternalLink';
-import Modal from '../../../../../common/Modal/Modal';
 import { modalActions } from '../../../../../common/Modal/ModalActions';
 
 const AddUserDialog = ({

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessRequest/components/AccessRequestModalForm.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessRequest/components/AccessRequestModalForm.tsx
@@ -119,7 +119,11 @@ const AccessRequestModalForm = () => {
     >
       {(formik) => (
         <Modal
-          title="Access Request Details"
+          title={
+            <>
+              Access Request Details <AccessRequestStateIcon accessRequest={accessRequest} />
+            </>
+          }
           onClose={handleClose}
           primaryText="Save"
           showPrimary={isEditMode}
@@ -135,7 +139,6 @@ const AccessRequestModalForm = () => {
           }
           id="access-request-modal"
           isPending={isLoading}
-          help={<AccessRequestStateIcon accessRequest={accessRequest} />}
           footer={
             !isPostAccessRequestDecisionError && !isCanMakeDecisionError ? null : (
               <>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDeleteModal/AddOnsDeleteModal.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDeleteModal/AddOnsDeleteModal.jsx
@@ -4,12 +4,12 @@ import { useDispatch } from 'react-redux';
 
 import { Form, TextInput } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { refetchClusterAddOns } from '~/queries/ClusterDetailsQueries/AddOnsTab/useFetchClusterAddOns';
 import { getOrganizationAndQuota } from '~/redux/actions/userActions';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErroBox from '../../../../../common/ErrorBox';
-import Modal from '../../../../../common/Modal/Modal';
 import { closeModal } from '../../../../../common/Modal/ModalActions';
 import shouldShowModal from '../../../../../common/Modal/ModalSelectors';
 import { setAddonsDrawer } from '../AddOnsActions';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsParametersModal/AddOnsParametersModal.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsParametersModal/AddOnsParametersModal.jsx
@@ -252,8 +252,7 @@ const AddOnsParametersModal = ({
       {(formik) => (
         <Modal
           title={`Configure ${addOn.name}`}
-          width={810}
-          variant="large"
+          modalSize="medium"
           onClose={() => handleClose(formik)}
           primaryText={isUpdateForm ? 'Update' : 'Install'}
           secondaryText="Cancel"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/DeleteIDPDialog/DeleteIDPDialog.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/DeleteIDPDialog/DeleteIDPDialog.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
+import Modal from '~/components/common/Modal/Modal';
 import { refetchIdentityProvidersWithHTPUsers } from '~/queries/ClusterDetailsQueries/AccessControlTab/UserQueries/useFetchIDPsWithHTPUsers';
 import { useDeleteIdentityProvider } from '~/queries/ClusterDetailsQueries/IDPPage/useDeleteIdentityProvider';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../../common/ErrorBox';
-import Modal from '../../../../common/Modal/Modal';
 import { modalActions } from '../../../../common/Modal/ModalActions';
 import shouldShowModal from '../../../../common/Modal/ModalSelectors';
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
@@ -193,7 +193,7 @@ export const UpdateMachinePoolModal = ({
 
   return (
     <Modal
-      variant="small"
+      modalSize="small"
       title="Update machine pool"
       onClose={() => cleanUp()}
       primaryText="Update machine pool"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/AutoscalerModal/ClusterAutoscalerModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/AutoscalerModal/ClusterAutoscalerModal.tsx
@@ -206,7 +206,7 @@ export const ClusterAutoscalerModal = ({
 
   return (
     <Modal
-      variant="large"
+      modalSize="large"
       isOpen={isOpen}
       title="Edit cluster autoscaling settings"
       data-testid="cluster-autoscaling-dialog"
@@ -217,7 +217,6 @@ export const ClusterAutoscalerModal = ({
       tertiaryText="Cancel"
       onSecondaryClick={handleReset}
       isPrimaryDisabled={hasAutoScalingErrors || primaryButtonProps.isDisabled}
-      showClose
       showTertiary={!isWizard}
       onClose={closeScalerModal}
     >

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/DeleteMachinePoolModal/DeleteMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/DeleteMachinePoolModal/DeleteMachinePoolModal.tsx
@@ -30,6 +30,7 @@ const DeleteMachinePoolModal = () => {
     <Modal
       title="Permanently delete machine pool?"
       primaryText="Delete"
+      primaryVariant="danger"
       onPrimaryClick={handleConfirmDelete}
       secondaryText="Cancel"
       onSecondaryClick={() => dispatch(closeModal())}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterIngressDialog/EditClusterIngressDialog.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterIngressDialog/EditClusterIngressDialog.jsx
@@ -122,7 +122,6 @@ const EditClusterIngressDialog = ({ provider, cluster, refreshCluster, clusterRo
 
         return (
           <Modal
-            width="max(35%, 550px)"
             primaryText="Save"
             secondaryText="Cancel"
             title="Edit cluster ingress"

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterIngressDialog/EditClusterIngressDialog.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterIngressDialog/EditClusterIngressDialog.jsx
@@ -15,6 +15,7 @@ import {
 
 import { isExactMajorMinor } from '~/common/versionHelpers';
 import { CheckboxField } from '~/components/clusters/wizards/form/CheckboxField';
+import Modal from '~/components/common/Modal/Modal';
 import { useEditClusterIngressMutation } from '~/queries/ClusterDetailsQueries/NetworkingTab/useEditClusterIngress';
 import { refetchGetClusterRouters } from '~/queries/ClusterDetailsQueries/NetworkingTab/useGetClusterRouters';
 import { useGlobalState } from '~/redux/hooks';
@@ -24,7 +25,6 @@ import { knownProducts } from '../../../../../../../common/subscriptionTypes';
 import { checkLabelsAdditionalRouter } from '../../../../../../../common/validators';
 import ErrorBox from '../../../../../../common/ErrorBox';
 import ExternalLink from '../../../../../../common/ExternalLink';
-import Modal from '../../../../../../common/Modal/Modal';
 import { modalActions } from '../../../../../../common/Modal/ModalActions';
 import modals from '../../../../../../common/Modal/modals';
 import shouldShowModal from '../../../../../../common/Modal/ModalSelectors';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyForm.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyForm.tsx
@@ -185,7 +185,6 @@ const EditClusterWideProxyForm = ({
       isPrimaryDisabled={isNotModified}
       onSecondaryClick={handleClose}
       isPending={isClusterEditPending}
-      width="max(30%, 600px)"
     >
       {clusterProxyError}
       <Form>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Support/components/AddNotificationContactDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Support/components/AddNotificationContactDialog.tsx
@@ -4,13 +4,13 @@ import { useDispatch } from 'react-redux';
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import shouldShowModal from '~/components/common/Modal/ModalSelectors';
 import { invalidateNotificationContacts } from '~/queries/ClusterDetailsQueries/ClusterSupportTab/useFetchNotificationContacts';
 import { useGlobalState } from '~/redux/hooks';
 import { AugmentedCluster } from '~/types/types';
 
 import { validateRHITUsername } from '../../../../../../common/validators';
-import Modal from '../../../../../common/Modal/Modal';
 import { closeModal } from '../../../../../common/Modal/ModalActions';
 
 type AddNotificationContactDialogProps = {

--- a/src/components/clusters/ClusterTransfer/AutoTransferClusterOwnershipForm.tsx
+++ b/src/components/clusters/ClusterTransfer/AutoTransferClusterOwnershipForm.tsx
@@ -165,7 +165,6 @@ function AutoTransferClusterOwnershipForm(props: AutoTransferClusterOwnershipFor
       aria-labelledby="transfer-in-progress-modal"
       onClose={handleClose}
       modalSize="medium"
-      isSmall={false}
       primaryText="Cancel transfer"
       isPrimaryDisabled={!canCancelTransfer}
       secondaryText="Close"
@@ -218,7 +217,6 @@ function AutoTransferClusterOwnershipForm(props: AutoTransferClusterOwnershipFor
           aria-labelledby="auto-transfer-cluster-ownership-modal"
           onClose={handleClose}
           modalSize="medium"
-          isSmall={false}
           primaryText="Initiate transfer"
           secondaryText="Cancel"
           onSecondaryClick={handleClose}

--- a/src/components/clusters/common/ArchiveClusterDialog/ArchiveClusterDialog.tsx
+++ b/src/components/clusters/common/ArchiveClusterDialog/ArchiveClusterDialog.tsx
@@ -3,11 +3,11 @@ import { useDispatch } from 'react-redux';
 
 import { Form } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { useArchiveCluster } from '~/queries/ClusterActionsQueries/useArchiveCluster';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.tsx
+++ b/src/components/clusters/common/DeleteClusterDialog/DeleteClusterDialog.tsx
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux';
 
 import { Flex, Form, TextInput } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { closeModal } from '~/components/common/Modal/ModalActions';
 import { useDeleteCluster } from '~/queries/ClusterActionsQueries/useDeleteCluster';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import modals from '../../../common/Modal/modals';
 
 type DeleteClusterDialogProps = {

--- a/src/components/clusters/common/DeleteProtectionModal/DeleteProtectionModal.tsx
+++ b/src/components/clusters/common/DeleteProtectionModal/DeleteProtectionModal.tsx
@@ -3,11 +3,11 @@ import { useDispatch } from 'react-redux';
 
 import { Flex } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { useUpdateDeleteProtections } from '~/queries/ClusterDetailsQueries/useUpdateDeleteProtection';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/EditConsoleURLDialog/EditConsoleURLDialog.tsx
+++ b/src/components/clusters/common/EditConsoleURLDialog/EditConsoleURLDialog.tsx
@@ -5,6 +5,7 @@ import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
 import getClusterName from '~/common/getClusterName';
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import modals from '~/components/common/Modal/modals';
 import { useEditConsoleURL } from '~/queries/ClusterActionsQueries/useEditConsoleURL';
 import { useGlobalState } from '~/redux/hooks';
@@ -12,7 +13,6 @@ import { ClusterWithPermissions } from '~/types/types';
 
 import { checkClusterConsoleURL } from '../../../../common/validators';
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 
 type EditConsoleURLDialogProps = {

--- a/src/components/clusters/common/EditDisplayNameDialog/EditDisplayNameDialog.tsx
+++ b/src/components/clusters/common/EditDisplayNameDialog/EditDisplayNameDialog.tsx
@@ -6,6 +6,7 @@ import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
 import getClusterName from '~/common/getClusterName';
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
+import Modal from '~/components/common/Modal/Modal';
 import { useEditClusterName } from '~/queries/ClusterActionsQueries/useEditClusterName';
 import { useGlobalState } from '~/redux/hooks';
 import { Subscription } from '~/types/clusters_mgmt.v1';
@@ -13,7 +14,6 @@ import { ClusterFromSubscription } from '~/types/types';
 
 import { checkClusterDisplayName } from '../../../../common/validators';
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.tsx
+++ b/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.tsx
@@ -74,8 +74,7 @@ const EditSubscriptionSettingsDialog = ({ onClose }: EditSubscriptionSettingsDia
     <Modal
       title="Subscription settings"
       secondaryTitle={shouldDisplayClusterName ? clusterDisplayName : undefined}
-      width={810}
-      variant="large"
+      modalSize="medium"
       onClose={handleCloseModal}
       primaryText="Save"
       secondaryText="Cancel"

--- a/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.tsx
+++ b/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsDialog.tsx
@@ -5,6 +5,7 @@ import { Content, ContentVariants, Form } from '@patternfly/react-core';
 
 import getClusterName from '~/common/getClusterName';
 import ErrorBox from '~/components/common/ErrorBox';
+import Modal from '~/components/common/Modal/Modal';
 import { useEditSubscription } from '~/queries/common/useEditSubscription';
 import { useGlobalState } from '~/redux/hooks';
 import { SubscriptionPatchRequest } from '~/types/accounts_mgmt.v1';
@@ -13,7 +14,6 @@ import {
   hasCapability,
   subscriptionCapabilities,
 } from '../../../../common/subscriptionCapabilities';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
@@ -135,8 +135,8 @@ const HibernateClusterModal = ({ onClose }: HibernateClusterModalProps) => {
   return (
     <Modal
       aria-label="hibernate-cluster-modal"
-      header={<HibernateClusterModalTitle title="Hibernate cluster" />}
-      titleIconVariant="danger"
+      title={<HibernateClusterModalTitle title="Hibernate cluster" />}
+      titleIconVariant="info"
       secondaryTitle={shouldDisplayClusterName ? clusterName : undefined}
       primaryText={isHibernateEnabled ? 'Hibernate cluster' : 'Close'}
       onPrimaryClick={onPrimaryClick}

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
@@ -5,13 +5,13 @@ import { Location } from 'react-router-dom';
 import { Form } from '@patternfly/react-core';
 
 import { NavigateFunction, ocmBaseName } from '~/common/routing';
+import Modal from '~/components/common/Modal/Modal';
 import { closeModal } from '~/components/common/Modal/ModalActions';
 import { useHibernateCluster } from '~/queries/ClusterActionsQueries/useHibernateCluster';
 import { useGetSchedules } from '~/queries/ClusterDetailsQueries/ClusterSettingsTab/useGetSchedules';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import modals from '../../../common/Modal/modals';
 import { isHypershiftCluster } from '../clusterStates';
 

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModalTitle.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModalTitle.tsx
@@ -1,24 +1,11 @@
 import React from 'react';
 
-import { Flex, FlexItem, Icon, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
-
 import TechnologyPreview from '~/components/common/TechnologyPreview';
 
 const HibernateClusterModalTitle = ({ title }: { title: string }) => (
-  <Flex alignItems={{ default: 'alignItemsCenter' }}>
-    <FlexItem>
-      <Icon size="md">
-        <InfoCircleIcon className="info" />
-      </Icon>
-    </FlexItem>
-    <FlexItem>
-      <Title headingLevel="h2">{title}</Title>
-    </FlexItem>
-    <FlexItem>
-      <TechnologyPreview className="pf-v6-u-ml-0" />
-    </FlexItem>
-  </Flex>
+  <>
+    {title} <TechnologyPreview className="pf-v6-u-ml-0" />
+  </>
 );
 
 export default HibernateClusterModalTitle;

--- a/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
+++ b/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
@@ -48,7 +48,7 @@ const ResumeClusterModal = ({ onClose }: ResumeClusterModalProps) => {
   return (
     <Modal
       data-testid="resume-cluster-modal"
-      header={<HibernateClusterModalTitle title="Resume from hibernation" />}
+      title={<HibernateClusterModalTitle title="Resume from hibernation" />}
       secondaryTitle={shouldDisplayClusterName ? clusterName : undefined}
       onClose={closeResumeModal}
       primaryText="Resume cluster"
@@ -57,6 +57,7 @@ const ResumeClusterModal = ({ onClose }: ResumeClusterModalProps) => {
       isPending={resumeClusterIsPending}
       onSecondaryClick={closeResumeModal}
       aria-label="Resume from hibernation"
+      titleIconVariant="info"
     >
       <Form onSubmit={() => resumeCluster({ clusterID, region })}>
         {resumeClusterIsError ? (

--- a/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
+++ b/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
@@ -3,12 +3,12 @@ import { useDispatch } from 'react-redux';
 
 import { Form } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { closeModal } from '~/components/common/Modal/ModalActions';
 import { useResumeCluster } from '~/queries/ClusterActionsQueries/useResumeCluster';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import modals from '../../../common/Modal/modals';
 import HibernateClusterContent from '../HibernateClusterModal/HibernateClusterContent';
 import HibernateClusterModalTitle from '../HibernateClusterModal/HibernateClusterModalTitle';

--- a/src/components/clusters/common/ScaleClusterDialog/ScaleClusterDialog.tsx
+++ b/src/components/clusters/common/ScaleClusterDialog/ScaleClusterDialog.tsx
@@ -4,13 +4,13 @@ import get from 'lodash/get';
 import { useDispatch } from 'react-redux';
 
 import getClusterName from '~/common/getClusterName';
+import Modal from '~/components/common/Modal/Modal';
 import { useEditCluster } from '~/queries/ClusterDetailsQueries/useEditCluster';
 import { refreshQueries } from '~/queries/refreshEntireCache';
 import { useGlobalState } from '~/redux/hooks';
 import { Cluster } from '~/types/clusters_mgmt.v1';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/ScaleClusterDialog/ScaleClusterDialog.tsx
+++ b/src/components/clusters/common/ScaleClusterDialog/ScaleClusterDialog.tsx
@@ -122,7 +122,7 @@ const ScaleClusterDialog = ({ handleSubmit, initialValues, pristine }: ScaleClus
           onSecondaryClick={cancelEdit}
           isPrimaryDisabled={pending || !dirty}
           isPending={pending}
-          isSmall
+          modalSize="small"
         >
           <>
             {error}

--- a/src/components/clusters/common/TransferClusterOwnershipDialog/TransferClusterOwnershipDialog.tsx
+++ b/src/components/clusters/common/TransferClusterOwnershipDialog/TransferClusterOwnershipDialog.tsx
@@ -6,6 +6,7 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 
 import getClusterName from '~/common/getClusterName';
 import { ocmBaseName } from '~/common/routing';
+import Modal from '~/components/common/Modal/Modal';
 import { useToggleSubscriptionReleased } from '~/queries/ClusterActionsQueries/useToggleSubscriptionReleased';
 import { useGlobalState } from '~/redux/hooks';
 import { Subscription, SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
@@ -13,7 +14,6 @@ import { ClusterFromSubscription, ErrorState } from '~/types/types';
 
 import ErrorBox from '../../../common/ErrorBox';
 import ExternalLink from '../../../common/ExternalLink';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/TransferClusterOwnershipDialog/TransferClusterOwnershipDialog.tsx
+++ b/src/components/clusters/common/TransferClusterOwnershipDialog/TransferClusterOwnershipDialog.tsx
@@ -96,8 +96,7 @@ const TransferClusterOwnershipDialog = ({ onClose }: TransferClusterOwnershipDia
     <Modal
       title="Transfer cluster ownership"
       secondaryTitle={shouldDisplayClusterName ? clusterDisplayName : undefined}
-      width={600}
-      variant="large"
+      modalSize="small"
       onClose={handleClose}
       primaryText="Initiate transfer"
       secondaryText="Cancel"

--- a/src/components/clusters/common/UnarchiveClusterDialog/UnarchiveClusterDialog.tsx
+++ b/src/components/clusters/common/UnarchiveClusterDialog/UnarchiveClusterDialog.tsx
@@ -3,11 +3,11 @@ import { useDispatch } from 'react-redux';
 
 import { Form } from '@patternfly/react-core';
 
+import Modal from '~/components/common/Modal/Modal';
 import { useUnArchiveCluster } from '~/queries/ClusterActionsQueries/useUnArchiveCluster';
 import { useGlobalState } from '~/redux/hooks';
 
 import ErrorBox from '../../../common/ErrorBox';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 

--- a/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.jsx
+++ b/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.jsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { Alert, Button, Form } from '@patternfly/react-core';
 
 import { Link } from '~/common/routing';
+import Modal from '~/components/common/Modal/Modal';
 import { useFetchMachineTypes } from '~/queries/ClusterDetailsQueries/MachinePoolTab/MachineTypes/useFetchMachineTypes';
 import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
@@ -22,7 +23,6 @@ import { getOrganizationAndQuota } from '../../../../redux/actions/userActions';
 import MechTraining from '../../../../styles/images/RH_BRAND_7764_01_MECH_Training.svg';
 import ErrorBox from '../../../common/ErrorBox';
 import ExternalLink from '../../../common/ExternalLink';
-import Modal from '../../../common/Modal/Modal';
 import { closeModal } from '../../../common/Modal/ModalActions';
 import modals from '../../../common/Modal/modals';
 import { isHypershiftCluster } from '../clusterStates';

--- a/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
+++ b/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
@@ -75,6 +75,7 @@ const CancelUpgradeModal: React.FC<CancelUpgradeModalProps> = ({ isHypershift })
         title="Cancel update"
         onClose={close}
         primaryText="Cancel this update"
+        primaryVariant="danger"
         secondaryText="Close"
         onPrimaryClick={deleteScheduleFunc}
         isPending={isDeleteSchedulePending}

--- a/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
+++ b/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import { Form } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
+import Modal from '~/components/common/Modal/Modal';
 import { useDeleteSchedule } from '~/queries/ClusterDetailsQueries/ClusterSettingsTab/useDeleteSchedule';
 import { refetchSchedules } from '~/queries/ClusterDetailsQueries/ClusterSettingsTab/useGetSchedules';
 import { invalidateClusterDetailsQueries } from '~/queries/ClusterDetailsQueries/useFetchClusterDetails';
@@ -11,7 +12,6 @@ import { useGlobalState } from '~/redux/hooks/useGlobalState';
 import type { UpgradePolicyWithState } from '~/types/types';
 
 import ErrorBox from '../../../../common/ErrorBox';
-import Modal from '../../../../common/Modal/Modal';
 import { closeModal } from '../../../../common/Modal/ModalActions';
 import shouldShowModal from '../../../../common/Modal/ModalSelectors';
 

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/ClusterAutoScaleSettingsDialog.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/ClusterAutoScaleSettingsDialog.tsx
@@ -152,7 +152,7 @@ const ClusterAutoScaleSettingsDialog = ({
 
   return (
     <Modal
-      variant="large"
+      modalSize="large"
       isOpen={isOpen}
       title="Edit cluster autoscaling settings"
       data-testid="cluster-autoscaling-dialog"
@@ -161,7 +161,6 @@ const ClusterAutoScaleSettingsDialog = ({
       onPrimaryClick={handleSave}
       onSecondaryClick={handleReset}
       isPrimaryDisabled={hasAutoScalingErrors}
-      showClose={false}
     >
       <>
         <Content component="p">

--- a/src/components/clusters/wizards/osd/CreateClusterErrorModal/CreateClusterErrorModal.test.tsx
+++ b/src/components/clusters/wizards/osd/CreateClusterErrorModal/CreateClusterErrorModal.test.tsx
@@ -28,7 +28,7 @@ describe('<CreateClusterErrorModal />', () => {
     const { container } = render(<CreateClusterErrorModal onRetry={jest.fn()} />);
 
     // Assert
-    expect(screen.getByRole('heading', { name: 'Error creating cluster' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Error creating cluster' })).toBeInTheDocument();
     await checkAccessibility(container);
   });
 
@@ -44,7 +44,7 @@ describe('<CreateClusterErrorModal />', () => {
     const { container } = render(<CreateClusterErrorModal onRetry={jest.fn()} />);
 
     // Assert
-    expect(screen.getByRole('heading', { name: 'Missing prerequisite' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Missing prerequisite' })).toBeInTheDocument();
     await checkAccessibility(container);
   });
 

--- a/src/components/clusters/wizards/osd/CreateClusterErrorModal/MissingPrereqErrorModal.tsx
+++ b/src/components/clusters/wizards/osd/CreateClusterErrorModal/MissingPrereqErrorModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Button, Icon, Title, useWizardContext } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import { useWizardContext } from '@patternfly/react-core';
 
 import Modal from '~/components/common/Modal/Modal';
 import { closeModal } from '~/components/common/Modal/ModalActions';
@@ -35,29 +34,17 @@ const MissingPrereqErrorModal = ({
 
   return (
     <Modal
-      header={
-        <Title headingLevel="h2" size="2xl">
-          <Icon className="pf-v6-u-mr-sm" status="danger">
-            <ExclamationCircleIcon />
-          </Icon>
-          {title}
-        </Title>
-      }
+      title={title}
+      titleIconVariant="danger"
       modalSize="medium"
       aria-label={title}
-      onPrimaryClick={close}
-      onClose={close}
-      actions={[
-        <Button key="retry" variant="primary" onClick={onRetry} type="submit">
-          Retry creating cluster
-        </Button>,
-        <Button key="prereq-guide" variant="secondary" onClick={goToClusterProviderStep}>
-          Go back to prerequisites guide
-        </Button>,
-        <Button key="secondary" variant="secondary" onClick={close}>
-          Cancel
-        </Button>,
-      ]}
+      primaryText="Retry creating cluster"
+      onPrimaryClick={onRetry}
+      secondaryText="Go back to prerequisites guide"
+      onSecondaryClick={goToClusterProviderStep}
+      showTertiary
+      tertiaryText="Cancel"
+      onTertiaryClick={close}
     >
       <p>
         {/* eslint-disable-next-line max-len */}

--- a/src/components/clusters/wizards/rosa/CreateClusterErrorModal/CreateClusterErrorModal.test.tsx
+++ b/src/components/clusters/wizards/rosa/CreateClusterErrorModal/CreateClusterErrorModal.test.tsx
@@ -28,7 +28,7 @@ describe('<CreateClusterErrorModal />', () => {
     const { container } = render(<CreateClusterErrorModal />);
 
     // Assert
-    expect(screen.getByRole('heading', { name: 'Error creating cluster' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Error creating cluster' })).toBeInTheDocument();
     await checkAccessibility(container);
   });
 

--- a/src/components/common/ErrorModal/ErrorModal.tsx
+++ b/src/components/common/ErrorModal/ErrorModal.tsx
@@ -1,9 +1,8 @@
 import React, { ComponentProps } from 'react';
 
 import ErrorDetailsDisplay from '~/components/common/ErrorDetailsDisplay';
+import Modal from '~/components/common/Modal/Modal';
 import { ErrorState } from '~/types/types';
-
-import Modal from '../Modal/Modal';
 
 export type ErrorModalProps = {
   title: string;

--- a/src/components/common/ErrorModal/ErrorModal.tsx
+++ b/src/components/common/ErrorModal/ErrorModal.tsx
@@ -1,8 +1,5 @@
 import React, { ComponentProps } from 'react';
 
-import { Icon, Title } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-
 import ErrorDetailsDisplay from '~/components/common/ErrorDetailsDisplay';
 import { ErrorState } from '~/types/types';
 
@@ -29,18 +26,10 @@ const ErrorModal = ({
 
   return (
     <Modal
-      header={
-        <Title headingLevel="h2" size="2xl">
-          <Icon status="danger">
-            <ExclamationCircleIcon />
-          </Icon>
-          {title}
-        </Title>
-      }
+      title={title}
+      titleIconVariant="danger"
       primaryText="Close"
       onPrimaryClick={close}
-      onClose={close}
-      showClose={false}
       showSecondary={false}
       aria-label={title}
     >

--- a/src/components/common/Modal/Modal.scss
+++ b/src/components/common/Modal/Modal.scss
@@ -1,11 +1,15 @@
-.modal-secondary-title {
-  .pf-v6-l-split__item {
+.custom-modal {
+  .custom-modal__secondary-title {
     margin-top: var(--pf-t--global--spacer--xs);
     font-size: var(--pf-t--global--font--size--md);
-    &:first-child {
+    .custom-modal__secondary-title__label {
       color: var(--pf-t--global--text--color--subtle);
       font-weight: var(--pf-t--global--font--weight--heading--bold);
       margin-right: var(--pf-t--global--spacer--sm);
     }
   }
+
+  .pf-v6-c-modal-box__title-text {
+    line-height: calc(var(--pf-t--global--font--line-height--heading) * 1.3rem);
+}
 }

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,26 +1,52 @@
 import React from 'react';
 import { Location, useLocation } from 'react-router-dom';
 
-import { Button, Spinner, Split, SplitItem, Stack, StackItem, Title } from '@patternfly/react-core';
-import { Modal as PfModal, ModalProps, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Modal as PfModal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalHeaderProps,
+  ModalProps,
+  ModalVariant,
+  Spinner,
+} from '@patternfly/react-core';
 
 import { NavigateFunction, useNavigate } from '~/common/routing';
 
 import './Modal.scss';
 
-type Props = Omit<
-  ModalProps,
-  // exclude props which are supplied
-  'ref' | 'aria-label'
-> & {
+type ModalDescriptionProps = {
+  description?: string | React.ReactNode;
   secondaryTitle?: string;
+};
+
+const ModalDescription = ({ description, secondaryTitle }: ModalDescriptionProps) => {
+  if (description) {
+    return description;
+  }
+  if (secondaryTitle) {
+    return (
+      <div className="custom-modal__secondary-title">
+        <span className="custom-modal__secondary-title__label">Cluster</span> {secondaryTitle}
+      </div>
+    );
+  }
+  return undefined;
+};
+
+type DefaultModalFooterProps = {
   showPrimary?: boolean;
+  primaryLink?: string;
+  primaryVariant?: React.ComponentProps<typeof Button>['variant'];
+  onPrimaryClick?: () => void;
+  isPrimaryDisabled?: boolean;
   primaryText?: string;
   showSecondary?: boolean;
+  secondaryLink?: string;
   secondaryText?: string;
-  showTertiary?: boolean;
-  tertiaryText?: string;
-  onPrimaryClick?: () => void;
+  isSecondaryDisabled?: boolean;
   onSecondaryClick?: ({
     location,
     navigate,
@@ -28,16 +54,117 @@ type Props = Omit<
     location: Location;
     navigate: NavigateFunction;
   }) => void;
+  showTertiary?: boolean;
+  tertiaryText?: string;
   onTertiaryClick?: () => void;
-  isSmall?: boolean;
-  modalSize?: ModalProps['variant'];
-  isPrimaryDisabled?: boolean;
-  isSecondaryDisabled?: boolean;
-  isPending?: boolean;
-  primaryVariant?: React.ComponentProps<typeof Button>['variant'];
-  primaryLink?: string;
-  secondaryLink?: string;
 };
+
+const DefaultModalFooter = ({
+  showPrimary,
+  primaryLink,
+  primaryVariant,
+  onPrimaryClick,
+  isPrimaryDisabled,
+  primaryText,
+  showSecondary,
+  secondaryLink,
+  secondaryText,
+  isSecondaryDisabled,
+  onSecondaryClick,
+  showTertiary,
+  tertiaryText,
+  onTertiaryClick,
+}: DefaultModalFooterProps) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      {showPrimary && !primaryLink && (
+        <Button
+          key="confirm"
+          variant={primaryVariant}
+          onClick={onPrimaryClick}
+          type="submit"
+          isDisabled={isPrimaryDisabled}
+          data-testid="btn-primary"
+        >
+          {primaryText}
+        </Button>
+      )}
+      {showPrimary && primaryLink && (
+        <Button
+          key="confirm"
+          variant={primaryVariant}
+          component="a"
+          target="_blank"
+          href={primaryLink}
+          isDisabled={isPrimaryDisabled}
+          data-testid="btn-primary"
+        >
+          {primaryText}
+        </Button>
+      )}
+      {showSecondary && !secondaryLink && (
+        <Button
+          key="secondary"
+          variant="secondary"
+          onClick={
+            onSecondaryClick
+              ? () =>
+                  onSecondaryClick({
+                    location,
+                    navigate,
+                  })
+              : undefined
+          }
+          isDisabled={isSecondaryDisabled}
+          data-testid="btn-secondary"
+        >
+          {secondaryText}
+        </Button>
+      )}
+      {showSecondary && secondaryLink && (
+        <Button
+          key="secondary"
+          variant="secondary"
+          component="a"
+          target="_blank"
+          href={secondaryLink}
+          isDisabled={isSecondaryDisabled}
+          data-testid="btn-secondary"
+        >
+          {secondaryText}
+        </Button>
+      )}
+      {showTertiary && (
+        <Button
+          key="tertiary"
+          variant="secondary"
+          onClick={onTertiaryClick}
+          data-testid="btn-tertiary"
+        >
+          {tertiaryText}
+        </Button>
+      )}
+    </>
+  );
+};
+
+type Props = DefaultModalFooterProps &
+  ModalDescriptionProps & {
+    title: string | React.ReactNode;
+    onClose?: () => void;
+    modalSize?: ModalProps['variant'];
+    isPending?: boolean;
+    children: React.ReactNode;
+    id?: string;
+    footer?: React.ReactNode;
+    'data-testid'?: string;
+    isOpen?: boolean;
+    titleIconVariant?: ModalHeaderProps['titleIconVariant'];
+    className?: string;
+    hideDefaultFooter?: boolean;
+  };
 
 const Modal = ({
   title = '',
@@ -52,8 +179,7 @@ const Modal = ({
   onPrimaryClick,
   onSecondaryClick,
   onTertiaryClick,
-  isSmall = true,
-  modalSize = ModalVariant.default,
+  modalSize = ModalVariant.small,
   isPrimaryDisabled,
   isSecondaryDisabled,
   isPending,
@@ -61,111 +187,30 @@ const Modal = ({
   primaryVariant = 'primary',
   primaryLink,
   secondaryLink,
-  ...extraProps
-}: Props) => {
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const header = secondaryTitle ? (
-    <Stack>
-      <StackItem>
-        <Title headingLevel="h1">{title}</Title>
-      </StackItem>
-      <StackItem className="modal-secondary-title">
-        <Split>
-          <SplitItem>Cluster</SplitItem>
-          <SplitItem>{secondaryTitle}</SplitItem>
-        </Split>
-      </StackItem>
-    </Stack>
-  ) : undefined;
-
-  return (
-    <PfModal
-      // For a medium size modal use variant="large".
-      // For a full screen modal use isSmall=false.
-      className={isPending ? 'openshift pending-modal' : 'openshift'}
-      aria-label={typeof title === 'string' ? title : ''}
-      variant={isSmall ? ModalVariant.small : modalSize}
+  id,
+  description,
+  footer,
+  'data-testid': dataTestid,
+  isOpen = true,
+  titleIconVariant,
+  className,
+  hideDefaultFooter,
+}: Props) => (
+  <PfModal
+    id={id}
+    className={`${className || ''} openshift custom-modal ${isPending ? 'pending-modal' : ''}`}
+    aria-label={typeof title === 'string' ? title : ''}
+    variant={modalSize}
+    isOpen={isOpen}
+    onClose={onClose}
+    data-testid={dataTestid}
+  >
+    <ModalHeader
       title={title}
-      header={header}
-      isOpen
-      onClose={onClose}
-      actions={
-        isPending
-          ? []
-          : [
-              showPrimary && !primaryLink && (
-                <Button
-                  key="confirm"
-                  variant={primaryVariant}
-                  onClick={onPrimaryClick}
-                  type="submit"
-                  isDisabled={isPrimaryDisabled}
-                  data-testid="btn-primary"
-                >
-                  {primaryText}
-                </Button>
-              ),
-              showPrimary && primaryLink && (
-                <Button
-                  key="confirm"
-                  variant={primaryVariant}
-                  component="a"
-                  target="_blank"
-                  href={primaryLink}
-                  isDisabled={isPrimaryDisabled}
-                  data-testid="btn-primary"
-                >
-                  {primaryText}
-                </Button>
-              ),
-              showSecondary && !secondaryLink && (
-                <Button
-                  key="secondary"
-                  variant="secondary"
-                  onClick={
-                    onSecondaryClick
-                      ? () =>
-                          onSecondaryClick({
-                            location,
-                            navigate,
-                          })
-                      : undefined
-                  }
-                  isDisabled={isSecondaryDisabled}
-                  data-testid="btn-secondary"
-                >
-                  {secondaryText}
-                </Button>
-              ),
-              showSecondary && secondaryLink && (
-                <Button
-                  key="secondary"
-                  variant="secondary"
-                  component="a"
-                  target="_blank"
-                  href={secondaryLink}
-                  isDisabled={isSecondaryDisabled}
-                  data-testid="btn-secondary"
-                >
-                  {secondaryText}
-                </Button>
-              ),
-              showTertiary && (
-                <Button
-                  key="tertiary"
-                  variant="secondary"
-                  onClick={onTertiaryClick}
-                  data-testid="btn-tertiary"
-                >
-                  {tertiaryText}
-                </Button>
-              ),
-            ]
-      }
-      {...extraProps}
-    >
+      description={ModalDescription({ description, secondaryTitle })}
+      titleIconVariant={titleIconVariant}
+    />
+    <ModalBody>
       {isPending ? (
         <div className="pf-v6-u-text-align-center">
           <Spinner size="lg" aria-label="Loading..." />
@@ -173,8 +218,29 @@ const Modal = ({
       ) : (
         children
       )}
-    </PfModal>
-  );
-};
+    </ModalBody>
+    <ModalFooter>
+      {footer || null}
+      {hideDefaultFooter
+        ? null
+        : DefaultModalFooter({
+            showPrimary,
+            primaryLink,
+            primaryVariant,
+            onPrimaryClick,
+            isPrimaryDisabled,
+            primaryText,
+            showSecondary,
+            secondaryLink,
+            secondaryText,
+            isSecondaryDisabled,
+            onSecondaryClick,
+            showTertiary,
+            tertiaryText,
+            onTertiaryClick,
+          })}
+    </ModalFooter>
+  </PfModal>
+);
 
 export default Modal;

--- a/src/components/common/TermsGuard/TermsGuard.tsx
+++ b/src/components/common/TermsGuard/TermsGuard.tsx
@@ -11,11 +11,11 @@ import {
 } from '@patternfly/react-core';
 
 import { useNavigate } from '~/common/routing';
+import Modal from '~/components/common/Modal/Modal';
 import type { PromiseReducerState } from '~/redux/stateTypes';
 import type { TermsReviewResponse } from '~/types/accounts_mgmt.v1';
 
 import getTermsAppLink from '../../../common/getTermsAppLink';
-import Modal from '../Modal/Modal';
 import Unavailable from '../Unavailable';
 
 import { ViewTermsButton } from './ViewTermsButton';

--- a/src/components/common/TermsGuard/TermsGuard.tsx
+++ b/src/components/common/TermsGuard/TermsGuard.tsx
@@ -102,12 +102,6 @@ const TermsGuard = ({ selfTermsReview, selfTermsReviewResult, children, gobackPa
     </Content>
   );
   const tncAppURL = getTncAppURL(selfTermsReviewResult.redirect_url);
-  const actions = [
-    <ViewTermsButton href={tncAppURL} key="view-terms-and-conditions" />,
-    <Button variant="secondary" key="cancel-terms-and-conditions" onClick={handleCancel}>
-      Cancel
-    </Button>,
-  ];
 
   return (
     <>
@@ -115,7 +109,15 @@ const TermsGuard = ({ selfTermsReview, selfTermsReviewResult, children, gobackPa
         title={dialogTitle}
         className="terms-and-conditions-guard-modal"
         onClose={handleCancel}
-        actions={actions}
+        hideDefaultFooter
+        footer={
+          <>
+            <ViewTermsButton href={tncAppURL} key="view-terms-and-conditions" />
+            <Button variant="secondary" key="cancel-terms-and-conditions" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </>
+        }
       >
         {dialogText}
       </Modal>


### PR DESCRIPTION
# Summary
 
The purpose of this PR is to refactor Modal.tsx to use the current version of the PF modal component.  Because there are changes to the the PF modal props, some of the props into Modal.tsx needed to change.

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3683](https://issues.redhat.com/browse/OCMUI-3683) 

# Additional information

While going through the modals, there were a couple of minor bugs that were fixed.  For example the cluster name was not showing when it should or the "delete" button was not red.  These minor things were fixed.  The modal content was not touched.  The functions passed as props were not touched.

Here is a log of all the impacted modals along with before/after screenshots: https://docs.google.com/document/d/1E4e0Q8-sYGi1ewZsS5DOz28ngZKvn1AWwuCyDwa3tyo


# How to Test

Look at the list of modals in the linked document.  Spot check numerous modals to ensure that they look and work correctly.  Because it was the same changes over and over again, I don't think it is necessary to check each one to approve the code, but each one will most likely need to be checked as part of a QE review.

# Screen Captures

See:  https://docs.google.com/document/d/1E4e0Q8-sYGi1ewZsS5DOz28ngZKvn1AWwuCyDwa3tyo

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
