### PR TITLE
OCMUI-3663: Fix crash on Machine pool update

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolsTable.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolsTable.jsx
@@ -150,7 +150,7 @@ export const MachinePoolsTable = ({
   );
 
   const onClickUpdateAction = React.useCallback(
-    (_, __, machinePool) =>
+    (machinePool) =>
       dispatch(
         openModal(modals.UPDATE_MACHINE_POOL_VERSION, {
           machinePool,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/UpdateMachinePools/UpdateMachinePoolModal.tsx
@@ -205,7 +205,7 @@ export const UpdateMachinePoolModal = ({
     >
       {!pending && !!error ? (
         <Alert
-          title={`Machine pool ${machinePool.id} could not be updated`}
+          title={`Machine pool ${machinePool?.id} could not be updated`}
           variant={AlertVariant.danger}
           isExpandable
           isInline
@@ -216,7 +216,7 @@ export const UpdateMachinePoolModal = ({
         </Alert>
       ) : (
         <p>
-          Update machine pool {machinePool.id} to version{' '}
+          Update machine pool {machinePool?.id} to version{' '}
           {displayControlPlaneVersion(controlPlaneVersion)}?
         </p>
       )}


### PR DESCRIPTION
# Summary

Action resolver was updated a little bit ago to change the function parameters to only accept a machinePool object.  However, the click action onClickUpdateAction still had the old parameters.  I updated the parameters and now we are sending the machinePool object properly to the modal window.

The machine pool and machine pool table files are jsx while the update files and helper files are typescript.  I would guess we would not have had this issue if we had strong typed the functions.  

# Jira

Fixes [OCMUI-3663](https://issues.redhat.com/browse/OCMUI-3663) 

# Additional information

I did not try to convert the machine pool files to typescript as this is a critical bug that needs to be fix ASAP.  We do have a backlog item to convert these files in the future and hopefully silly bugs like this will be prevented.

# How to Test

1. Create/open ready HCP cluster
2. On the command line run: `rosa create machinepool -c cluster-name-here`
3. This will create an interactive prompt.  When prompted for version, select an old 4.18.x version.  The version is key here.
4. Use defaults for the rest of the inputs
5. Once the machine pool is created, go to the details page for the cluster
6. Go to the Machine Pools tab
7. Your new machine pool should be in the table and should `update` next to the version.
8. Using the 3 dot action menu, select `Update version`
9. This should bring up a screen that says update the machine pool to the latest version.  It should not through an error.

# screenshots
<img width="1287" height="303" alt="Screenshot From 2025-10-06 19-02-47" src="https://github.com/user-attachments/assets/1e2ef262-bd3b-446c-9292-ea1d25c968c2" />
<img width="855" height="438" alt="Screenshot From 2025-10-06 19-02-21" src="https://github.com/user-attachments/assets/5ddd5827-d7c7-43ff-adc1-3c59c956bb63" />




# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
