### PR TITLE
OCMUI-3605: added email verification to ROSA hands on page

### DIFF
--- a/src/components/App/Router.tsx
+++ b/src/components/App/Router.tsx
@@ -219,14 +219,7 @@ const Router: React.FC<RouterProps> = ({ planType, clusterId, externalClusterId 
         <Route path="/quota" element={<Quota />} />
         <Route path="/archived" element={<ArchivedClusterListMultiRegion getMultiRegion />} />
         <Route path="/dashboard" element={<Dashboard />} />
-        <Route
-          path="/overview/rosa/hands-on"
-          element={
-            <TermsGuard gobackPath="/overview/rosa/hands-on">
-              <RosaHandsOnPage />
-            </TermsGuard>
-          }
-        />
+        <Route path="/overview/rosa/hands-on" element={<RosaHandsOnPage />} />
         <Route path="/overview/rosa" element={<ServicePage serviceName="ROSA" />} />
         <Route path="/overview/osd" element={<ServicePage serviceName="OSD" />} />
         <Route path="/overview" element={<Overview />} />

--- a/src/components/RosaHandsOn/RosaHandsOnPage.tsx
+++ b/src/components/RosaHandsOn/RosaHandsOnPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import * as Sentry from '@sentry/browser';
 
 import { trackEvents } from '~/common/analytics';
@@ -17,7 +18,15 @@ const RosaHandsOnPage = () => {
     useDemoExperiencePolling();
   const [requestError, setRequestError] = React.useState<unknown>();
   const [requestingExperience, setRequestingExperience] = React.useState<boolean>(false);
-
+  const chrome = useChrome();
+  React.useEffect(() => {
+    // remove once OCM forces email verification on all /openshift
+    chrome.auth
+      .reAuthWithScopes('api.ocm', 'profile_level.name_and_address_and_ea_and_rhos')
+      .catch((err) => {
+        Sentry.captureException(err);
+      });
+  }, [chrome]);
   const requestCluster = async () => {
     try {
       setRequestingExperience(true);


### PR DESCRIPTION
# Summary

Added reauth with scopes on entering rosa hands on page, as workaround for /openshift not requesting a scope that enforces email verification. Original fix, adding TermsGuard wasn't sufficient, this fix requests the correct scope.

- Removed recently added `TermsGuard` wrapper as it does not resolve this issue.
- Added 'chrome.auth.reAuthWithScopes(...)' check to 'src/components/RosaHandsOn/RosaHandsOnPage.tsx' page.

# Jira

Fixes [OCMUI-3605](https://issues.redhat.com/browse/OCMUI-3605)

# How to Test

Logout of console.redhat.com. Navigate to console.redhat.com/openshift/overview/rosa/hands-on. Log in with an unverified email. See that you are navigated to enter more details and verify your email. Once done you should see this screen:
<img width="1269" height="805" alt="image" src="https://github.com/user-attachments/assets/65533f3b-6c0c-4100-8df3-0a89baa48f13" />
Can only be tested in production env.  _(Dave T. wrote: 'smaybe?, pls see my comment below)_

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
