### PR TITLE
OCMUI-3786 Convert HibernateClusterUpgradeScheduled to PF timestamp

### DIFF
--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterUpgradeScheduled.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterUpgradeScheduled.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Alert } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Alert, Timestamp, TimestampFormat } from '@patternfly/react-core';
 
 const HibernateClusterUpgradeScheduled = ({
   clusterName,
@@ -19,8 +18,15 @@ const HibernateClusterUpgradeScheduled = ({
       variant="warning"
       title={
         <p>
-          There is a scheduled update to <DateFormat type="exact" date={Date.parse(nextRun)} />. The
-          scheduled update cannot be executed if the cluster is hibernating.
+          There is a scheduled update at{' '}
+          <Timestamp
+            date={new Date(nextRun)}
+            shouldDisplayUTC
+            locale="eng-GB"
+            dateFormat={TimestampFormat.medium}
+            timeFormat={TimestampFormat.short}
+          />
+          . The scheduled update cannot be executed if the cluster is hibernating.
         </p>
       }
     />


### PR DESCRIPTION
# Summary

Change HibernateClusterUpgradeScheduled.tsx to use the PatternFly Timestamp component and remove

`import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';`

# Jira

 Fixes [OCMUI-3786](https://issues.redhat.com/browse/OCMUI-3786)

# Additional information

Note that the text size of the text is slightly smaller - this is by design and part of PatternFly styling.  I have no idea why the orange "technology preview" label is different between main and staging - but it isn't due to this PR.

Note that no logic to determine the date was changed - just the wrapper to display the date.  

# How to Test

- Either use the test cluster: kim-osd-aws-9-19-2 OR create a test cluster by:
  - Create an OSD cluster at a lesser version
  - Once the cluster has been created, schedule an update for a date in the far future
  - Wait a few minutes
- Click on the cluster actions and choose "Hibernate"
- A modal should open indicating when the update is scheduled.
- Verify that the date/time of the modal is correct


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="561" height="342" alt="Screenshot 2025-09-19 at 3 48 46 PM" src="https://github.com/user-attachments/assets/5230d93d-d019-44dc-98fc-8e968fbd3cac" /> | <img width="561" height="342" alt="Screenshot 2025-09-19 at 3 58 50 PM" src="https://github.com/user-attachments/assets/9be7786b-c31d-47a7-8905-8393971eb0b6" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
