### PR TITLE
OCMUI-3827, OCMUI-3828 Transfer ownership button bug

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Owner/Owner.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Owner/Owner.test.tsx
@@ -4,7 +4,7 @@ import {
   ALLOW_EUS_CHANNEL,
   AUTO_CLUSTER_TRANSFER_OWNERSHIP,
 } from '~/queries/featureGates/featureConstants';
-import { mockUseFeatureGate, screen, withState } from '~/testUtils';
+import { mockUseFeatureGate, screen, waitFor, withState } from '~/testUtils';
 
 import fixtures from '../../../__tests__/ClusterDetails.fixtures';
 
@@ -54,6 +54,9 @@ describe('Owner Component', () => {
     withState(initialState).render(<Owner />);
     expect(await screen.findByText('N/A')).toBeInTheDocument();
     expect(screen.queryByText(/Transfer ownership/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Transfer ownership/i })).not.toBeInTheDocument();
+    });
   });
   it('Returns static owner value when HCP ROSA', async () => {
     mockUseFeatureGate([[ALLOW_EUS_CHANNEL, true]]);
@@ -86,7 +89,9 @@ describe('Owner Component', () => {
 
     withState(initialState).render(<Owner />);
     expect(await screen.findByText(testOwner)).toBeInTheDocument();
-    expect(screen.queryByText(/Transfer ownership/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Transfer ownership/i })).not.toBeInTheDocument();
+    });
   });
 
   it('Returns static owner value when OSD', async () => {
@@ -120,12 +125,16 @@ describe('Owner Component', () => {
 
     withState(initialState).render(<Owner />);
     expect(await screen.findByText(testOwner)).toBeInTheDocument();
-    expect(screen.queryByText(/Transfer ownership/i)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Transfer ownership/i })).not.toBeInTheDocument();
+    });
   });
 
-  // reworking this with UXD - test is currently invalid
   it('Returns modal link to transfer owner', async () => {
-    mockUseFeatureGate([[ALLOW_EUS_CHANNEL, true]]);
+    mockUseFeatureGate([
+      [ALLOW_EUS_CHANNEL, true],
+      [AUTO_CLUSTER_TRANSFER_OWNERSHIP, true],
+    ]);
     const useParamsMock = jest.requireMock('react-router-dom').useParams;
     useParamsMock.mockReturnValue({ id: '1msoogsgTLQ4PePjrTOt3UqvMzX' });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Owner/Owner.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Owner/Owner.tsx
@@ -87,7 +87,7 @@ export function Owner() {
     <DescriptionListGroup>
       <DescriptionListTerm>Owner </DescriptionListTerm>
       <DescriptionListDescription>
-        {!showOwnershipTransfer ? OwnerTransferButton : owner}
+        {showOwnershipTransfer ? OwnerTransferButton : owner}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );


### PR DESCRIPTION
# Summary

There are two bugs where the transfer ownership edit button (aka a pencil) is showing when it should not and not showing when it should.

I left in a debugging value when creating OCMUI-3762 also fault unit test passed with debugging value.  This very small PR fixed the debugging value (aka removes a `!` that shouldn't be there) and updates the tests to be accurate.

# Jira
Fixes [OCMUI-3827](https://issues.redhat.com/browse/OCMUI-3827) 
Fixes [OCMUI-3828](https://issues.redhat.com/browse/OCMUI-3828) 

# Additional information

Verified with Zac that this is the correct way the links should work.

# How to Test

- Create the following clusters:
  -  OSD cluster (or use: kim-osd-aws-9-19-2)
  - ROSA HCP cluster (or use: kim-hcp-9-28-1)
  - ROSA classic cluster (or use: kim-rosa-classic-9-29-1)
- Ensure that you are the cluster owner or have cluster editor role (see https://issues.redhat.com/browse/OCMUI-3828 for directions)
- Go to the cluster details > overview tab for each cluster
- Ensure that the edit pencil button is only available on the ROSA Classic cluster and is missing on the other two


# Screen Captures

<img width="351" height="351" alt="Screenshot 2025-09-29 at 10 42 53 AM" src="https://github.com/user-attachments/assets/56bc4a61-98a6-472a-b13b-d0652c26e4c7" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
