### PR TITLE
OCMUI-3803 convert ClusterCreatedIndicator to PF Timestamp

### DIFF
--- a/src/components/clusters/ClusterListMultiRegion/components/ClusterCreatedIndicator.jsx
+++ b/src/components/clusters/ClusterListMultiRegion/components/ClusterCreatedIndicator.jsx
@@ -3,10 +3,16 @@ import dayjs from 'dayjs';
 import get from 'lodash/get';
 import PropTypes from 'prop-types';
 
-import { Button, Icon, Popover, PopoverPosition } from '@patternfly/react-core';
+import {
+  Button,
+  Icon,
+  Popover,
+  PopoverPosition,
+  Timestamp,
+  TimestampFormat,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 
 import { SubscriptionCommonFieldsSupport_level as SubscriptionCommonFieldsSupportLevel } from '~/types/accounts_mgmt.v1';
 
@@ -105,7 +111,11 @@ function ClusterCreatedIndicator({ cluster }) {
         {OCPTrialExpiresStr}
         &nbsp;on&nbsp;
         <strong>
-          <DateFormat date={subscription.eval_expiration_date} type="onlyDate" />
+          <Timestamp
+            date={new Date(subscription.eval_expiration_date)}
+            dateFormat={TimestampFormat.medium}
+            locale="en-GB"
+          />
         </strong>
         .&nbsp;Your cluster is not&nbsp;
         <ExternalLink


### PR DESCRIPTION
# Summary

Convert UpgradeTimeSelect to use PatternFly's Timestamp component. This removes the use of: import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';

NOTE: This did not change how the date/time is received or calculated - only how it is displayed. There is no logic change only presentation.

# Jira

Fixes [OCMUI-3803](https://issues.redhat.com/browse/OCMUI-3803) 


# How to Test

On the cluster list, identify an OCP cluster that has an expiration date (I used d260aa11-1e46-4090-bf70-8feea5b9b049)
In the "Created" column, click on the "days left" link
In the popover, verify that the date is formatted as expected

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="353" height="223" alt="Screenshot 2025-10-02 at 11 06 06 AM" src="https://github.com/user-attachments/assets/85350c19-acb7-42a3-b717-7dd350086e2d" /> | <img width="353" height="223" alt="Screenshot 2025-10-02 at 11 06 36 AM" src="https://github.com/user-attachments/assets/c3ef9078-50d4-4ea4-af2c-8b7d5fae2a78" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
