### PR TITLE
[OCMUI-1874]Updated Rosa hosted wizard(day1) test cases to cover security group definition

### DIFF
--- a/cypress/e2e/rosa-hosted/RosaClusterHostedCreation.js
+++ b/cypress/e2e/rosa-hosted/RosaClusterHostedCreation.js
@@ -9,6 +9,7 @@ const region = clusterProperties.Region.split(',')[0];
 const awsAccountID = Cypress.env('QE_AWS_ID');
 const awsBillingAccountID = Cypress.env('QE_AWS_BILLING_ID');
 const qeInfrastructure = Cypress.env('QE_INFRA_REGIONS')[region][0];
+const securityGroups = qeInfrastructure.SECURITY_GROUPS_NAME;
 const rolePrefix = Cypress.env('QE_ACCOUNT_ROLE_PREFIX');
 const installerARN = `arn:aws:iam::${awsAccountID}:role/${rolePrefix}-HCP-ROSA-Installer-Role`;
 const clusterName = `smoke-cypress-rosa-hypershift-${(Math.random() + 1).toString(36).substring(7)}`;
@@ -83,6 +84,13 @@ describe(
         .clear()
         .type('{selectAll}')
         .type(clusterProperties.MachinePools[0].RootDiskSize);
+      CreateRosaWizardPage.additionalSecurityGroupsLink().click();
+      cy.contains('h4', clusterProperties.MachinePools[0].SecurityGroupsInfoNote).should(
+        'be.visible',
+      );
+      securityGroups.forEach((value) => {
+        CreateRosaWizardPage.selectAdditionalSecurityGroups(value);
+      });
       CreateRosaWizardPage.rosaNextButton().click();
     });
 
@@ -182,6 +190,9 @@ describe(
         'Instance Metadata Service (IMDS)',
         clusterProperties.InstanceMetadataService,
       );
+      securityGroups.forEach((value) => {
+        cy.contains(value).scrollIntoView().should('be.visible').should('be.exist');
+      });
     });
 
     it('Step - Review and create : Networking definitions', () => {

--- a/cypress/fixtures/rosa-hosted/RosaClusterHostedCreation.json
+++ b/cypress/fixtures/rosa-hosted/RosaClusterHostedCreation.json
@@ -29,7 +29,8 @@
       "AvailabilityZones": "us-west-2a",
       "NodeCount": "4",
       "Autoscaling": "Disabled",
-      "RootDiskSize": "555"
+      "RootDiskSize": "555",
+      "SecurityGroupsInfoNote": "You cannot add or edit security groups associated with machine pools that were created during cluster creation"
     }
   ],
   "networking": {


### PR DESCRIPTION
# Summary

Updated Rosa hosted wizard test cases to cover security group definition in day 1 

# Jira
Fixes [OCMUI-1874](https://issues.redhat.com/browse/OCMUI-1874)

# Additional information

Updated Rosa hosted wizard test cases to cover security group definition in day 1 


# How to Test
Launch the local server from the PR using reviewx tool
```
reviewx 158
```

Run the test case
```
npx cypress run --browser chrome --config baseUrl='https://prod.foo.redhat.com:1337/openshift/' --spec  cypress/e2e/rosa-hosted/RosaClusterHostedCreation.js
```

# Screen Captures

nil

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
