### PR TITLE
OCMUI-3792 Convert ContractInfo to use PF Timestamp

### DIFF
--- a/src/components/clusters/wizards/rosa/AccountsRolesScreen/AWSBillingAccount/ContractInfo.tsx
+++ b/src/components/clusters/wizards/rosa/AccountsRolesScreen/AWSBillingAccount/ContractInfo.tsx
@@ -5,8 +5,9 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Timestamp,
+  TimestampFormat,
 } from '@patternfly/react-core';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import { BillingContract, getDimensionValue } from './awsBillingAccountHelper';
 
@@ -16,7 +17,11 @@ const ContractInfo = ({ contract }: { contract: BillingContract }) => (
       <DescriptionListTerm>Start date:</DescriptionListTerm>
       <DescriptionListDescription>
         {contract.start_date ? (
-          <DateFormat type="onlyDate" date={new Date(contract.start_date)} />
+          <Timestamp
+            date={new Date(contract.start_date)}
+            locale="en-GB"
+            dateFormat={TimestampFormat.medium}
+          />
         ) : (
           'N/A'
         )}
@@ -26,7 +31,11 @@ const ContractInfo = ({ contract }: { contract: BillingContract }) => (
       <DescriptionListTerm>End date:</DescriptionListTerm>
       <DescriptionListDescription>
         {contract.end_date ? (
-          <DateFormat type="onlyDate" date={new Date(contract.end_date)} />
+          <Timestamp
+            date={new Date(contract.end_date)}
+            locale="en-GB"
+            dateFormat={TimestampFormat.medium}
+          />
         ) : (
           'N/A'
         )}


### PR DESCRIPTION
# Summary

Convert ContractInfo to use PatternFly's Timestamp component. This removes the use of: import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';

NOTE: This did not change how the date/time is received or calculated - only how it is displayed. There is no logic change only presentation.

NOTE: The Date/time has a slightly smaller font. This coming from PatternFly and is expected.

# Jira

Fixes [OCMUI-3792](https://issues.redhat.com/browse/OCMUI-3792)


# How to Test

This one is not straight forward to test because you either need to change or mock the AWS account to have a particular contract associated. 

With that said, the easiest way to approach this is to remove one check in the code so the date will always appear.  
In `src/components/clusters/wizards/rosa/AccountsRolesScreen/AWSBillingAccount/awsBillingAccountHelper.ts` on line ~16 add `true ||`. so it looks like this:
```
  const isBillingContract = dimensions.some(
    (dimension: ContractDimension) => true ||
      resources.includes(dimension.name || '') && Number(dimension.value || 0) > 0,
  );

```

1. Then go to the ROSA wizard
2. Choose "hosted" control plane
3. Choose any billing account
4. Click on the "Contract enabled for this billing account" link
5. In the popover ensure the date is formatted correctly


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="552" height="386" alt="Screenshot 2025-10-01 at 1 51 37 PM" src="https://github.com/user-attachments/assets/0f4755c6-dac3-4580-aced-48c0f94647ce" />  | <img width="552" height="386" alt="Screenshot 2025-10-01 at 1 57 02 PM" src="https://github.com/user-attachments/assets/11fb047e-843f-4f22-a2f0-7367a94fdff1" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [x] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [x] Updated/created Polarion test cases which were peer QE reviewed
- [x] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
