### PR TITLE
OCMUI-3782 Change subscriptionCompliancy to use PF date

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/SubscriptionCompliancy.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/SubscriptionCompliancy.jsx
@@ -3,8 +3,7 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
-import { Alert, Button } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Alert, Button, Timestamp, TimestampFormat } from '@patternfly/react-core';
 
 import getClusterName from '~/common/getClusterName';
 import { normalizedProducts } from '~/common/subscriptionTypes';
@@ -124,9 +123,12 @@ function SubscriptionCompliancy({ cluster, openModal, canSubscribeOCP = false })
     >
       {lastChecked}
       <p>
-        Your OpenShift evaluation will expire at&nbsp;
-        <DateFormat date={subscription.eval_expiration_date} type="onlyDate" />
-        .&nbsp;
+        Your OpenShift evaluation will expire at{' '}
+        <Timestamp
+          date={subscription.eval_expiration_date}
+          dateFormat={TimestampFormat.medium}
+          locale="eng-GB"
+        />{' '}
         {cluster.canEdit ? textForUsersCanEdit : textForUsersCanNotEdit}
       </p>
     </Alert>


### PR DESCRIPTION
# Summary

Change SubscriptionCompliancy.jsx to use the PatternFly Timestamp component and remove 

`import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';`

# Jira

<!-- link to the corresponding Jira item -->
 Fixes [OCMUI-3782](https://issues.redhat.com/browse/OCMUI-3782) 

# Additional information

Note that the text size of the text is slightly smaller - this is by design and part of PatternFly styling.

Note that no logic to determine the date was changed - just the wrapper to display the date.

This might best be reviewed at the same time as OCMUI-3785 ( #141 )

# How to Test

- Go to a cluster that is currently has an evaluation subscription.  Currently this cluster is in this state: https://console.dev.redhat.com/openshift/details/s/32v6XIeZjV41wdZHdXPDNN12eR3#overview

- If one doesn't exist do the following: On the Cluster List click on Register Cluster > Put in a fake UUID > Select "Self-Support 60-day evaluation" under the SLA.  Click on Register cluster
 
- Ensure that the date in the "OpenShift evaluation expiration date" alert is displaying correctly and matches staging.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="728" height="98" alt="Screenshot 2025-09-19 at 8 33 16 AM" src="https://github.com/user-attachments/assets/88b26147-7a24-45bd-9a9a-07d40d6610f5" /> | <img width="728" height="98" alt="Screenshot 2025-09-19 at 8 33 31 AM" src="https://github.com/user-attachments/assets/a13dfd94-3308-446a-b163-b9a6e34e3ff1" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
