### PR TITLE
OCMUI-3789: replaced DataFormat on final step upgrade wizard

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeWizard/FinishedStep.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/FinishedStep.tsx
@@ -8,9 +8,10 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   Spinner,
+  Timestamp,
+  TimestampFormat,
 } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import ErrorBox from '../../../../common/ErrorBox';
 
@@ -62,7 +63,15 @@ const FinishedStep = ({
             'the next hour'
           ) : (
             <>
-              one hour of <DateFormat type="exact" date={new Date(upgradeTimestamp!)} />
+              one hour of
+              <Timestamp
+                style={{ fontSize: '1rem' }}
+                date={new Date(upgradeTimestamp!)}
+                shouldDisplayUTC
+                locale="eng-GB"
+                dateFormat={TimestampFormat.medium}
+                timeFormat={TimestampFormat.short}
+              />
             </>
           )}
           .


### PR DESCRIPTION
# Summary

Simple replacement of DataFormat on final step upgrade wizard to PF6 DateFormat

# Jira

[OCMUI-3789](https://issues.redhat.com/browse/OCMUI-3789)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

Create cluster with older version.
Try to manually schedule an upgrade further in the future time.
When upgrade is scheduled you will be presented with confirmation modal where this component is rendered.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <img width="1916" height="1100" alt="image" src="https://github.com/user-attachments/assets/3259fd0d-5005-4593-9260-ed659af03323" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
