### PR TITLE
OCMUI-3793, OCMUI-3784 LiveDateFormat to use PF Timestamp component

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/ClusterLogs.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterLogs/ClusterLogs.tsx
@@ -235,7 +235,7 @@ const ClusterLogs = ({
             <>
               Updated &nbsp;
               {fetchedClusterLogsAt && !isPending ? (
-                <LiveDateFormat timestamp={fetchedClusterLogsAt.getTime()} />
+                <LiveDateFormat date={fetchedClusterLogsAt} />
               ) : (
                 <Spinner size="sm" aria-label="Loading..." />
               )}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Monitoring/components/MonitoringEmptyState.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Monitoring/components/MonitoringEmptyState.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 
 import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+
+import LiveDateFormat from '~/components/common/LiveDateFormat/LiveDateFormat';
 
 type MonitoringEmptyStateProps = {
   children?: React.ReactNode | null;
   hideLastCheckIn?: boolean;
   hideIcon?: boolean;
   title?: string;
-  lastCheckIn?: Date | number | string;
+  lastCheckIn?: Date;
 };
 
 const MonitoringEmptyState = ({
@@ -28,8 +29,7 @@ const MonitoringEmptyState = ({
       {children}
       {!hideLastCheckIn && (
         <p>
-          {/* @ts-ignore */}
-          Last Check-in: <DateFormat date={lastCheckIn} type="relative" />
+          Last Check-in: <LiveDateFormat date={lastCheckIn} />
         </p>
       )}
     </EmptyStateBody>

--- a/src/components/common/LiveDateFormat/LiveDateFormat.test.tsx
+++ b/src/components/common/LiveDateFormat/LiveDateFormat.test.tsx
@@ -10,9 +10,9 @@ describe('<LiveDateFormat />', () => {
     jest.setSystemTime(new Date('1 Jan 2021 00:00:00 GMT').getTime());
   });
 
-  it('displays "just now" on initial render', () => {
-    render(<LiveDateFormat timestamp={Date.now()} />);
-    expect(screen.getByText('Just now')).toBeInTheDocument();
+  it('displays "a few seconds ago" on initial render', () => {
+    render(<LiveDateFormat date={new Date()} />);
+    expect(screen.getByText('a few seconds ago')).toBeInTheDocument();
   });
 
   afterAll(() => {

--- a/src/components/common/LiveDateFormat/LiveDateFormat.tsx
+++ b/src/components/common/LiveDateFormat/LiveDateFormat.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
 
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Timestamp, TimestampFormat, TimestampTooltipVariant } from '@patternfly/react-core';
+
+dayjs.extend(relativeTime);
 
 type Props = {
-  timestamp: number;
+  date?: Date | undefined;
 };
 
-const LiveDateFormat = ({ timestamp }: Props) => {
+const LiveDateFormat = ({ date }: Props) => {
   // use state to trigger an update on a set interval
   const [, triggerUpdate] = React.useState(0);
   React.useEffect(() => {
@@ -15,7 +19,22 @@ const LiveDateFormat = ({ timestamp }: Props) => {
     return () => clearInterval(timer);
   }, []);
 
-  return <DateFormat type="relative" date={timestamp} />;
+  if (!date) {
+    return 'N/A';
+  }
+
+  return (
+    <Timestamp
+      date={date}
+      dateFormat={TimestampFormat.medium}
+      timeFormat={TimestampFormat.medium}
+      shouldDisplayUTC
+      locale="eng-GB"
+      tooltip={{ variant: TimestampTooltipVariant.default }}
+    >
+      {dayjs().to(dayjs(date))}
+    </Timestamp>
+  );
 };
 
 export default LiveDateFormat;


### PR DESCRIPTION
# Summary

This PR converts the LiveDateFormat component to use DayJS (for relative date/time) and PF's Timestamp component for display.  The LiveDateFormat component will show a relative time/date  from today (for example "5 minutes ago").

This removes the dependency on `{ DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';` from these files

# Jira

 Fixes [OCMUI-3793](https://issues.redhat.com/browse/OCMUI-3793)
 Fixes [OCMUI-3784](https://issues.redhat.com/browse/OCMUI-3784)

# Additional information

There is a slight difference between how DateFormat and DayJS for "now" when displaying relative time.  DateFormat would display this a "Just now" and DayJS displays "a few seconds ago".

See DayJS's relative time chart: https://day.js.org/docs/en/display/from-now#list-of-breakdown-range

Note that the text size of the text is  underlined and slightly smaller - this is by design and part of PatternFly styling.

# How to Test

The LiveDateFormat component is used in two places:  cluster logs and the monitoring tab.

## Cluster logs
Open any running cluster (OSD, ROSA, etc)
Go to the "Cluster history" tab
Ensure that the "Updated  " time is correct

## Monitoring tab
This one is difficult to set up.   You need a registered OCP cluster that connected to OCM, but never sent information (aka telemetry) back.   Honestly I had no idea how to really do this so I modified the code.

Open "MonitoringEmptyState.tsx"
Change the props to be:
```
const MonitoringEmptyState = ({
  children = null,
  hideLastCheckIn = false,
  lastCheckIn =new Date('2025-09-15'),
  hideIcon = false,
  title = 'Monitoring data is not available',
}: MonitoringEmptyStateProps) => (

```

Then later on flip the `hideLastCheckIn` line: 
```
 {hideLastCheckIn && (
```

Go to a cluster that is currently has an evaluation subscription. Currently this cluster is in this state: https://console.dev.redhat.com/openshift/details/s/32v6XIeZjV41wdZHdXPDNN12eR3#overview

If one doesn't exist do the following: On the Cluster List click on Register Cluster > Put in a fake UUID > Select "Self-Support 60-day evaluation" under the SLA. Click on Register cluster

Go to the Monitoring tab and ensure the date is displayed correctly

# Screen Captures

## Cluster logs

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="927" height="371" alt="Screenshot 2025-09-19 at 10 07 28 AM" src="https://github.com/user-attachments/assets/7fdac1c5-3c53-4f42-b5a0-7567843afa1b" /> | <img width="927" height="371" alt="Screenshot 2025-09-19 at 10 07 42 AM" src="https://github.com/user-attachments/assets/77102846-3284-47f8-91a3-d6c467beeb41" /> |

## Monitoring tab

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="758" height="309" alt="Screenshot 2025-09-19 at 10 39 38 AM" src="https://github.com/user-attachments/assets/96d5e4db-10c0-46c2-89c7-6e979cd2812c" /> | <img width="921" height="371" alt="Screenshot 2025-09-19 at 9 56 24 AM" src="https://github.com/user-attachments/assets/dbe61917-6120-47a4-89c9-3aeb367a28c7" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
