### PR TITLE
OCMUI-3785 Convert ClusterCreatedIndicator to PF Timestamp

### DIFF
--- a/src/components/clusters/ClusterListMultiRegion/components/ClusterCreatedIndicator.jsx
+++ b/src/components/clusters/ClusterListMultiRegion/components/ClusterCreatedIndicator.jsx
@@ -3,10 +3,16 @@ import dayjs from 'dayjs';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
-import { Button, Icon, Popover, PopoverPosition } from '@patternfly/react-core';
+import {
+  Button,
+  Icon,
+  Popover,
+  PopoverPosition,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import { SubscriptionCommonFieldsSupport_level as SubscriptionCommonFieldsSupportLevel } from '~/types/accounts_mgmt.v1';
 
@@ -105,7 +111,11 @@ function ClusterCreatedIndicator({ cluster }) {
         {OCPTrialExpiresStr}
         &nbsp;on&nbsp;
         <strong>
-          <DateFormat date={subscription.eval_expiration_date} type="onlyDate" />
+          <Timestamp
+            date={subscription.eval_expiration_date}
+            dateFormat={TimestampFormat.medium}
+            locale="eng-GB"
+          />
         </strong>
         .&nbsp;Your cluster is not&nbsp;
         <ExternalLink


### PR DESCRIPTION
# Summary

Change ClusterCreatedIndicator.jsx to use the PatternFly Timestamp component and remove

`import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';`

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3785](https://issues.redhat.com/browse/OCMUI-3785)

# Additional information

Note that the text size of the text is slightly smaller - this is by design and part of PatternFly styling.

Note that no logic to determine the date was changed - just the wrapper to display the date.

This might best be reviewed at the same time as OCMUI-3782 ( #139 )

# How to Test

Ensure that you have a cluster that currently has an evaluation subscription. Currently this cluster is in this state: https://console.dev.redhat.com/openshift/details/s/32v6XIeZjV41wdZHdXPDNN12eR3#overview

If one doesn't exist do the following: On the Cluster List click on Register Cluster > Put in a fake UUID > Select "Self-Support 60-day evaluation" under the SLA. Click on Register cluster

On the cluster list, click on the yellow ( ! ) triangle to bring up the popover.  

In the popover ensure that the date is displaying correctly

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="800" height="241" alt="Screenshot 2025-09-19 at 11 25 04 AM" src="https://github.com/user-attachments/assets/539b2560-c584-4f66-8cd0-43452d90b46c" />  | <img width="800" height="241" alt="Screenshot 2025-09-19 at 11 26 22 AM" src="https://github.com/user-attachments/assets/64d35b99-135c-4992-bda4-8ed8ce3a4900" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
