### PR TITLE
OCMUI-3791: replaced DateFormat with pf6 TimeStamp

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeWizard.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeWizard.tsx
@@ -8,11 +8,12 @@ import {
   ModalBody,
   ModalVariant,
   Spinner,
+  Timestamp,
+  TimestampFormat,
   Title,
   Wizard,
   WizardStep,
 } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import { ModalWizardHeader } from '~/components/clusters/wizards/common/ModalWizardHeader/ModalWizardHeader';
 import ErrorBox from '~/components/common/ErrorBox';
@@ -294,11 +295,24 @@ const UpgradeWizard = () => {
                     <dl>
                       <dt>UTC</dt>
                       <dd>
-                        <DateFormat type="exact" date={new Date(upgradeTimestamp!)} />
+                        <Timestamp
+                          date={new Date(upgradeTimestamp!)}
+                          shouldDisplayUTC
+                          locale="eng-GB"
+                          dateFormat={TimestampFormat.medium}
+                          timeFormat={TimestampFormat.short}
+                        />
                       </dd>
                       <div>
                         <dt>Local time</dt>
-                        <dd>{new Date(upgradeTimestamp!).toString()}</dd>
+                        <dd>
+                          <Timestamp
+                            date={new Date(upgradeTimestamp!)}
+                            locale="eng-GB"
+                            dateFormat={TimestampFormat.long}
+                            timeFormat={TimestampFormat.short}
+                          />
+                        </dd>
                       </div>
                     </dl>
                   )}


### PR DESCRIPTION
# Summary

Simple replacement of DateFormat component with PF6 TimeStamp component

# Jira

[OCMUI-3791](https://issues.redhat.com/browse/OCMUI-3791)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

Create a cluster that does not have latest version. 
Navigate to Settings tab and try to schedule upgrade at a different time.
Observe that date and time are correct for UTC and local. Refer to AFTER screenshot

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <img width="1916" height="1100" alt="image" src="https://github.com/user-attachments/assets/fb704546-edd6-4472-b131-67a914087e95" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
