### PR TITLE
[OCMUI-4011]Fix for failing cluster requests test case

### DIFF
--- a/cypress/e2e/clusters/ClusterRequests.js
+++ b/cypress/e2e/clusters/ClusterRequests.js
@@ -16,6 +16,7 @@ describe(
       ClusterRequestPage.isClusterRequestsUrl();
       ClusterRequestPage.isClusterRequestsScreen();
       ClusterRequestPage.isClusterTranferRequestHeaderPage();
+      ClusterRequestPage.clusterTransferRequestHelpIcon().click();
       ClusterRequestPage.isClusterTranferRequestContentPage(
         'Transfer cluster ownership so that another user in your organization or another organization can manage this cluster',
       );

--- a/cypress/pageobjects/ClusterRequests.page.js
+++ b/cypress/pageobjects/ClusterRequests.page.js
@@ -5,12 +5,15 @@ class ClusterRequests extends Page {
     super.assertUrlIncludes('/openshift/cluster-request');
   }
 
+  clusterTransferRequestHelpIcon = () =>
+    cy.contains('Cluster transfer ownership request').parent().find('button');
+
   isClusterRequestsScreen() {
     cy.contains('h1', 'Cluster Requests');
   }
 
-  isClusterTranferRequestHeaderPage(headerName = 'Transfer Ownership Request') {
-    cy.contains('h2', headerName).should('be.visible');
+  isClusterTranferRequestHeaderPage(headerName = 'Cluster transfer ownership request') {
+    cy.contains(headerName).should('be.visible');
   }
 
   isClusterTranferRequestContentPage(content) {


### PR DESCRIPTION
# Summary
Fixed failing cluster requests test case

# Jira
 Fixes [OCMUI-4011](https://issues.redhat.com/browse/OCMUI-4011)

# Additional information
Quick fix for cluster requests test case based on cluster request page definition change.

# How to Test

Run the test case
`npx cypress run --browser chrome --config baseUrl='https://console.dev.redhat.com/openshift/' --spec  cypress/e2e/clusters/ClusterRequests.js`

# Screen Captures

<img width="1841" height="822" alt="Screenshot 2025-11-19 at 12 24 31 PM" src="https://github.com/user-attachments/assets/8bb97b85-e0cb-453c-b753-941b8fd207d8" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation

## Summary by Sourcery

Update ClusterRequests page object and Cypress test to fix the failing cluster requests test case after the transfer request page content changed

Bug Fixes:
- Fix failing cluster requests test case after page definition change

Enhancements:
- Add method to locate the cluster transfer request help icon in the page object
- Update header locator to match the revised transfer request page title

Tests:
- Click the help icon before verifying the transfer request content in the Cypress spec

[OCMUI-4011]: https://redhat.atlassian.net/browse/OCMUI-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ