### PR TITLE
Point OpenShift Local docs to upstream rather than archived source page [trivial change]

### DIFF
--- a/src/common/installLinks.mjs
+++ b/src/common/installLinks.mjs
@@ -205,8 +205,7 @@ const links = {
   RHCOS_BAREMETAL_RAW_X86: `${MIRROR_RHCOS_LATEST_X86}/rhcos-metal.x86_64.raw.gz`,
   INSTALL_BAREMETAL_MULTI_ARCH: `${OCP_DOCS_BASE}/postinstallation_configuration/configuring-multi-architecture-compute-machines-on-an-openshift-cluster#creating-multi-arch-compute-nodes-bare-metal`,
 
-  OPENSHIFT_LOCAL_SUPPORT_AND_COMMUNITY_DOCS:
-    'https://source.redhat.com/groups/public/cooperative_community_support/cooperative_community_support_wiki/codeready_containers_case_response_template',
+  OPENSHIFT_LOCAL_SUPPORT_AND_COMMUNITY_DOCS: 'https://crc.dev/docs/using/',
 
   INSTALL_GCPIPI_GETTING_STARTED: `${OCP_DOCS_BASE}/installing_on_gcp/installing-gcp-account`,
   INSTALL_GCPIPI_LEARN_MORE: `${OCP_DOCS_BASE}/installing_on_gcp/installing-gcp-default`,


### PR DESCRIPTION
# Summary

_This PR is a correctly rebased version of https://github.com/RedHatInsights/uhc-portal/pull/149_

OpenShift Local install page has a "step 2" link "for more information on on the OpenShift Local support and community docs click here" which currently goes to an Archived page on the Red Hat intranet.  This changes the link to upstream crc.dev documentation.

# Jira

None; trivial change

# Additional information

n/a

# How to Test

n/a

# Screen Captures

<img width="718" height="203" alt="Screenshot 2025-09-22 at 3 38 56 PM" src="https://github.com/user-attachments/assets/510d58e4-83ac-4702-b57a-d652b564020a" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation