### PR TITLE
OCMUI-3790 convert UpgradeTimeSelection to use PF

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeTimeSelection.test.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeTimeSelection.test.tsx
@@ -48,7 +48,7 @@ describe('<UpgradeTimeSelection />', () => {
 
     const radioButton = screen.getByRole('radio', { name: /Schedule a different time/i });
     expect(radioButton).toBeChecked();
-    expect(screen.getByText('06 Jun 2025 22:00 UTC')).toBeInTheDocument();
+    expect(screen.getByText('6 Jun 2025, 22:00 UTC')).toBeInTheDocument();
     await user.click(radioButton);
 
     expect(

--- a/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeTimeSelection.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeTimeSelection.tsx
@@ -12,9 +12,10 @@ import {
   SelectOption,
   Split,
   SplitItem,
+  Timestamp,
+  TimestampFormat,
   Title,
 } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import './UpgradeWizard.scss';
 
@@ -219,7 +220,13 @@ const UpgradeTimeSelection = ({
             <dl className="cluster-upgrade-dl">
               <dt>UTC </dt>
               <dd>
-                <DateFormat type="exact" date={new Date(timestamp)} />
+                <Timestamp
+                  date={new Date(timestamp)}
+                  shouldDisplayUTC
+                  locale="eng-GB"
+                  dateFormat={TimestampFormat.medium}
+                  timeFormat={TimestampFormat.short}
+                />
               </dd>
             </dl>
           </>


### PR DESCRIPTION
# Summary

Convert UpgradeTimeSelect to use PatternFly's Timestamp component. This removes the use of: import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';

NOTE: This did not change how the date/time is received or calculated - only how it is displayed. There is no logic change only presentation.

NOTE: The Date/time has a slightly smaller font. This coming from PatternFly and is expected.

# Jira

Fixes [OCMUI-3790](https://issues.redhat.com/browse/OCMUI-3790)


# How to Test

Create a cluster that is behind the most current OR use cluster kim-osd-aws-9-19-2
Go to the Settings tab
Ensure that "Individual updates" is selected
Click on the "Update" button on the right
Select a version and click next
Choose "Schedule a different time"
Ensure that the text below starting with "UTC" is correctly displayed

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="790" height="491" alt="Screenshot 2025-10-01 at 11 28 44 AM" src="https://github.com/user-attachments/assets/4a0a86e3-3871-452f-9649-02d051b8054c" /> |  <img width="790" height="491" alt="Screenshot 2025-10-01 at 11 28 26 AM" src="https://github.com/user-attachments/assets/e9417f63-b0f4-427e-b4e8-bb900b0a6b9b" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
