### PR TITLE
OCMUI-3781: add eus to versions api call

### DIFF
--- a/src/services/clusterService.ts
+++ b/src/services/clusterService.ts
@@ -492,7 +492,7 @@ export function getClusterService(apiRequest: APIRequest = defaultApiRequest) {
           product: isHCP ? 'hcp' : undefined,
           // Internal users can test other channels via `ocm` CLI, no UI needed.
           // For external users, make sure we only offer stable channel.
-          search: `enabled='t' AND (channel_group='stable'${includeUnstableVersions ? " OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly' OR channel_group='eus'" : " OR channel_group='eus'"})${isRosa ? " AND rosa_enabled='t'" : ''}${
+          search: `enabled='t' AND (channel_group='stable' OR channel_group='eus'${includeUnstableVersions ? " OR channel_group='candidate' OR channel_group='fast' OR channel_group='nightly'" : ''})${isRosa ? " AND rosa_enabled='t'" : ''}${
             isMarketplaceGcp ? " AND gcp_marketplace_enabled='t'" : ''
           }${isWIF ? " AND wif_enabled='t'" : ''}`,
           size: -1,


### PR DESCRIPTION
# Summary

Added EUS to cluster versions API call.

# Jira

[OCMUI-3781](https://issues.redhat.com/browse/OCMUI-3781)

# Additional information

Simple query change to include EUS during every cluster version call.

# How to Test

The easiest way is to navigate to ROSA wizard and check network tab in Chrome dev tools. Filter network api calls with /versions.
There should be a GET request.
In that request confirm that the URL and query includes "OR channel_group='eus'"

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1528" height="322" alt="image" src="https://github.com/user-attachments/assets/7bf5b2ce-2c4a-409c-911d-527cfa121ac6" /> | <img width="1528" height="220" alt="image" src="https://github.com/user-attachments/assets/9274c0d7-4dc8-47d4-895c-8726a8a7b6f1" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
