### PR TITLE
OCMUI-3672: Disable 'Next' button during OCM roles check in ROSA Classic wizard

### DIFF
--- a/src/components/clusters/wizards/rosa/ClusterRolesScreen/ClusterRolesScreen.jsx
+++ b/src/components/clusters/wizards/rosa/ClusterRolesScreen/ClusterRolesScreen.jsx
@@ -134,11 +134,6 @@ const ClusterRolesScreen = () => {
   }
 
   useEffect(() => {
-    setFieldValue(FieldId.IsGetOCMRolePending, isGetOCMRolePending, false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isGetOCMRolePending]);
-
-  useEffect(() => {
     if (isGetOCMRolePending) {
       setGetOCMRoleErrorBox(null);
     } else if (isGetOCMRoleSuccess) {

--- a/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.jsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.jsx
@@ -17,6 +17,7 @@ import { getScrollErrorIds } from '~/components/clusters/wizards/form/utils';
 import { useFormState } from '~/components/clusters/wizards/hooks';
 import { CreateManagedClusterButtonWithTooltip } from '~/components/common/CreateManagedClusterTooltip';
 import { useCanCreateManagedCluster } from '~/queries/ClusterDetailsQueries/useFetchActionsPermissions';
+import { useFetchGetOCMRole } from '~/queries/RosaWizardQueries/useFetchGetOCMRole';
 
 import { isUserRoleForSelectedAWSAccount } from './AccountsRolesScreen/AccountsRolesScreen';
 import { FieldId } from './constants';
@@ -60,8 +61,6 @@ const CreateRosaWizardFooter = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [steps, setStep]);
 
-  const oCMRoleLoading = values[FieldId.IsGetOCMRolePending] || false;
-
   const awsRequests = useSelector((state) => ({
     accountIDsLoading: state.rosaReducer.getAWSAccountIDsResponse.pending || false,
     accountARNsLoading: state.rosaReducer.getAWSAccountRolesARNsResponse.pending || false,
@@ -72,11 +71,13 @@ const CreateRosaWizardFooter = ({
   const isRefreshingVPCs =
     awsRequests.vpcsLoading && currentStepId === getVpcLoadingStep(isHypershiftSelected);
 
+  const { isPending: isGetOCMRolePending } = useFetchGetOCMRole(values[FieldId.AssociatedAwsId]);
+
   const areAwsResourcesLoading =
     awsRequests.accountIDsLoading ||
     awsRequests.accountARNsLoading ||
     awsRequests.userRoleLoading ||
-    oCMRoleLoading ||
+    isGetOCMRolePending ||
     isRefreshingVPCs;
 
   const isButtonLoading = isValidating || areAwsResourcesLoading;

--- a/src/components/clusters/wizards/rosa/constants.ts
+++ b/src/components/clusters/wizards/rosa/constants.ts
@@ -34,7 +34,6 @@ export enum RosaFieldId {
   DetectedOcmAndUserRoles = 'detected_ocm_and_user_roles',
   EtcdKeyArn = 'etcd_key_arn',
   Hypershift = 'hypershift',
-  IsGetOCMRolePending = 'is_get_ocm_role_pending',
   RosaMaxOsVersion = 'rosa_max_os_version',
   SharedVpc = 'shared_vpc',
   SupportRoleArn = 'support_role_arn',


### PR DESCRIPTION
# Summary

Disable 'Next' button during OCM roles check in ROSA Classic wizard.

'Cluster roles and policies' step was bypassed during the OCM roles check, resulting in cluster submission failures.
This was due to users being able to proceed to the next wizard step while still checking for admin OCM role.

# Jira

Fixes [OCMUI-3672](https://issues.redhat.com/browse/OCMUI-3672)

# Additional information

The issue was that ClusterRolesScreen is using useFetchGetOCMRole (React Query hook)
and in CreateRosaWizardFooter, the loading status is being set by Redux.
As a result, CreateRosaWizardFooter never gets the loading status, and 'pending' it is always set to false - 'Next' button is always enabled.

The fix - The footer retrieves the information directly from the formik values.

# How to Test

1. Login to OCM UI staging.
2. Launch Rosa wizard
3. Select control plane as Rosa classic architecture.
4. Proceed to next step and fill all the required fields in each step.
5. Reach to Networking > CIDR step.
6. Proceed to the next step and quickly click the 'Next' button again to continue without waiting for the OCM role checks to complete in the 'Cluster roles and policies' step
7. Click "Create cluster" button from "Review and create" step.
8. See the behavior.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1232" height="555" alt="image" src="https://github.com/user-attachments/assets/d6452ff2-694c-491c-b7d2-b949555e4901" /> |<img width="1645" height="744" alt="Screenshot From 2025-09-30 15-42-46" src="https://github.com/user-attachments/assets/91604f98-0238-4f1e-b9ac-e304a5d59915" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
