### PR TITLE
OCMUI-3826 - Misleading "Alert and recommendations" banner for archived /Deleted OCP clusters

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
@@ -345,7 +345,8 @@ function ClusterDetailsTop(props) {
   const hasGCPOrgPolicyAlert = !!showGcpOrgPolicyWarning;
   const hasSubscriptionCompliancyAlert =
     isOCP &&
-    (!isArchived || !isDeprovisioned) &&
+    !isArchived &&
+    !isDeprovisioned &&
     (supportLevel === SubscriptionCommonFieldsSupportLevel.Eval ||
       supportLevel === SubscriptionCommonFieldsSupportLevel.None);
   const hasClusterNonEditableAlert = !cluster.canEdit && isAvailableAssistedInstallCluster(cluster);


### PR DESCRIPTION
# Summary

for archived OCP clusters, the count variable hasSubscriptionCompliancyAlert was incorrectly set to true due to an || vs && operator blunder for the variable. This was causing the alerts expandable section to be showing with a value of 1, without having an actual alert in it. 

# Jira


Fixes [OCMUI-3826](https://issues.redhat.com/browse/OCMUI-3826) 


# How to Test

1. From the cluster list, go to the cluster archives and access any OCP cluster
2. The alerts and notifications expandable section should not be showing 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1603" height="684" alt="ocmui3826_before" src="https://github.com/user-attachments/assets/b546fc94-333c-4f97-89d9-e8df6502d473" /> | <img width="880" height="563" alt="ocmui3826_after" src="https://github.com/user-attachments/assets/701fe079-f042-477b-a23d-dc9d61df15d6" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
