### PR TITLE
Ocm UI 3783 updatemachinepoolmodal dayjs

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
 import { OutlinedArrowAltCircleUpIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-arrow-alt-circle-up-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import Modal from '~/components/common/Modal/Modal';
 import { modalActions } from '~/components/common/Modal/ModalActions';
@@ -96,13 +102,19 @@ export const UpdatePoolButton = ({
     const schedule = machinePool.upgradePolicies?.items?.[0];
 
     if (schedule?.next_run && schedule?.version) {
+      const currentDate = new Date(schedule.next_run);
       return (
         <PopoverHint
           iconClassName="pf-v6-u-ml-sm"
           hint={
             <>
-              {scheduledMessage} at <DateFormat type="exact" date={Date.parse(schedule.next_run)} />{' '}
-              to version {schedule.version}
+              {scheduledMessage} at{' '}
+              <Timestamp
+                date={currentDate}
+                dateFormat={TimestampFormat.full}
+                timeFormat={TimestampFormat.full}
+              />
+              {schedule.version}
             </>
           }
         />

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
@@ -111,8 +111,10 @@ export const UpdatePoolButton = ({
               {scheduledMessage} at{' '}
               <Timestamp
                 date={currentDate}
-                dateFormat={TimestampFormat.full}
-                timeFormat={TimestampFormat.full}
+                shouldDisplayUTC
+                dateFormat={TimestampFormat.medium}
+                timeFormat={TimestampFormat.medium}
+                locale="en-GB"
               />
               {schedule.version}
             </>


### PR DESCRIPTION
# Summary

Replacing old DateFormat component with PF6 Timestamp component for UpdateMachinePoolModal

# Jira

[OCMUI-3783](https://issues.redhat.com/browse/OCMUI-3783)


# How to Test

1. Create an HCP cluster.
2. Make sure update for Machine Pool is available.
3. In the Machine Pool list, there should be a popup icon near the version that will have a timestamp in the popup.

# Screen Captures



| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <img width="554" height="161" alt="Screenshot 2025-09-16 at 3 57 57 PM" src="https://github.com/user-attachments/assets/135c3960-79d3-4943-9b2b-a811a5748c06" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
