### PR TITLE
OCMUI-4265, OCMUI-4270:  Add/Edit machine pool HCP - allow 0 min nodes

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
@@ -728,15 +728,6 @@ describe('isEnforcedDefaultMachinePool', () => {
         false,
         0,
       ],
-      [
-        'empty cluster, it is hypershift the rest undefined',
-        {},
-        undefined,
-        undefined,
-        undefined,
-        true,
-        2,
-      ],
     ])(
       '%p',
       (

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/EditMachinePoolModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/EditMachinePoolModal.tsx
@@ -405,10 +405,12 @@ const EditMachinePoolModal = ({
                 }}
               />
             )}
-            {isMaxReached ? (
-              <Tooltip content="Maximum cluster node count limit reached">
+            {(() => {
+              const nodeCount = values.autoscaling ? values.autoscaleMax : values.replicas;
+              const isDisabled = !!isMaxReached && nodeCount > 0;
+              const button = (
                 <SubmitButton
-                  isMaxReached={isMaxReached}
+                  isMaxReached={isDisabled}
                   isValid={isValid}
                   isSubmitting={isSubmitting}
                   machinePoolsResponse={machinePoolsResponse || []}
@@ -418,20 +420,13 @@ const EditMachinePoolModal = ({
                   submitForm={submitForm}
                   isEdit={isEdit}
                 />
-              </Tooltip>
-            ) : (
-              <SubmitButton
-                isMaxReached={isMaxReached || false}
-                isValid={isValid}
-                isSubmitting={isSubmitting}
-                machinePoolsResponse={machinePoolsResponse || []}
-                machineTypesResponse={machineTypesResponse}
-                initialValues={initialValues}
-                values={values}
-                submitForm={submitForm}
-                isEdit={isEdit}
-              />
-            )}
+              );
+              return isDisabled ? (
+                <Tooltip content="Maximum cluster node count limit reached">{button}</Tooltip>
+              ) : (
+                button
+              );
+            })()}
             <Button
               variant="link"
               isDisabled={isSubmitting}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMaxReplicasField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMaxReplicasField.tsx
@@ -33,6 +33,9 @@ const AutoscaleMaxReplicasField = ({
   const isMultizoneMachinePool = isMPoolAz(cluster, mpAvailZones);
   const isRosa = normalizeProductID(cluster.product?.id) === normalizedProducts.ROSA;
 
+  const isHcp = isHypershiftCluster(cluster);
+  const minAllowed = isHcp ? 0 : 1;
+
   const minNodes = isMultizoneMachinePool ? initMinNodes / 3 : initMinNodes;
   const maxNodes = isMultizoneMachinePool ? initMaxNodes / 3 : initMaxNodes;
 
@@ -47,6 +50,7 @@ const AutoscaleMaxReplicasField = ({
   return (
     <FormGroup
       fieldId={fieldId}
+      data-testid="autoscale-max-group"
       label="Maximum nodes count"
       isRequired
       labelHelp={
@@ -77,7 +81,7 @@ const AutoscaleMaxReplicasField = ({
           helpers.setTouched(true, false);
         }}
         id={fieldId}
-        min={minNodes || 1}
+        min={Math.max(minNodes, minAllowed)}
         max={maxNodes}
         inputProps={{
           onBlur: (event: React.FocusEvent<HTMLInputElement>) => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMinReplicasField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMinReplicasField.tsx
@@ -47,7 +47,7 @@ const AutoscaleMinReplicasField = ({
           helpers.setTouched(true, false);
         }}
         id={fieldId}
-        min={minNodes || 1}
+        min={minNodes ?? 1}
         max={maxNodes}
         inputProps={{
           onBlur: (event: React.FocusEvent<HTMLInputElement>) => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -138,6 +138,135 @@ describe('useMachinePoolFormik', () => {
   });
 
   describe('validationSchema', () => {
+    describe('autoscaleMin', () => {
+      it('should allow 0 min nodes for HCP clusters with autoscaling enabled', async () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          autoscaling: {
+            min_replicas: 0,
+            max_replicas: 5,
+          },
+        };
+
+        const otherPool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          replicas: 3,
+        };
+
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        const values = {
+          ...hyperShiftExpectedInitialValues,
+          autoscaling: true,
+          autoscaleMin: 0,
+          autoscaleMax: 5,
+        };
+
+        await expect(validationSchema.validateAt('autoscaleMin', values)).resolves.toBe(0);
+      });
+    });
+
+    describe('replicas', () => {
+      it('should allow 0 replicas for HCP clusters with autoscaling disabled', async () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          replicas: 0,
+        };
+
+        const otherPool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          replicas: 3,
+        };
+
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        const values = {
+          ...hyperShiftExpectedInitialValues,
+          autoscaling: false,
+          replicas: 0,
+        };
+
+        await expect(validationSchema.validateAt('replicas', values)).resolves.toBe(0);
+      });
+    });
+
+    describe('autoscaleMax', () => {
+      it('should allow 0 max nodes for HCP clusters with autoscaling enabled', async () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          autoscaling: {
+            min_replicas: 0,
+            max_replicas: 0,
+          },
+        };
+
+        const otherPool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          replicas: 3,
+        };
+
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        const values = {
+          ...hyperShiftExpectedInitialValues,
+          autoscaling: true,
+          autoscaleMin: 0,
+          autoscaleMax: 0,
+        };
+
+        await expect(validationSchema.validateAt('autoscaleMax', values)).resolves.toBe(0);
+      });
+
+      it('should reject 0 max nodes for non-HCP clusters with autoscaling enabled', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          autoscaling: true,
+          autoscaleMin: 0,
+          autoscaleMax: 0,
+        };
+
+        await expect(validationSchema.validateAt('autoscaleMax', values)).rejects.toThrow(
+          'Max nodes must be greater than 0.',
+        );
+      });
+    });
+
     describe('capacityReservationId', () => {
       it.each(['open', 'none', 'capacity-reservations-only'])(
         'should not require capacityReservationId when preference is %s',

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -63,6 +63,80 @@ describe('useMachinePoolFormik', () => {
     expect(initialValues).toEqual(expected);
   });
 
+  describe('initialValues autoscaling', () => {
+    describe('HCP clusters', () => {
+      it('should set autoscaleMin to minNodesRequired', () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          replicas: 3,
+        };
+
+        const otherPool = {
+          kind: 'NodePool2',
+          id: 'other-pool2',
+          replicas: 3,
+        };
+
+        const { initialValues } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        expect(initialValues.autoscaleMin).toBe(0);
+        expect(initialValues.autoscaleMax).toBe(0);
+      });
+
+      it('should preserve existing autoscaling min_replicas of 0', () => {
+        const machinePoolWithZeroMin = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          autoscaling: {
+            min_replicas: 0,
+            max_replicas: 10,
+          },
+        };
+
+        const { initialValues } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool: machinePoolWithZeroMin,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePoolWithZeroMin],
+          }),
+        ).result.current;
+
+        expect(initialValues.autoscaleMin).toBe(0);
+        expect(initialValues.autoscaleMax).toBe(10);
+      });
+    });
+
+    describe('Non-HCP clusters', () => {
+      it('should allow autoscaleMin of 0 when minNodesRequired is 0', () => {
+        const machinePool = {
+          kind: 'MachinePool',
+          id: 'test-pool',
+          replicas: 0,
+        };
+
+        const { initialValues } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool],
+          }),
+        ).result.current;
+
+        expect(initialValues.autoscaleMin).toBe(0);
+      });
+    });
+  });
+
   describe('validationSchema', () => {
     describe('capacityReservationId', () => {
       it.each(['open', 'none', 'capacity-reservations-only'])(

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -124,8 +124,8 @@ const useMachinePoolFormik = ({
     let capacityReservationId;
     let capacityReservationPreference;
 
-    autoscaleMin = (machinePool as MachinePool)?.autoscaling?.min_replicas || minNodesRequired;
-    autoscaleMax = (machinePool as MachinePool)?.autoscaling?.max_replicas || minNodesRequired;
+    autoscaleMin = (machinePool as MachinePool)?.autoscaling?.min_replicas ?? minNodesRequired;
+    autoscaleMax = (machinePool as MachinePool)?.autoscaling?.max_replicas ?? minNodesRequired;
 
     const instanceTypeId = (machinePool as MachinePool)?.instance_type;
     const instanceType = (

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -162,7 +162,7 @@ const useMachinePoolFormik = ({
       autoscaling: !!machinePool?.autoscaling,
       auto_repair: autoRepair,
       autoscaleMin,
-      autoscaleMax: autoscaleMax || 1,
+      autoscaleMax: isHypershift ? autoscaleMax : autoscaleMax || 1,
       replicas,
       labels: machinePool?.labels
         ? Object.keys(machinePool.labels).map((key) => ({
@@ -375,7 +375,14 @@ const useMachinePoolFormik = ({
                       'autoscaleMax',
                     );
                   }
-                  if (value !== undefined && value < 1) {
+                  if (value !== undefined && value < 0) {
+                    return new Yup.ValidationError(
+                      'Max nodes cannot be negative.',
+                      value,
+                      'autoscaleMax',
+                    );
+                  }
+                  if (value !== undefined && value < 1 && !isHypershift) {
                     return new Yup.ValidationError(
                       'Max nodes must be greater than 0.',
                       value,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
@@ -144,4 +144,195 @@ describe('<EditNodeCountSection />', () => {
       expect(link).toHaveAttribute('href', docLinks.OSD_CLUSTER_AUTOSCALING);
     });
   });
+
+  describe('HCP cluster minimum node requirements', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('allows 0 minimum nodes for tainted machine pool in HCP cluster', async () => {
+      const taintedMachinePool = {
+        id: 'tainted-pool',
+        replicas: 1,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+        taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+      };
+
+      const otherPool = {
+        id: 'other-pool',
+        replicas: 2,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 1, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[otherPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={taintedMachinePool}
+          />
+        </Formik>,
+      );
+
+      const nodeCountInput = screen.getByLabelText('Compute nodes') as HTMLInputElement;
+      const minusButton = screen.getByLabelText('Decrement compute nodes');
+
+      await user.click(minusButton);
+      expect(nodeCountInput.value).toBe('0');
+    });
+
+    it('allows 0 minimum nodes for untainted pool when other pools have 2+ untainted nodes in HCP cluster', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        replicas: 1,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const otherPool = {
+        id: 'other-pool',
+        replicas: 3,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 1, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[otherPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const nodeCountInput = screen.getByLabelText('Compute nodes') as HTMLInputElement;
+      const minusButton = screen.getByLabelText('Decrement compute nodes');
+
+      await user.click(minusButton);
+      expect(nodeCountInput.value).toBe('0');
+    });
+
+    it('requires 1 minimum node for untainted pool when other pools have 1 untainted node in HCP cluster', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        replicas: 2,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const otherPool = {
+        id: 'other-pool',
+        replicas: 1,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 2, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[otherPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const nodeCountInput = screen.getByLabelText('Compute nodes') as HTMLInputElement;
+      const minusButton = screen.getByLabelText('Decrement compute nodes');
+
+      // Decrement once: 2 -> 1 (should work)
+      await user.click(minusButton);
+      expect(nodeCountInput.value).toBe('1');
+      expect(minusButton).toBeDisabled();
+    });
+
+    it('requires 2 minimum nodes for untainted pool when other pools have 0 untainted nodes in HCP cluster', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        replicas: 3,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const taintedPool = {
+        id: 'tainted-pool',
+        replicas: 3,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+        taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+      };
+
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 3, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[taintedPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const nodeCountInput = screen.getByLabelText('Compute nodes') as HTMLInputElement;
+      const minusButton = screen.getByLabelText('Decrement compute nodes');
+
+      // Decrement once: 3 -> 2 (should work)
+      await user.click(minusButton);
+      expect(nodeCountInput.value).toBe('2');
+      expect(minusButton).toBeDisabled();
+    });
+
+    it('requires 2 minimum nodes for untainted pool when no other pools exist in HCP cluster', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        replicas: 2,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      withState(initialState).render(
+        <Formik
+          initialValues={{ replicas: 2, instanceType: 'm5.xlarge', autoscaling: false }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[currentPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const nodeCountInput = screen.getByLabelText('Compute nodes') as HTMLInputElement;
+      const minusButton = screen.getByLabelText('Decrement compute nodes');
+
+      // Should not be able to decrement below 2
+      expect(nodeCountInput.value).toBe('2');
+      expect(minusButton).toBeDisabled();
+    });
+  });
 });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Formik } from 'formik';
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import docLinks from '~/common/docLinks.mjs';
 import * as utils from '~/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/components/utils';
@@ -142,6 +142,75 @@ describe('<EditNodeCountSection />', () => {
 
       const link = screen.getByText('Learn more about autoscaling');
       expect(link).toHaveAttribute('href', docLinks.OSD_CLUSTER_AUTOSCALING);
+    });
+
+    it('does not allow 0 max replicas for classic (non-HCP) cluster', async () => {
+      withState(initialState).render(
+        <Formik
+          initialValues={{
+            autoscaling: true,
+            autoscaleMin: 1,
+            autoscaleMax: 1,
+            instanceType: { id: 'm5.xlarge' },
+          }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={nonHCPCluster}
+            machinePool={defaultMachinePool}
+          />
+        </Formik>,
+      );
+
+      const autoScaleMaxNodesFormGroup = screen.getByTestId('autoscale-max-group');
+      const autoscaleMaxNodesInput = within(autoScaleMaxNodesFormGroup).getByRole(
+        'spinbutton',
+      ) as HTMLInputElement;
+      expect(autoscaleMaxNodesInput.value).toBe('1');
+
+      const autoscaleMaxNodesMinusButton = within(autoScaleMaxNodesFormGroup).getByRole('button', {
+        name: 'Minus',
+      });
+      expect(autoscaleMaxNodesMinusButton).toBeDisabled();
+    });
+
+    it('allows 0 max replicas for HCP cluster', async () => {
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{
+            autoscaling: true,
+            autoscaleMin: 0,
+            autoscaleMax: 1,
+            instanceType: { id: 'm5.xlarge' },
+          }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[defaultMachinePool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={{}}
+          />
+        </Formik>,
+      );
+
+      const autoScaleMaxNodesFormGroup = screen.getByTestId('autoscale-max-group');
+      const autoscaleMaxNodesInput = within(autoScaleMaxNodesFormGroup).getByRole(
+        'spinbutton',
+      ) as HTMLInputElement;
+      expect(autoscaleMaxNodesInput.value).toBe('1');
+
+      const autoscaleMaxNodesMinusButton = within(autoScaleMaxNodesFormGroup).getByRole('button', {
+        name: 'Minus',
+      });
+      expect(autoscaleMaxNodesMinusButton).not.toBeDisabled();
+
+      await user.click(autoscaleMaxNodesMinusButton);
+      expect(autoscaleMaxNodesInput.value).toBe('0');
     });
   });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
@@ -1,0 +1,263 @@
+import { ClusterFromSubscription } from '~/types/types';
+
+import { countReplicasWithoutTaints, getClusterMinNodes } from './machinePoolsHelper';
+
+const hcpCluster = {
+  product: { id: 'ROSA' },
+  cloud_provider: { id: 'aws' },
+  hypershift: { enabled: true },
+} as ClusterFromSubscription;
+
+describe('machinePoolsHelper', () => {
+  describe('countReplicasWithoutTaints', () => {
+    it('returns 0 for empty array', () => {
+      expect(countReplicasWithoutTaints([])).toBe(0);
+    });
+
+    it('counts replicas from untainted pools', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 3 },
+        { id: 'pool-2', replicas: 5 },
+      ];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(8);
+    });
+
+    it('ignores tainted pools', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 3 },
+        {
+          id: 'pool-2',
+          replicas: 5,
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        },
+      ];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(3);
+    });
+
+    it('excludes pool by id when excludePoolId is provided', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 3 },
+        { id: 'pool-2', replicas: 5 },
+      ];
+
+      expect(countReplicasWithoutTaints(pools, 'pool-1')).toBe(5);
+    });
+
+    it('uses autoscaling min_replicas when available', () => {
+      const pools = [
+        { id: 'pool-1', autoscaling: { min_replicas: 2, max_replicas: 10 } },
+        { id: 'pool-2', replicas: 3 },
+      ];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(5);
+    });
+
+    it('prefers autoscaling min_replicas over replicas', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 10, autoscaling: { min_replicas: 2, max_replicas: 10 } },
+      ];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(2);
+    });
+
+    it('handles mixed tainted and untainted pools with exclusion', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 2 },
+        {
+          id: 'pool-2',
+          replicas: 3,
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        },
+        { id: 'pool-3', replicas: 4 },
+        { id: 'pool-4', autoscaling: { min_replicas: 1, max_replicas: 5 } },
+      ];
+
+      expect(countReplicasWithoutTaints(pools, 'pool-1')).toBe(5); // pool-3 (4) + pool-4 (1)
+    });
+
+    it('ignores pools with empty taints array', () => {
+      const pools = [
+        { id: 'pool-1', replicas: 3, taints: [] },
+        { id: 'pool-2', replicas: 5 },
+      ];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(8);
+    });
+  });
+
+  describe('getClusterMinNodes', () => {
+    describe('HCP clusters', () => {
+      it('returns 0 for tainted machine pool', () => {
+        const taintedPool = {
+          id: 'tainted-pool',
+          replicas: 2,
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        };
+
+        const otherPool = {
+          id: 'other-pool',
+          replicas: 2,
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: taintedPool,
+          machinePools: [otherPool, taintedPool],
+        });
+
+        expect(result).toBe(0);
+      });
+
+      it('returns 0 when other pools have 2+ untainted nodes', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 1,
+        };
+
+        const otherPool = {
+          id: 'other-pool',
+          replicas: 3,
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [otherPool, currentPool],
+        });
+
+        expect(result).toBe(0);
+      });
+
+      it('returns 1 when other pools have 1 untainted node', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 2,
+        };
+
+        const otherPool = {
+          id: 'other-pool',
+          replicas: 1,
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [otherPool, currentPool],
+        });
+
+        expect(result).toBe(1);
+      });
+
+      it('returns 2 when other pools have 0 untainted nodes', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 2,
+        };
+
+        const taintedPool = {
+          id: 'tainted-pool',
+          replicas: 3,
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [taintedPool, currentPool],
+        });
+
+        expect(result).toBe(2);
+      });
+
+      it('returns 2 when no other pools exist', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 2,
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [currentPool],
+        });
+
+        expect(result).toBe(2);
+      });
+
+      it('counts autoscaling min_replicas when calculating other pools', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 1,
+        };
+
+        const autoscalingPool = {
+          id: 'autoscaling-pool',
+          autoscaling: {
+            min_replicas: 3,
+            max_replicas: 10,
+          },
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [autoscalingPool, currentPool],
+        });
+
+        expect(result).toBe(0);
+      });
+
+      it('ignores tainted pools when counting replicas', () => {
+        const currentPool = {
+          id: 'current-pool',
+          replicas: 1,
+        };
+
+        const taintedPool1 = {
+          id: 'tainted-pool-1',
+          replicas: 5,
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        };
+
+        const taintedPool2 = {
+          id: 'tainted-pool-2',
+          autoscaling: {
+            min_replicas: 3,
+            max_replicas: 10,
+          },
+          taints: [{ key: 'test', value: 'true', effect: 'NoSchedule' }],
+        };
+
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: currentPool,
+          machinePools: [taintedPool1, taintedPool2, currentPool],
+        });
+
+        // All other pools are tainted, so current pool needs minimum 2
+        expect(result).toBe(2);
+      });
+
+      it('returns 2 when adding first pool to empty HCP cluster (machinePool undefined)', () => {
+        const result = getClusterMinNodes({
+          cluster: hcpCluster,
+          machineTypesResponse: {},
+          machinePool: undefined,
+          machinePools: [],
+        });
+
+        // First pool being added to empty cluster needs minimum 2
+        expect(result).toBe(2);
+      });
+    });
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
@@ -253,11 +253,11 @@ const normalizeNodePool = (nodePool: NodePool) => {
   const normalizedNodePool = { ...nodePool, instance_type: nodePool.aws_node_pool?.instance_type };
   if (nodePool.autoscaling) {
     normalizedNodePool.autoscaling = { ...nodePool.autoscaling };
-    if (nodePool.autoscaling?.min_replica && nodePool.autoscaling?.min_replica > 0) {
+    if (nodePool.autoscaling?.min_replica !== undefined) {
       (normalizedNodePool as any).autoscaling.min_replicas = nodePool.autoscaling.min_replica;
       delete normalizedNodePool.autoscaling.min_replica;
     }
-    if (nodePool.autoscaling?.max_replica && nodePool.autoscaling?.max_replica > 0) {
+    if (nodePool.autoscaling?.max_replica !== undefined) {
       (normalizedNodePool as any).autoscaling.max_replicas = nodePool.autoscaling.max_replica;
       delete normalizedNodePool.autoscaling.max_replica;
     }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
@@ -142,6 +142,14 @@ const isEnforcedDefaultMachinePool = (
     });
 };
 
+const countReplicasWithoutTaints = (machinePools: MachinePool[], excludePoolId?: string) =>
+  machinePools?.reduce((count, pool) => {
+    if (pool.id !== excludePoolId && !pool.taints?.length) {
+      return count + (pool.autoscaling?.min_replicas ?? pool.replicas ?? 0);
+    }
+    return count;
+  }, 0);
+
 const isMinimumCountWithoutTaints = ({
   currentMachinePoolId,
   machinePools,
@@ -157,22 +165,13 @@ const isMinimumCountWithoutTaints = ({
     return true; // This only applies to HCP clusters
   }
 
-  let numberReplicas = machinePools?.reduce((count, pool) => {
-    if (pool.id !== currentMachinePoolId) {
-      if (!pool.taints?.length) {
-        return count + (pool.autoscaling?.min_replicas ?? pool.replicas ?? 0);
-      }
-    }
-    return count;
-  }, 0);
+  let numberReplicas = countReplicasWithoutTaints(machinePools, currentMachinePoolId);
 
-  if (
-    includeCurrentMachinePool &&
-    currentMachinePoolId &&
-    !machinePools.find((pool) => pool.id === currentMachinePoolId)?.taints?.length
-  ) {
-    // The minimum the current machine pool can have is 1 so adding it if the method is using to count total nodes
-    numberReplicas += 1;
+  if (includeCurrentMachinePool && currentMachinePoolId) {
+    const currentPool = machinePools.find((pool) => pool.id === currentMachinePoolId);
+    if (!currentPool?.taints?.length) {
+      numberReplicas += currentPool?.autoscaling?.min_replicas ?? currentPool?.replicas ?? 0;
+    }
   }
 
   return numberReplicas >= 2;
@@ -290,15 +289,13 @@ const getClusterMinNodes = ({
   machinePool: MachinePool | undefined;
   machinePools: MachinePool[];
 }) => {
+  // For HCP, return lowest allowed node count to maintain a total of at least 2 untainted nodes across all pools.
   if (isHypershiftCluster(cluster)) {
-    return isMinimumCountWithoutTaints({
-      currentMachinePoolId: machinePool?.id,
-      cluster,
-      machinePools,
-      includeCurrentMachinePool: true,
-    })
-      ? 1
-      : 2;
+    if (machinePool?.taints?.length) {
+      return 0;
+    }
+    const otherPoolsWithoutTaints = countReplicasWithoutTaints(machinePools, machinePool?.id);
+    return Math.max(0, 2 - otherPoolsWithoutTaints);
   }
   const isMultiAz = isMultiAZ(cluster);
 
@@ -365,6 +362,7 @@ const getCapacityPreferenceLabel = (
 export {
   actionResolver,
   canUseSpotInstances,
+  countReplicasWithoutTaints,
   getClusterMinNodes,
   getMinNodesRequired,
   getNodeIncrement,


### PR DESCRIPTION
# Summary

This PR updates the machine pool validation logic for HCP (Hosted Control Plane) clusters to allow 0 nodes, both when autoscaling is off and on. When autoscaling is off, the implementation ensures that the total number of untainted nodes across all machine pools remains at least 2, while allowing individual pools to have 0 nodes when this requirement is already met by other pools.

**Key changes:**
- Updated `getClusterMinNodes` to allow 0 nodes for HCP clusters based on cluster-wide untainted node count
-  Fixed `isMinimumCountWithoutTaints` to properly account for current pool's actual replica count
- Refactored duplicate code by extracting `countReplicasWithoutTaints` helper function

- When autoscaling is on, min and max fields allows 0 as input.

Additional bugfix: Allow 0 nodes when autoscaling is on for ROSA classic.

# Jira

Fixes [OCMUI-4265](https://issues.redhat.com/browse/OCMUI-4265) , [OCMUI-4270](https://issues.redhat.com/browse/OCMUI-OCMUI-4270) 



# Additional information

The logic now works as follows for HCP clusters, when autoscaling is off,:
- If a machine pool has taints, it can have 0 nodes (tainted nodes don't count toward the 2-node requirement)
- For untainted pools, the minimum allowed is calculated as: `Math.max(0, 2 - otherPoolsWithoutTaints)`
- This ensures the cluster maintains at least 2 untainted nodes total while maximizing flexibility

# How to Test

Scenario 1:

1. Create or access an HCP cluster with multiple machine pools
2. Add/edit a machine pool
3. Verify that when other untainted pools have 2+ nodes, the node count field allows 0
4. Verify that tainted pools always allow 0 nodes
5. Verify that the total untainted nodes across all pools remains at least 2

Scenario 2:
1. Create or access an HCP cluster
2. Add/edit a machine pool
3. Enable autoscaling
4. 0 is now a valid input for min and max nodes fields

# Screen Captures

| Before | After |
| ------ | ----- |
|<img width="727" height="360" alt="image" src="https://github.com/user-attachments/assets/127389f7-d17f-4ec7-a128-3107289b6758" /> | <img width="736" height="373" alt="image" src="https://github.com/user-attachments/assets/fd7b209f-6ecf-459a-89ed-b9845ef4479f" /> |

Autoscaling on - min and max allows 0:

<img width="620" height="215" alt="image" src="https://github.com/user-attachments/assets/96d0f2fc-6780-4110-a383-e44c4a7b151d" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation

[OCMUI-4265]: https://redhat.atlassian.net/browse/OCMUI-4265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OCMUI-4270]: https://redhat.atlassian.net/browse/OCMUI-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ