### PR TITLE
Nested routes demo

### DIFF
--- a/src/components/App/Router.tsx
+++ b/src/components/App/Router.tsx
@@ -38,7 +38,7 @@ import ArchivedClusterListMultiRegion from '../clusters/ArchivedClusterListMulti
 import ClusterDetailsSubscriptionIdMultiRegion from '../clusters/ClusterDetailsMultiRegion/ClusterDetailsSubscriptionIdMultiRegion';
 import AccessRequestNavigate from '../clusters/ClusterDetailsMultiRegion/components/AccessRequest/components/AccessRequestNavigate';
 import IdentityProviderPageMultiregion from '../clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/index';
-import ClusterListMultiRegion from '../clusters/ClusterListMultiRegion';
+import { ClustersNew } from '../clusters/ClustersNew/ClustersNew';
 import ClusterRequestList from '../clusters/ClusterTransfer/ClusterRequest';
 import CreateClusterPage from '../clusters/CreateClusterPage';
 import GovCloudPage from '../clusters/GovCloud/GovCloudPage';
@@ -242,7 +242,7 @@ const Router: React.FC<RouterProps> = ({ planType, clusterId, externalClusterId 
         'Operational' or 'Major Outage' status for "OpenShift Cluster Manager" on the
         'http:///status.redhat.com' site. If this route is changed, then the related catchpoint
         tests must be updated. For more info. see: https://issues.redhat.com/browse/OCMUI-2398 */}
-        <Route path="/cluster-list" element={<ClusterListMultiRegion getMultiRegion />} />
+        <Route path="/cluster-list/*" element={<ClustersNew />} />
         {isClusterTransferOwnershipEnabled ? (
           <Route path="/cluster-request" element={<ClusterRequestList />} />
         ) : null}

--- a/src/components/clusters/ClustersNew/ClustersNew.tsx
+++ b/src/components/clusters/ClustersNew/ClustersNew.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react';
+import { Route, Routes, useLocation } from 'react-router-dom';
+
+import { Tab, Tabs, TabsComponent, TabTitleText } from '@patternfly/react-core';
+
+import { Link, Navigate } from '~/common/routing';
+import ClusterTransferList from '~/components/clusters/ClusterTransfer/ClusterTransferList';
+
+import ClusterListMultiRegion from '../ClusterListMultiRegion';
+
+export const ClustersNew = () => {
+  const location = useLocation();
+
+  const activeTabKey = useMemo(() => {
+    const path = location.pathname;
+
+    if (path.endsWith('/list')) return 'list';
+    if (path.endsWith('/requests')) return 'requests';
+
+    return 'list';
+  }, [location.pathname]);
+
+  return (
+    <>
+      <Tabs
+        activeKey={activeTabKey}
+        component={TabsComponent.div}
+        aria-label="Tabs in the nav element example"
+      >
+        <Tab
+          eventKey="list"
+          title={
+            <Link to="/cluster-list/list">
+              <TabTitleText>List</TabTitleText>
+            </Link>
+          }
+        />
+        <Tab
+          eventKey="requests"
+          title={
+            <Link to="/cluster-list/requests">
+              <TabTitleText>Requests</TabTitleText>
+            </Link>
+          }
+        />
+      </Tabs>
+      <Routes>
+        <Route index element={<Navigate to="/cluster-list/list" replace />} />
+        <Route path="list" element={<ClusterListMultiRegion getMultiRegion />} />
+        <Route path="requests" element={<ClusterTransferList />} />
+      </Routes>
+    </>
+  );
+};


### PR DESCRIPTION
# Summary

Testing out nested routes with tabs.

The tabs links still look ugly. You'll have to click on the tab name, the link is only there. We need to figure out how to combine react router `Link` with `Tab`s. We might end up having to switch to `useNavigate` or use custom CSS.

There should be no content flashing when reloading the `requests` tab directly. 

# How to Test

This is only an experiment. Run the application locally and click on cluster lists. Then you can switch between cluster list and requests, each one with a different route.