### PR TITLE
OCMUI-3989: Remove code specific to source=gcp url parameter

### DIFF
--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Formik } from 'formik';
 
-import { getQueryParam } from '~/common/queryHelpers';
 import { useIsOSDFromGoogleCloud } from '~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud';
 import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
 import { checkAccessibility, mockUseFeatureGate, render, screen, waitFor } from '~/testUtils';
@@ -15,9 +14,7 @@ import { useGetBillingQuotas } from './useGetBillingQuotas';
 // Mock hooks
 jest.mock('~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud');
 jest.mock('~/components/clusters/wizards/osd/BillingModel/useGetBillingQuotas');
-jest.mock('~/common/queryHelpers');
 
-const mockGetQueryParam = getQueryParam as jest.Mock;
 const mockUseIsOSDFromGoogleCloud = useIsOSDFromGoogleCloud as jest.Mock;
 const mockUseGetBillingQuotas = useGetBillingQuotas as jest.Mock;
 
@@ -103,11 +100,6 @@ describe('<BillingModel />', () => {
   describe('When creating a cluster coming from google cloud console', () => {
     beforeEach(() => {
       mockUseIsOSDFromGoogleCloud.mockReturnValue(true);
-      mockGetQueryParam.mockReturnValue('gcp');
-      mockUseGetBillingQuotas.mockReturnValue({
-        ...defaultQuotas,
-        standardOsd: false,
-      });
     });
     it('is accessible', async () => {
       const { container } = render(buildTestComponent(true));
@@ -172,74 +164,8 @@ describe('<BillingModel />', () => {
 
       expect(screen.queryByText('Free trial (upgradeable)')).not.toBeInTheDocument();
     });
-
-    it('has customer cloud subscription selected by default', () => {
-      render(buildTestComponent(true));
-      const byocRadioCCSOption = screen.getByRole('radio', {
-        name: /customer cloud subscription/i,
-      });
-      expect(byocRadioCCSOption).toBeInTheDocument();
-      expect(byocRadioCCSOption).toBeChecked();
-    });
   });
 
-  describe('When creating a cluster coming from google cloud console', () => {
-    beforeEach(() => {
-      mockUseIsOSDFromGoogleCloud.mockReturnValue(true);
-    });
-    it('is accessible', async () => {
-      const { container } = render(buildTestComponent(true));
-      await checkAccessibility(container);
-    });
-    it('does not display free trial option', () => {
-      render(buildTestComponent(true));
-
-      expect(screen.queryByText('Free trial (upgradeable)')).not.toBeInTheDocument();
-    });
-
-    it('does not display annual subscription option', () => {
-      render(buildTestComponent(true));
-
-      expect(
-        screen.queryByText('Annual: Fixed capacity subscription from Red Hat'),
-      ).not.toBeInTheDocument();
-    });
-
-    it('displays only on-demand marketplace option', () => {
-      render(buildTestComponent(true));
-
-      expect(screen.getByText(/On-Demand: Flexible usage billed through/i)).toBeInTheDocument();
-    });
-
-    it('has On-Demand selected by default', async () => {
-      render(buildTestComponent(true));
-
-      const onDemandRadioOption = screen.getByRole('radio', {
-        name: /On-Demand: Flexible usage billed through/i,
-      });
-      expect(onDemandRadioOption).toBeInTheDocument();
-
-      // Wait for the useEffect to update the billing model
-      await waitFor(() => {
-        expect(onDemandRadioOption).toBeChecked();
-      });
-    });
-
-    it('displays only customer cloud subscription infrastructure option', () => {
-      render(buildTestComponent(true));
-
-      expect(screen.getByText('Customer cloud subscription')).toBeInTheDocument();
-      expect(screen.queryByText('Red Hat cloud account')).not.toBeInTheDocument();
-    });
-    it('has customer cloud subscription selected by default', () => {
-      render(buildTestComponent(true));
-      const byocRadioCCSOption = screen.getByRole('radio', {
-        name: /customer cloud subscription/i,
-      });
-      expect(byocRadioCCSOption).toBeInTheDocument();
-      expect(byocRadioCCSOption).toBeChecked();
-    });
-  });
   describe('Google Cloud Marketplace', () => {
     it('Google Cloud Marketplace option is enabled when there is gcp quota', async () => {
       mockUseGetBillingQuotas.mockReturnValue({

--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.tsx
@@ -17,7 +17,6 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons'
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 
 import installLinks from '~/common/installLinks.mjs';
-import { deleteQueryParam, getQueryParam } from '~/common/queryHelpers';
 import { normalizedProducts, STANDARD_TRIAL_BILLING_MODEL_TYPE } from '~/common/subscriptionTypes';
 import supportLinks from '~/common/supportLinks.mjs';
 import {
@@ -41,7 +40,6 @@ import './BillingModel.scss';
 
 export const BillingModel = () => {
   const isOSDFromGoogleCloud = useIsOSDFromGoogleCloud();
-  const sourceIsGCP = getQueryParam('source') === 'gcp';
   const {
     values: {
       [FieldId.Product]: product,
@@ -171,29 +169,6 @@ export const BillingModel = () => {
     quotas.standardOsd,
     selectedMarketplace,
   ]);
-
-  React.useEffect(() => {
-    if (sourceIsGCP) {
-      setFieldValue(
-        FieldId.MarketplaceSelection,
-        SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp,
-        false,
-      );
-      setFieldValue(FieldId.CloudProvider, CloudProviderType.Gcp, false);
-
-      // it's possible the select was used before the parent radio button was selected
-      // ensure the parent radio button is selected and the correct values are set
-      setFieldValue(
-        FieldId.BillingModel,
-        SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp,
-        false,
-      );
-      setFieldValue(FieldId.Byoc, 'true', false);
-      setFieldValue(FieldId.Product, normalizedProducts.OSD, false);
-      deleteQueryParam('source');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourceIsGCP]);
 
   let isRhInfraQuotaDisabled = false;
   let isByocQuotaDisabled = false;


### PR DESCRIPTION
# Summary

A couple of years ago we created a custom parameter that google cloud could send to our OSD Wizard that would only show GCP as an option.  The was done with source=gcp added to the URL.  We have now created a new OSD GCP specific curated wizard that google references making this parameter obsolete. 

I have removed the parameter check and the duplicated unit tests.

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3989](https://issues.redhat.com/browse/OCMUI-3989)

# How to Test

1. Go to the osd wizard landing page.  Add the url paramter source=gcp.
```
https://prod.foo.redhat.com:1337/openshift/create/osd?source=gcp
```
2. Verify that the Subscription Type remains on the default value of "Annual"
3. That is pretty much it, since we no longer default to the google market place, all the rest of the OSD wizard will work normally.


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3989]: https://redhat.atlassian.net/browse/OCMUI-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ