### PR TITLE
OCMUI-3751 Incorrect node count on edit HCP node pool

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
@@ -357,6 +357,17 @@ describe('isMinimumCountWithoutTaints ', () => {
       ).toBeFalsy();
     });
 
+    it('returns true if less than 2 nodes without taints - include current machine pool', () => {
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools,
+          currentMachinePoolId: 'mp-no-taints',
+          includeCurrentMachinePool: true,
+        }),
+      ).toBeTruthy();
+    });
+
     it('returns false if less than 2 autoscaled nodes without taints - no scaling', () => {
       expect(
         isMinimumCountWithoutTaints({


### PR DESCRIPTION
# Summary

There appears to be an error in how the minimum number of allowed nodes per machine pools for HCP clusters.  When you create an HCP cluster with exactly 2 node pools (aka 2 subnets) with a node count of 1, there is weird behavior when you go to edit the machine pools.

If the machine pools are auto scaled:
The overview tab shows an error and you cannot changes to the machine pool unless you change the node count 

If the machine pools are not autoscaled:
The number of nodes automatically changes from 1 to 2 and you can not longer choose 1.  Again - effectively you cannot save the machine pool unless you change the node count.

# Jira

Fixes [OCMUI-3751](https://issues.redhat.com/browse/OCMUI-3751) 

# Additional information

This area of the is complex so care was taken to surgically change the count only for HCP clusters and only when trying to determine the number of nodes across the cluster.  The changed method is also used to determine if the user can modify taints and/or delete a machine pool.  To keep changes isolated, a new parameter was add and only set when terminating the minimum value of nodes a machine pool can have.


Here are the rules for HCP clusters:  There can be no fewer than 2 nodes without taints across all machine pools.

# How to Test

Create (or modify) a HCP cluster so it has 2 machine pools each with autoscaling and min/max both set to 1 node
Open the edit machine pool modal and ensure there is not an error on the overview tab

Create (or modify) a HCP cluster so it has 2 machine pools each without autoscaling and number of nodes set to 1 node
Open the edit machine pool modal and the node value does not change and that 1 is an option.

# Screen Captures (AutoScale)

<img width="800" alt="Screenshot 2025-09-18 at 4 21 46 PM" src="https://github.com/user-attachments/assets/45a8750e-dfba-4a7e-b010-3d9ad05a90fe" />


| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="849" height="587" alt="Screenshot 2025-09-18 at 4 22 11 PM" src="https://github.com/user-attachments/assets/4c9f18f3-6db5-4355-9dbe-e63c8efcfc06" /> |  <img width="849" height="587" alt="Screenshot 2025-09-18 at 4 22 41 PM" src="https://github.com/user-attachments/assets/bcf06f08-c602-4ad8-8422-2f773a4fcc08" /> |


# Screen Captures (Not autoscale)
<img width="800"  alt="Screenshot 2025-09-18 at 4 19 09 PM" src="https://github.com/user-attachments/assets/ea97cf55-a111-4f39-bc96-01562d131493" />


| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="849" height="587" alt="Screenshot 2025-09-18 at 4 20 11 PM" src="https://github.com/user-attachments/assets/fe50bbab-c0ca-49f0-aa89-293bab7aad7c" /> | <img width="849" height="587" alt="Screenshot 2025-09-18 at 4 20 56 PM" src="https://github.com/user-attachments/assets/77a24205-8f3e-47e7-8e89-c9a37cc69225" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
