### PR TITLE
OCMUI-3768: fix build command in konflux pipelines

### DIFF
--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -48,10 +48,9 @@ spec:
   # extend the unit-tests pipeline task to increase RAM
   taskRunSpecs:
     - pipelineTaskName: build-container
-      params:
-      - name: build-args
-        value:
-        - YARN_BUILD_SCRIPT=build:saas
+      env:
+      - name: YARN_BUILD_SCRIPT
+        value: build:saas
     - pipelineTaskName: run-unit-tests
       stepSpecs:
         - name: unit-tests


### PR DESCRIPTION
# Summary

replace the default command of the universal FE builder – `yarn build:prod`, with the custom command we use for integrating sentry-release into the prod' build – `yarn build:saas`.


# Jira

fixes [OCMUI-3768](https://issues.redhat.com/browse/OCMUI-3768)


# Additional information

TODO


# How to Test

the fix can't be tested until merged, as it should only be applied to 'push' PL, and not 'pull-request'.  
see test flows in the ticket.

it was tested during dev' by applying the same changes to the 'pull-request' pipeline first, and monitoring the 'build-container' task logs.  after that succeeded, changes were moved over to the 'push' pipeline.


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no QE