### PR TITLE
OCMUI-3598: Wrong color for edit billing account link icon

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccount.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccount.tsx
@@ -7,7 +7,6 @@ import {
   DescriptionListTerm,
   Flex,
   FlexItem,
-  Icon,
 } from '@patternfly/react-core';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 
@@ -56,15 +55,14 @@ export function OverviewBillingAccount() {
                   data-testid="billingMarketplaceAccountLink"
                   isDisabled={!cluster?.canEdit} // This won't show disabled currently, but setting the tooltip anyway
                   variant="link"
+                  icon={<PencilAltIcon />}
+                  iconPosition="end"
                   isInline
                   onClick={() => setIsBillingModalOpen(true)}
                   disableReason={disableChangeReason}
                   isAriaDisabled={!!disableChangeReason}
                 >
                   {billingAccount}{' '}
-                  <Icon>
-                    <PencilAltIcon color="blue" />
-                  </Icon>
                 </ButtonWithTooltip>
               </FlexItem>
             </Flex>


### PR DESCRIPTION
# Summary

The link to edit the Billing account inside the cluster details overview of HCP clusters includes a pencil icon with the wrong blue color. 
It looks like the default html blue color was used, which is not the PF one for links.
The Icon is now passed as a prop instead of manually added inside the Button content.


# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->
Fixes: [OCMUI-3598](https://issues.redhat.com/browse/OCMUI-3598)


# How to Test

1. Open a ROSA HCP cluster details page
2. Scroll down until you see the Billing marketplace account link
3. See the link and icon color

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="720" height="302" alt="image" src="https://github.com/user-attachments/assets/4c374352-933a-4390-87d7-59cb6f8a4c38" /> | <img width="430" height="223" alt="image" src="https://github.com/user-attachments/assets/b7b48e3b-dfa1-4224-9ca6-d0d9eb5f150f" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
