### PR TITLE
OCMUI-3750: Fix ability to select AZ when vpc changes

### DIFF
--- a/src/components/clusters/wizards/common/NetworkingSection/AvailabilityZoneSelection.jsx
+++ b/src/components/clusters/wizards/common/NetworkingSection/AvailabilityZoneSelection.jsx
@@ -29,7 +29,8 @@ const AvailabilityZoneSelection = ({
     if (prevVpc.current !== newVpcId && input.value) {
       input.onChange('');
     }
-  }, [input, newVpcId, prevVpc]);
+    prevVpc.current = newVpcId;
+  }, [input, newVpcId]);
 
   const onToggle = (isOpen) => {
     setIsOpen(isOpen);
@@ -112,7 +113,7 @@ AvailabilityZoneSelection.propTypes = {
   }),
   meta: PropTypes.shape({
     touched: PropTypes.bool,
-    error: PropTypes.string,
+    error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   }),
 };
 


### PR DESCRIPTION
# Summary

Fix ability to select AZ when vpc changes.

User cannot select an Availability Zone value from the dropdown after changing the VPC in the "Virtual Private Cloud (VPC) Subnet Settings" step.

# Jira

Fixes [OCMUI-3750](https://issues.redhat.com/browse/OCMUI-3750) -->


# How to Test
0. Create a couple of VPCs in an aws region of your choice. 
1. Open the ROSA wizard.
2. Select the control plane type "Classic architecture."
4. Fill in all required fields in each step
5. Click "Install into existing VPC" and go to Networking > VPC Settings.
6. Select a VPC from the dropdown.
7. Select a different VPC from the dropdown.
8. Try to select a value from the Availability Zone dropdown.
9. You should be able to select an AZ and it actual be selected.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
