### PR TITLE
OCMUI-3802 Convert Expiration Alert to PF Timestamp

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import dayjs from 'dayjs';
 import { useDispatch } from 'react-redux';
 
-import { Alert, AlertProps, Button } from '@patternfly/react-core';
+import { Alert, AlertProps, Button, Timestamp, TimestampFormat } from '@patternfly/react-core';
 
 import ExternalLink from '~/components/common/ExternalLink';
 import { modalActions } from '~/components/common/Modal/ModalActions';
@@ -31,7 +31,13 @@ const ExpirationAlert = ({
   const expirationTime = dayjs.utc(expirationTimestamp);
   const hours = expirationTime.diff(now, 'hour');
   const timeUntilExpiryString = now.to(expirationTime);
-  const expirationTimeString = expirationTime.local().format('dddd, MMMM Do YYYY, h:mm a');
+  const expirationTimedate = (
+    <Timestamp
+      date={new Date(expirationTimestamp)}
+      dateFormat={TimestampFormat.full}
+      timeFormat={TimestampFormat.short}
+    />
+  );
 
   const upgradeTrialClusterModal = () => {
     dispatch(
@@ -77,17 +83,17 @@ const ExpirationAlert = ({
       variant = 'info';
   }
 
-  let contents: string | React.ReactElement =
-    `This cluster is scheduled for deletion on ${expirationTimeString}`;
+  let contents: string | React.ReactElement = (
+    <>This cluster is scheduled for deletion on {expirationTimedate}</>
+  );
   if (OSDRHMExpiration) {
     contents = hideRHMarketplace ? (
       <>Once expired, the cluster will be deleted permanently.</>
     ) : (
       <>
-        Your cluster subscription was purchased from Red Hat Marketplace and will expire on
-        {` ${expirationTimeString}. `}
-        Once expired, the cluster will be deleted permanently. To avoid deletion, please purchase a
-        new subscription from the{' '}
+        Your cluster subscription was purchased from Red Hat Marketplace and will expire on{' '}
+        {expirationTimedate}. Once expired, the cluster will be deleted permanently. To avoid
+        deletion, please purchase a new subscription from the{' '}
         <ExternalLink href="https://marketplace.redhat.com/en-us/products/red-hat-openshift-dedicated">
           Red Hat Marketplace
         </ExternalLink>{' '}
@@ -95,7 +101,12 @@ const ExpirationAlert = ({
       </>
     );
   } else if (trialExpiration) {
-    contents = `Your free trial cluster will automatically be deleted on ${expirationTimeString}. Upgrade your cluster at any time to prevent deletion.`;
+    contents = (
+      <>
+        Your free trial cluster will automatically be deleted on {expirationTimedate}. Upgrade your
+        cluster at any time to prevent deletion.
+      </>
+    );
   }
 
   return (

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/__tests__/ExpirationAlert.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/__tests__/ExpirationAlert.test.tsx
@@ -46,7 +46,7 @@ describe('<ExpirationAlert />', () => {
       const expirationTimeString = dayjs
         .utc(expirationTimestamp)
         .local()
-        .format('dddd, MMMM Do YYYY, h:mm a');
+        .format('dddd, MMMM D, YYYY [at] h:mm A');
 
       // Act
       render(<ExpirationAlert expirationTimestamp={expirationTimestamp} />);
@@ -121,7 +121,7 @@ describe('<ExpirationAlert />', () => {
         const expirationTimeString = dayjs
           .utc(expirationTimestamp)
           .local()
-          .format('dddd, MMMM Do YYYY, h:mm a');
+          .format('dddd, MMMM D, YYYY [at] h:mm A');
 
         // Act
         render(<ExpirationAlert expirationTimestamp={expirationTimestamp} OSDRHMExpiration />);


### PR DESCRIPTION
# Summary

Convert ExpirationAlert to use PatternFly's Timestamp component. This removes the use of custom formatting from dayJS. 

NOTE: This did not change how the date/time is received or calculated - only how it is displayed. There is no logic change only presentation.

NOTE: The Date/time has a slightly smaller font and other small text changes including from 'am' to "AM" and using the word "at" between date and time. This coming from PatternFly and is expected.

# Jira

Fixes [OCMUI-3802](https://issues.redhat.com/browse/OCMUI-3802)

# Additional information

The way the unit tests are constructed aren't great and they use dayJS to confirm the date format which isn't great either.  This is difficult because we can't send in a static date because logic inside the ExpirationAlert component compares to today.  I decided dramatically changing the unit tests was beyond the scope of this PR and made only the needed adjustments.

# How to Test
This date logic is used in numerous alerts on the cluster details including:

- "This cluster is scheduled for deletion on ..." alert
- "Your cluster subscription was purchased from Red Hat Marketplace and will expire on ..." alert
- "Your free trial cluster will automatically be deleted on ..." alert

But all the displayed date/time all point to the same code, so for code-level reviews, only checking one is probably enough:

- Go to the cluster details for any cluster that is to be automatically deleted.  (I used daz-hcp-1)
- Expand the Alerts section
- Look for the "This cluster will be deleted in a day" alert
- Verify that the date and time are in the expected format.

# Screen Captures

Before: <img width="1118" height="116" alt="Screenshot 2025-10-02 at 9 37 37 AM" src="https://github.com/user-attachments/assets/3fdab476-583b-4feb-8065-6fa9ed696b0e" />

After: 
<img width="1118" height="116" alt="Screenshot 2025-10-02 at 9 37 22 AM" src="https://github.com/user-attachments/assets/ce1aa4d6-e4e3-4f88-bec3-597189a1e9eb" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
