### PR TITLE
OCMUI-3788 CancelUpgradeModal to PF Timestamp

### DIFF
--- a/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
+++ b/src/components/clusters/common/Upgrades/CancelUpgradeModal/CancelUpgradeModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Form } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
+import { Form, Timestamp, TimestampFormat } from '@patternfly/react-core';
 
 import Modal from '~/components/common/Modal/Modal';
 import { useDeleteSchedule } from '~/queries/ClusterDetailsQueries/ClusterSettingsTab/useDeleteSchedule';
@@ -86,9 +85,12 @@ const CancelUpgradeModal: React.FC<CancelUpgradeModalProps> = ({ isHypershift })
           <Form onSubmit={deleteScheduleFunc}>
             <p>
               This update to version {schedule?.version} is scheduled for{' '}
-              <DateFormat
-                type="exact"
-                date={schedule?.next_run ? Date.parse(schedule.next_run) : new Date()}
+              <Timestamp
+                date={schedule.next_run ? new Date(schedule.next_run) : undefined}
+                shouldDisplayUTC
+                locale="eng-GB"
+                dateFormat={TimestampFormat.medium}
+                timeFormat={TimestampFormat.short}
               />
               .{' '}
             </p>


### PR DESCRIPTION
# Summary

Convert CancelUpgradeModal to use PatternFly's Timestamp component.  This removes the use of: `import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';`

NOTE:  This did not change how the date/time is received or calculated - only how it is displayed.  There is no logic change only presentation.

NOTE: The Date/time has a slightly smaller font.  This coming from PatternFly and is expected.

# Jira

 Fixes [OCMUI-3788](https://issues.redhat.com/browse/OCMUI-3788)



# How to Test

Create a cluster that has an upgrade schedule in a date in the future OR use cluster`kim-osd-aws-9-19-2`
Go to the Settings tab
On the right-hand side, click on "Cancel this upgrade" link to open the modal
On the modal - verify the date/time is in the correct format.
Click "close"

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="563" height="173" alt="Screenshot 2025-09-24 at 5 03 36 PM" src="https://github.com/user-attachments/assets/a18ad37a-f6bf-4d8f-8866-b7c261761526" /> | <img width="563" height="173" alt="Screenshot 2025-09-24 at 5 04 40 PM" src="https://github.com/user-attachments/assets/5b5b17c9-de3b-4a40-a8b3-5550cabd2bcd" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
