### PR TITLE
OCMUI-3731 Fix networking switches

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/ApplicationIngressCard/ApplicationIngressCard.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/ApplicationIngressCard/ApplicationIngressCard.tsx
@@ -191,7 +191,11 @@ const ApplicationIngressCard: React.FC<ApplicationIngressCardProps> = ({
                 isStack
               >
                 <Switch
-                  label="Strict"
+                  label={
+                    isDefaultRouterNamespaceOwnershipPolicyStrict
+                      ? 'Strict'
+                      : 'Inter-namespace ownership allowed'
+                  }
                   isChecked={!!isDefaultRouterNamespaceOwnershipPolicyStrict}
                   isDisabled
                 />
@@ -199,7 +203,7 @@ const ApplicationIngressCard: React.FC<ApplicationIngressCardProps> = ({
 
               <FormGroup label="Wildcard policy" labelHelp={<WildcardPolicyPopover />} isStack>
                 <Switch
-                  label="Allowed"
+                  label={isDefaultIngressWildcardPolicyAllowed ? 'Allowed' : 'Disallowed'}
                   isChecked={isDefaultIngressWildcardPolicyAllowed}
                   isDisabled
                 />
@@ -210,7 +214,11 @@ const ApplicationIngressCard: React.FC<ApplicationIngressCardProps> = ({
           {canShowLoadBalancer && (
             <FormGroup label="Load balancer type" labelHelp={<LoadBalancerPopover />}>
               <Switch
-                label={LoadBalancerFlavorLabel[LoadBalancerFlavor.nlb]}
+                label={
+                  isNLB
+                    ? LoadBalancerFlavorLabel[LoadBalancerFlavor.nlb]
+                    : LoadBalancerFlavorLabel[LoadBalancerFlavor.classic]
+                }
                 isChecked={isNLB}
                 isDisabled
               />

--- a/src/components/common/ReduxFormComponents_deprecated/ReduxCheckbox.jsx
+++ b/src/components/common/ReduxFormComponents_deprecated/ReduxCheckbox.jsx
@@ -26,6 +26,7 @@ import PopoverHint from '../PopoverHint';
 function ReduxCheckbox(props) {
   const {
     label,
+    labelOff,
     meta: { error, touched },
     input: { name, value, ...restInput },
     isSwitch = false,
@@ -36,6 +37,7 @@ function ReduxCheckbox(props) {
     ...extraProps // any extra props not specified above
   } = props;
   const InputComponent = isSwitch ? Switch : Checkbox;
+  const finalLabel = !value && labelOff ? labelOff : label;
   return (
     <FormGroup fieldId={name}>
       <Split hasGutter>
@@ -48,7 +50,7 @@ function ReduxCheckbox(props) {
             {...extraProps}
             label={
               <>
-                {label}
+                {finalLabel}
                 {isRequired ? (
                   <span
                     className="pf-v6-c-form__label-required redux-checkbox-required"
@@ -78,6 +80,7 @@ function ReduxCheckbox(props) {
 
 ReduxCheckbox.propTypes = {
   label: PropTypes.string.isRequired,
+  labelOff: PropTypes.string,
   input: PropTypes.object.isRequired,
   meta: PropTypes.object.isRequired,
   isSwitch: PropTypes.bool,


### PR DESCRIPTION
# Summary

When setting or editing the switches for: 

- Namespace ownership policy
- Wildcard policy
- Load balance type

The value next to the switch did not change which makes it confusing what the actual values is.

# Jira

 Fixes [OCMUI-3731](https://issues.redhat.com/browse/OCMUI-3731) 

# Additional information

Areas where you can edit the value (wizards, Edit application ingress) there as a "labelOff" attribute that is sent down to a PatternFly Switch prop.  In PF 6 this prop was removed.  This PR fixes to switch the label based on the switch state.

Secondly on Cluster details > Networking tab > Application ingress, it appears that the state of these switches always had static labels (aka they never had a "labelOff" value).  This PR fixes that. 

# How to Test

- Build an OSD AWS cluster (or use: kim-osd-aws-9-19-2).  
- Go to the Networking tab and scroll down to the Application ingress section. Ensure shown fields have the correct label
- Open the Application ingress modal and ensure shown fields have correct label
- Lastly to the ROSA wizard
- Choose classic control plane
- On the Networking > Configuration step,  choose Custom settings
- Ensure shown fields have correct label

| Switch | State | Label |
| ------ | ------ | ----- |
| Namespace ownership policy | Off/left | Inter-namespace ownership allowed |
| Wildcard policy | Off/left | Disallowed |
| Load balancer type | Off/left | Classic Load Balancer |
| Namespace ownership policy | On/right | Strict |
| Wildcard policy | On/right | Allowed |
| Load balancer type | On/right | Network Load Balancer |


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="906" height="643" alt="Screenshot 2025-09-22 at 2 32 37 PM" src="https://github.com/user-attachments/assets/544abfb5-c56e-4301-bca5-8eb84dd6fb0c" /> <img width="844" height="792" alt="Screenshot 2025-09-22 at 2 33 00 PM" src="https://github.com/user-attachments/assets/1027bc9f-876a-4a5e-a353-1bafa3ba9271" /> <img width="844" height="792" alt="Screenshot 2025-09-22 at 2 33 12 PM" src="https://github.com/user-attachments/assets/190bffa0-00a9-4b10-809e-7d39f3f1c921" /> <img width="973" height="714" alt="Screenshot 2025-09-22 at 2 33 31 PM" src="https://github.com/user-attachments/assets/74b1711c-6129-47d3-b357-7bca565df54b" /> |<img width="847" height="650" alt="Screenshot 2025-09-22 at 2 33 58 PM" src="https://github.com/user-attachments/assets/83d99221-0e36-4e88-9c42-d73a3298ca16" /> <img width="847" height="721" alt="Screenshot 2025-09-22 at 2 34 19 PM" src="https://github.com/user-attachments/assets/d37ae6d1-93cb-4840-8515-6695033a82d8" /> <img width="847" height="721" alt="Screenshot 2025-09-22 at 2 34 31 PM" src="https://github.com/user-attachments/assets/582824bf-c097-4734-bf28-af28b5ed81e3" /> <img width="847" height="539" alt="Screenshot 2025-09-22 at 2 34 46 PM" src="https://github.com/user-attachments/assets/4bfb646b-d1d4-4310-9d9e-8a82e39b9dcb" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
