### PR TITLE
OCMUI-3787 UpgradeStatus to use PF Timestamp

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeStatus.test.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeStatus.test.tsx
@@ -120,7 +120,7 @@ describe('<UpgradeStatus />', () => {
       render(<UpgradeStatus {...manualUpgradeScheduled} />);
 
       expect(screen.getByText('Upgrade scheduled')).toBeInTheDocument();
-      expect(screen.getByText(/01 Dec 2020 00:00 UTC/)).toBeInTheDocument();
+      expect(screen.getByText(/1 Dec 2020, 00:00 UTC/)).toBeInTheDocument();
     });
 
     it('should not show cancel button when canEdit is false', () => {
@@ -156,7 +156,7 @@ describe('<UpgradeStatus />', () => {
     it('should show upgrade time when the schedule is "scheduled"', () => {
       render(<UpgradeStatus {...automaticUpdateScheduleProps} />);
       expect(screen.getByText('Upgrade scheduled')).toBeInTheDocument();
-      expect(screen.getByText(/01 Dec 2020 00:00 UTC/)).toBeInTheDocument();
+      expect(screen.getByText(/1 Dec 2020, 00:00 UTC/)).toBeInTheDocument();
     });
 
     it('should not show upgrade time when the schedule is "pending"', () => {
@@ -172,7 +172,7 @@ describe('<UpgradeStatus />', () => {
       render(<UpgradeStatus {...pendingProps} />);
 
       expect(screen.getByText(/Update available/)).toBeInTheDocument();
-      expect(screen.queryByText(/01 Dec 2020 00:00 UTC/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/1 Dec 2020, 00:00 UTC/)).not.toBeInTheDocument();
       expect(screen.queryByText('Upgrade scheduled')).not.toBeInTheDocument();
     });
   });
@@ -202,7 +202,7 @@ describe('<UpgradeStatus />', () => {
 
     it('should not show date', () => {
       render(<UpgradeStatus {...updateInProgressProps} />);
-      expect(screen.queryByText(/01 Dec 2020 00:00 UTC/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/1 Dec 2020, 00:00 UTC/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/clusters/common/Upgrades/UpgradeStatus.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeStatus.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Button, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import { InProgressIcon } from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
 import { OutlinedArrowAltCircleUpIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-arrow-alt-circle-up-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import { VersionGate } from '~/types/clusters_mgmt.v1';
 import type { AugmentedCluster, UpgradePolicyWithState } from '~/types/types';
@@ -121,7 +127,13 @@ const UpgradeStatus = ({
         {scheduledUpgrade && upgradeState !== 'started' && upgradeState !== 'pending' && (
           <>
             <div className="ocm-upgrade-status-scheduled-title">Upgrade scheduled</div>
-            <DateFormat type="exact" date={Date.parse(scheduledUpgrade.next_run || '')} />
+            <Timestamp
+              date={scheduledUpgrade.next_run ? new Date(scheduledUpgrade.next_run) : undefined}
+              shouldDisplayUTC
+              locale="eng-GB"
+              dateFormat={TimestampFormat.medium}
+              timeFormat={TimestampFormat.short}
+            />
           </>
         )}
       </div>


### PR DESCRIPTION
# Summary

Change UpgradeStatus.tsx to use the PatternFly Timestamp component and remove

import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';

# Jira

Fixes [OCMUI-3787](https://issues.redhat.com/browse/OCMUI-3787)

# Additional information

Note that the text size of the text is slightly smaller - this is by design and part of PatternFly styling.

Note that no logic to determine the date was changed - just the wrapper to display the date.

# How to Test

There are two places where this date is displayed - once on the Cluster detail Overview tab an on the Settings tab.

- Either use the test cluster: kim-osd-aws-9-19-2 OR create a test cluster by:
  - Create an OSD cluster at a lesser version
  - Once the cluster has been created, schedule an update for a date in the far future
  - Wait a few minutes
- On the Settings tab, ensure that the date/time under the scheduled upgrade graph on the right side of the screen is correct
- On the Overview tab, click on "View details" under the Version section
- In the popover, ensure the date/time is correct.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="322" height="291" alt="Screenshot 2025-09-19 at 4 27 25 PM" src="https://github.com/user-attachments/assets/cc322a9f-d25e-46d4-91ec-8c965f481a7f" /> <img width="322" height="291" alt="Screenshot 2025-09-19 at 4 27 44 PM" src="https://github.com/user-attachments/assets/2bd070f7-fcba-413f-9461-631fa32839b1" /> | <img width="322" height="291" alt="Screenshot 2025-09-19 at 4 29 36 PM" src="https://github.com/user-attachments/assets/f0cf09a3-316a-4dac-8960-25463b0f6a3a" /> <img width="322" height="291" alt="Screenshot 2025-09-19 at 4 29 09 PM" src="https://github.com/user-attachments/assets/d45e4d6f-80e4-46f4-b749-28356d366b06" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
