### PR TITLE
OCMUI-4281: Update flaky step from playwright page utility

### DIFF
--- a/playwright/page-objects/cluster-details-page.ts
+++ b/playwright/page-objects/cluster-details-page.ts
@@ -220,14 +220,8 @@ export class ClusterDetailsPage extends BasePage {
   }
 
   async waitForInstallerScreenToLoad(): Promise<void> {
-    await this.page.waitForSelector('li.pf-v6-c-wizard__nav-item', {
-      state: 'detached',
-      timeout: 30000,
-    });
-    await this.page.waitForSelector('div.cluster-loading-container', {
-      state: 'detached',
-      timeout: 100000,
-    });
+    await expect(this.clusterNameTitle()).toBeVisible({ timeout: 100000 });
+    await expect(this.clusterInstallationHeader()).toBeVisible({ timeout: 30000 });
   }
 
   async waitForDeleteClusterActionComplete(): Promise<void> {


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->
Update the flaky step from playwright page utility for osd wizard specs

# Jira

Fixes [OCMUI-4281](https://issues.redhat.com/browse/OCMUI-4281)

# Additional information

The recent playwright smoke execution exposed flaky definition in wizard submission steps from the wizard spec definition. This was particularly reported from in OSD wizards specs.
This PR fixes the flaky definition by updating respective page utility definition.

# How to Test

1. Configure the playwright.env.json definition (refer [readme](https://github.com/RedHatInsights/uhc-portal/tree/main/playwright#example-playwrightenvjson-structure) for more details)
2. 
```
{
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_GCP_WIF_CONFIG": "ocmui-test-wif",
  "QE_INFRA_GCP": {
    "PSC_INFRA": {
      "VPC_NAME": "qeocmui-psc-test-vpc",
      "REGION": "us-central1",
      "CONTROLPLANE_SUBNET": "qeocmui-psc-test-control-plane",
      "COMPUTE_SUBNET": "qeocmui-psc-test-worker",
      "PRIVATE_SERVICE_CONNECT_SUBNET": "qeocmui-psc-test-psc"
    }
  }
}
```
3. Run some random OSD test specs.
4. 
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/osd-gcp/osd-non-ccs-gcp-cluster-creation.spec.ts

BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.ts

BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/osd-gcp/osd-marketplace-gcp-wif-cluster-creation.spec.ts
```
# Screen Captures

```
 BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test --workers 4 --grep='(?=.*@smoke)(?=.*@osd)' 
 
yarn run v1.22.22
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 193 tests using 4 workers
  193 passed (6.0m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 365.46s.

```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).


[OCMUI-4281]: https://redhat.atlassian.net/browse/OCMUI-4281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ