### PR TITLE
[OCMUI-3778]fix failing rosa wizard smoke test cases

### DIFF
--- a/cypress/pageobjects/CreateRosaWizard.page.js
+++ b/cypress/pageobjects/CreateRosaWizard.page.js
@@ -380,21 +380,11 @@ class CreateRosaCluster extends Page {
   }
 
   selectStandaloneControlPlaneTypeOption() {
-    cy.getByTestId('standalone-control-planes').click({ force: true });
-    cy.getByTestId('standalone-control-planes')
-      .should('have.attr', 'aria-selected')
-      .then((isSelected) => {
-        expect(isSelected).to.eq('true');
-      });
+    cy.getByTestId('standalone-control-planes').find('input').check({ force: true });
   }
 
   selectHostedControlPlaneTypeOption() {
-    cy.getByTestId('hosted-control-planes').click({ force: true });
-    cy.getByTestId('hosted-control-planes')
-      .should('have.attr', 'aria-selected')
-      .then((isSelected) => {
-        expect(isSelected).to.eq('true');
-      });
+    cy.getByTestId('hosted-control-planes').find('input').check({ force: true });
   }
 
   selectAWSInfrastructureAccount(accountID) {


### PR DESCRIPTION
# Summary
fix for failing rosa wizard smoke test cases.

# Jira
Fixes [OCMUI-3778](https://issues.redhat.com/browse/OCMUI-3778)

# Additional information

Recent [PR](https://github.com/RedHatInsights/uhc-portal/pull/99) on control plane tile fix has been broken all the ROSA wizard checks in smoke runs against staging . This PR will fix failing locators used in tests.

# How to Test

Run any of the wizard specific test case
for example,
`npx cypress run --browser chrome --config baseUrl='https://console.dev.redhat.com/openshift/' --spec cypress/e2e/rosa/RosaClusterCreation.js`

# Screen Captures
nil

# Review process


## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
