### PR TITLE
OCMUI-4223 : playwright e2e specs on shared VPC, DNS zone GCP wizard areas

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -94,11 +94,22 @@ The test configuration uses `playwright.env.json` for environment-specific setti
     "VPC_NAME": "Google cloud VPC name",
     "CONTROLPLANE_SUBNET": "Google cloud control plane subnet",
     "COMPUTE_SUBNET": "Google cloud compute subnet",
+    // GCP Private service connect details.
     "PSC_INFRA": {
       "VPC_NAME": "Google cloud Private service connect VPC",
       "CONTROLPLANE_SUBNET": "Google cloud control plane subnet",
       "COMPUTE_SUBNET": "Google cloud compute subnet",
       "PRIVATE_SERVICE_CONNECT_SUBNET": "Google cloud psc subnet"
+    },
+    //GCP Shared VPC details.
+    "SHARED_VPC_INFRA": {
+      "HOST_PROJECT_ID": "host project id",
+      "SERVICE_PROJECT_ID": "service project id",
+      "VPC_NAME": "shared VPC name from host project",
+      "REGION": "shared VPC configured region",
+      "CONTROLPLANE_SUBNET": "control plane subnet from shared vpc",
+      "COMPUTE_SUBNET": "compute subnet from shared vpc",
+      "PRIVATE_SERVICE_CONNECT_SUBNET": "psc subnet from shared vpc"
     }
   },
   // AWS VPC definition required for ROSA hosted, rosa classic clusters with custom VPCs

--- a/playwright/e2e/osd-gcp/osd-ccs-gcp-wizard-validation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ccs-gcp-wizard-validation.spec.ts
@@ -8,8 +8,7 @@ const { Clusters, ClustersValidation } = testData;
 const QE_GCP = process.env.QE_GCP_OSDCCSADMIN_JSON;
 
 // Create parameterized tests for each cluster configuration
-Clusters.forEach((clusterProperties, index) => {
-  const isCCSCluster = !clusterProperties.InfrastructureType.includes('Red Hat');
+Clusters.forEach((clusterProperties) => {
   const testSuffix = clusterProperties.AuthenticationType
     ? `-${clusterProperties.AuthenticationType}`
     : '';
@@ -40,67 +39,63 @@ Clusters.forEach((clusterProperties, index) => {
         await createOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
         await expect(createOSDWizardPage.workloadIdentityFederationButton()).toBePressed();
         await expect(createOSDWizardPage.serviceAccountButton()).not.toBePressed();
-        if (isCCSCluster) {
-          await createOSDWizardPage.wizardNextButton().click();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.CloudProvider.Common.AcknowledgementUncheckedError,
-          );
+        await createOSDWizardPage.wizardNextButton().click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.CloudProvider.Common.AcknowledgementUncheckedError,
+        );
 
-          if (clusterProperties.CloudProvider.includes('GCP')) {
-            if (clusterProperties.AuthenticationType?.includes('Service Account')) {
-              await createOSDWizardPage.serviceAccountButton().click();
-              await createOSDWizardPage.wizardNextButton().click();
-              await createOSDWizardPage.isTextContainsInPage(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP.EmptyGCPServiceJSONFieldError,
-              );
+        if (clusterProperties.CloudProvider.includes('GCP')) {
+          if (clusterProperties.AuthenticationType?.includes('Service Account')) {
+            await createOSDWizardPage.serviceAccountButton().click();
+            await createOSDWizardPage.wizardNextButton().click();
+            await createOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP.EmptyGCPServiceJSONFieldError,
+            );
 
-              await createOSDWizardPage.uploadGCPServiceAccountJSON(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP
-                  .InvalidFormatGCPServiceJSONValues,
-              );
-              await createOSDWizardPage.wizardNextButton().click();
-              await createOSDWizardPage.isTextContainsInPage(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP
-                  .InvalidFormatGCPServiceJSONFieldError,
-              );
+            await createOSDWizardPage.uploadGCPServiceAccountJSON(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP
+                .InvalidFormatGCPServiceJSONValues,
+            );
+            await createOSDWizardPage.wizardNextButton().click();
+            await createOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP
+                .InvalidFormatGCPServiceJSONFieldError,
+            );
 
-              await createOSDWizardPage.uploadGCPServiceAccountJSON(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP.InvalidGCPServiceJSONValues,
-              );
-              await createOSDWizardPage.wizardNextButton().click();
-              await createOSDWizardPage.isTextContainsInPage(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP
-                  .InvalidGCPServiceJSONFieldError,
-              );
+            await createOSDWizardPage.uploadGCPServiceAccountJSON(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP.InvalidGCPServiceJSONValues,
+            );
+            await createOSDWizardPage.wizardNextButton().click();
+            await createOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP.InvalidGCPServiceJSONFieldError,
+            );
 
-              if (QE_GCP) {
-                await createOSDWizardPage.uploadGCPServiceAccountJSON(QE_GCP || '{}');
-              }
-            } else {
-              await createOSDWizardPage.workloadIdentityFederationButton().click();
-              await createOSDWizardPage.wizardNextButton().click();
-              await createOSDWizardPage.isTextContainsInPage(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP.NoWIFConfigSelectionError,
-              );
-              await createOSDWizardPage.isTextContainsInPage(
-                ClustersValidation.ClusterSettings.CloudProvider.Common
-                  .AcknowledgementUncheckedError,
-              );
+            if (QE_GCP) {
+              await createOSDWizardPage.uploadGCPServiceAccountJSON(QE_GCP || '{}');
+            }
+          } else {
+            await createOSDWizardPage.workloadIdentityFederationButton().click();
+            await createOSDWizardPage.wizardNextButton().click();
+            await createOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP.NoWIFConfigSelectionError,
+            );
+            await createOSDWizardPage.isTextContainsInPage(
+              ClustersValidation.ClusterSettings.CloudProvider.Common.AcknowledgementUncheckedError,
+            );
 
-              await expect(createOSDWizardPage.gcpWIFCommandInput()).toHaveValue(
-                ClustersValidation.ClusterSettings.CloudProvider.GCP.WIFCommandValue,
-              );
+            await expect(createOSDWizardPage.gcpWIFCommandInput()).toHaveValue(
+              ClustersValidation.ClusterSettings.CloudProvider.GCP.WIFCommandValue,
+            );
 
-              await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+            await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
 
-              const wifConfig = process.env.QE_GCP_WIF_CONFIG;
-              if (wifConfig) {
-                await createOSDWizardPage.selectWorkloadIdentityConfiguration(wifConfig);
-              }
+            const wifConfig = process.env.QE_GCP_WIF_CONFIG;
+            if (wifConfig) {
+              await createOSDWizardPage.selectWorkloadIdentityConfiguration(wifConfig);
             }
           }
-          await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
         }
+        await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
         await createOSDWizardPage.wizardNextButton().click();
       });
 
@@ -185,9 +180,7 @@ Clusters.forEach((clusterProperties, index) => {
       });
 
       test(`Machine pool nodes field validations`, async ({ createOSDWizardPage }) => {
-        const machinePoolProperties = isCCSCluster
-          ? ClustersValidation.ClusterSettings.Machinepool.NodeCount.CCS
-          : ClustersValidation.ClusterSettings.Machinepool.NodeCount.NonCCS;
+        const machinePoolProperties = ClustersValidation.ClusterSettings.Machinepool.NodeCount.CCS;
 
         await createOSDWizardPage.isMachinePoolScreen();
         await createOSDWizardPage.selectComputeNodeType(clusterProperties.InstanceType);
@@ -232,7 +225,7 @@ Clusters.forEach((clusterProperties, index) => {
           machinePoolProperties.SingleZone.MinAndMaxLimitDependencyError,
         );
 
-        await createOSDWizardPage.setMinimumNodeCount(isCCSCluster ? '2' : '4');
+        await createOSDWizardPage.setMinimumNodeCount('2');
         await createOSDWizardPage.setMaximumNodeCount('500');
         await createOSDWizardPage.isTextContainsInPage(
           machinePoolProperties.SingleZone.UpperLimitError,
@@ -241,7 +234,7 @@ Clusters.forEach((clusterProperties, index) => {
         await createOSDWizardPage.isTextContainsInPage(
           machinePoolProperties.SingleZone.LowerLimitError,
         );
-        await createOSDWizardPage.setMaximumNodeCount(isCCSCluster ? '2' : '4');
+        await createOSDWizardPage.setMaximumNodeCount('2');
 
         await createOSDWizardPage.minimumNodeCountPlusButton().click();
         await createOSDWizardPage.isTextContainsInPage(
@@ -300,7 +293,7 @@ Clusters.forEach((clusterProperties, index) => {
           machinePoolProperties.MultiZone.MinAndMaxLimitDependencyError,
         );
 
-        await createOSDWizardPage.setMinimumNodeCount(isCCSCluster ? '2' : '3');
+        await createOSDWizardPage.setMinimumNodeCount('2');
         await createOSDWizardPage.setMaximumNodeCount('500');
         await createOSDWizardPage.isTextContainsInPage(
           machinePoolProperties.MultiZone.UpperLimitError,
@@ -309,7 +302,7 @@ Clusters.forEach((clusterProperties, index) => {
         await createOSDWizardPage.isTextContainsInPage(
           machinePoolProperties.MultiZone.LowerLimitError,
         );
-        await createOSDWizardPage.setMaximumNodeCount(isCCSCluster ? '2' : '3');
+        await createOSDWizardPage.setMaximumNodeCount('2');
 
         await createOSDWizardPage.minimumNodeCountPlusButton().click();
         await createOSDWizardPage.isTextContainsInPage(
@@ -323,372 +316,359 @@ Clusters.forEach((clusterProperties, index) => {
         await createOSDWizardPage.minimumNodeCountMinusButton().click();
       });
 
-      if (isCCSCluster) {
-        test(`Cluster autoscaling validations`, async ({ createOSDWizardPage }) => {
-          await createOSDWizardPage.editClusterAutoscalingSettingsButton().click();
+      test(`Cluster autoscaling validations`, async ({ createOSDWizardPage }) => {
+        await createOSDWizardPage.editClusterAutoscalingSettingsButton().click();
 
-          // Log verbosity validation
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('0');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .LogVerbosityLimitError,
-          );
+        // Log verbosity validation
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('0');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .LogVerbosityLimitError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('7');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .LogVerbosityLimitError,
-          );
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('7');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .LogVerbosityLimitError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('3');
-          await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .LogVerbosityLimitError,
-            false,
-          );
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().fill('3');
+        await createOSDWizardPage.clusterAutoscalingLogVerbosityInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .LogVerbosityLimitError,
+          false,
+        );
 
-          // Max node provision time validation
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .RequiredFieldError,
-          );
+        // Max node provision time validation
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .RequiredFieldError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('8H');
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('8H');
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('90k');
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('90k');
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('8s');
-          await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-            false,
-          );
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().clear();
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().fill('8s');
+        await createOSDWizardPage.clusterAutoscalingMaxNodeProvisionTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+          false,
+        );
 
-          // Balancing ignored labels validation
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
-          await createOSDWizardPage
-            .clusterAutoscalingBalancingIgnoredLabelsInput()
-            .fill('test with whitespace,test');
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .WhitespaceLabelValueError,
-          );
+        // Balancing ignored labels validation
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
+        await createOSDWizardPage
+          .clusterAutoscalingBalancingIgnoredLabelsInput()
+          .fill('test with whitespace,test');
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .WhitespaceLabelValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
-          await createOSDWizardPage
-            .clusterAutoscalingBalancingIgnoredLabelsInput()
-            .fill('test,test,');
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .EmptyLabelValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
+        await createOSDWizardPage
+          .clusterAutoscalingBalancingIgnoredLabelsInput()
+          .fill('test,test,');
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .EmptyLabelValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
-          await createOSDWizardPage
-            .clusterAutoscalingBalancingIgnoredLabelsInput()
-            .fill('test@434$,123,&test_(t)35435');
-          await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage('Empty labels are not allowed', false);
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().clear();
+        await createOSDWizardPage
+          .clusterAutoscalingBalancingIgnoredLabelsInput()
+          .fill('test@434$,123,&test_(t)35435');
+        await createOSDWizardPage.clusterAutoscalingBalancingIgnoredLabelsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage('Empty labels are not allowed', false);
 
-          // Cores validation
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().fill('10');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().blur();
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().fill('9');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .MinMaxLimitError,
-          );
+        // Cores validation
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().fill('10');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().blur();
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().fill('9');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling.MinMaxLimitError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().fill('9');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().blur();
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().fill('10');
-          await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .MinMaxLimitError,
-            false,
-          );
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().fill('9');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMinInput().blur();
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().fill('10');
+        await createOSDWizardPage.clusterAutoscalingCoresTotalMaxInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling.MinMaxLimitError,
+          false,
+        );
 
-          // Memory validation
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('10');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('9');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .MinMaxLimitError,
-          );
+        // Memory validation
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('10');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('9');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling.MinMaxLimitError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('-1');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .NegativeValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('-1');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .NegativeValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('-1');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .NegativeValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('-1');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .NegativeValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('9');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('10');
-          await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .NegativeValueError,
-            false,
-          );
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().fill('9');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMinInput().blur();
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().fill('10');
+        await createOSDWizardPage.clusterAutoscalingMemoryTotalMaxInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .NegativeValueError,
+          false,
+        );
 
-          // Max nodes validation
-          await expect(createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput()).toHaveValue(
-            '255',
-          );
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().fill('257');
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .MaxNodesValueMultizoneLimitError,
-          );
+        // Max nodes validation
+        await expect(createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput()).toHaveValue('255');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().fill('257');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .MaxNodesValueMultizoneLimitError,
+        );
 
+        await createOSDWizardPage.clusterAutoscalingRevertAllToDefaultsButton().click();
+        await createOSDWizardPage.clusterAutoscalingCloseButton().click();
+
+        // Test single zone
+        await createOSDWizardPage.wizardBackButton().click();
+        await createOSDWizardPage.selectAvailabilityZone('Single Zone');
+        await createOSDWizardPage.wizardNextButton().click();
+        await createOSDWizardPage.selectComputeNodeType(clusterProperties.InstanceType);
+        await createOSDWizardPage.enableAutoscalingCheckbox().uncheck();
+        await createOSDWizardPage.enableAutoscalingCheckbox().check();
+        await createOSDWizardPage.editClusterAutoscalingSettingsButton().click();
+
+        await expect(createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput()).toHaveValue('254');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().fill('255');
+        await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .MaxNodesValueSinglezoneLimitError,
+        );
+
+        if (clusterProperties.CloudProvider.includes('GCP')) {
           await createOSDWizardPage.clusterAutoscalingRevertAllToDefaultsButton().click();
           await createOSDWizardPage.clusterAutoscalingCloseButton().click();
-
-          // Test single zone
           await createOSDWizardPage.wizardBackButton().click();
-          await createOSDWizardPage.selectAvailabilityZone('Single Zone');
+          await createOSDWizardPage.selectAvailabilityZone('Multi-zone');
           await createOSDWizardPage.wizardNextButton().click();
           await createOSDWizardPage.selectComputeNodeType(clusterProperties.InstanceType);
           await createOSDWizardPage.enableAutoscalingCheckbox().uncheck();
           await createOSDWizardPage.enableAutoscalingCheckbox().check();
           await createOSDWizardPage.editClusterAutoscalingSettingsButton().click();
+        }
 
-          await expect(createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput()).toHaveValue(
-            '254',
-          );
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().fill('255');
-          await createOSDWizardPage.clusterAutoscalingMaxNodesTotalInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .MaxNodesValueSinglezoneLimitError,
-          );
+        // GPU validation
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidGPUValueError,
+        );
 
-          if (clusterProperties.CloudProvider.includes('GCP')) {
-            await createOSDWizardPage.clusterAutoscalingRevertAllToDefaultsButton().click();
-            await createOSDWizardPage.clusterAutoscalingCloseButton().click();
-            await createOSDWizardPage.wizardBackButton().click();
-            await createOSDWizardPage.selectAvailabilityZone('Multi-zone');
-            await createOSDWizardPage.wizardNextButton().click();
-            await createOSDWizardPage.selectComputeNodeType(clusterProperties.InstanceType);
-            await createOSDWizardPage.enableAutoscalingCheckbox().uncheck();
-            await createOSDWizardPage.enableAutoscalingCheckbox().check();
-            await createOSDWizardPage.editClusterAutoscalingSettingsButton().click();
-          }
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:5');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidGPUValueError,
+        );
 
-          // GPU validation
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidGPUValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:5,');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidGPUValueError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:5');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidGPUValueError,
-          );
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:12,test:1:5');
+        await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidGPUValueError,
+          false,
+        );
+        // await expect(page.locator('div').filter({ hasText:  })).not.toBeVisible();
 
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:5,');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidGPUValueError,
-          );
+        // Scale down validation
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .press('Control+a');
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .fill('1.5');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .ThreasholdLimitError,
+        );
 
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().fill('test:10:12,test:1:5');
-          await createOSDWizardPage.clusterAutoscalingGPUsInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidGPUValueError,
-            false,
-          );
-          // await expect(page.locator('div').filter({ hasText:  })).not.toBeVisible();
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .press('Control+a');
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .fill('-1.5');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .NegativeValueError,
+        );
 
-          // Scale down validation
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .press('Control+a');
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .fill('1.5');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .ThreasholdLimitError,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .press('Control+a');
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownUtilizationThresholdInput()
+          .fill('0.5');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .NegativeValueError,
+          false,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .press('Control+a');
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .fill('-1.5');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .NegativeValueError,
-          );
+        // Time-based validations
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().fill('7H');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .press('Control+a');
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUtilizationThresholdInput()
-            .fill('0.5');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUtilizationThresholdInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .NegativeValueError,
-            false,
-          );
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().fill('7h');
+        await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+          false,
+        );
 
-          // Time-based validations
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUnneededTimeInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().fill('7H');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterAddInput()
+          .press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().fill('8Sec');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownUnneededTimeInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().fill('7h');
-          await createOSDWizardPage.clusterAutoscalingScaleDownUnneededTimeInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-            false,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterAddInput()
+          .press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().fill('8s');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+          false,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterAddInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().fill('8Sec');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterDeleteInput()
+          .press('Control+a');
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterDeleteInput()
+          .fill('10milli');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterAddInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().fill('8s');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterAddInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-            false,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterDeleteInput()
+          .press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().fill('10s');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+          false,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterDeleteInput()
-            .press('Control+a');
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterDeleteInput()
-            .fill('10milli');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterFailureInput()
+          .press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().fill('5M');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterDeleteInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().fill('10s');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterDeleteInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-            false,
-          );
+        await createOSDWizardPage
+          .clusterAutoscalingScaleDownDelayAfterFailureInput()
+          .press('Control+a');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().fill('5m');
+        await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().blur();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
+            .InvalidTimeValueError,
+          false,
+        );
 
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterFailureInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().fill('5M');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-          );
-
-          await createOSDWizardPage
-            .clusterAutoscalingScaleDownDelayAfterFailureInput()
-            .press('Control+a');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().fill('5m');
-          await createOSDWizardPage.clusterAutoscalingScaleDownDelayAfterFailureInput().blur();
-          await createOSDWizardPage.isTextContainsInPage(
-            ClustersValidation.ClusterSettings.Machinepool.Common.ClusterAutoscaling
-              .InvalidTimeValueError,
-            false,
-          );
-
-          await createOSDWizardPage.clusterAutoscalingRevertAllToDefaultsButton().click();
-          await createOSDWizardPage.clusterAutoscalingCloseButton().click();
-        });
-      }
+        await createOSDWizardPage.clusterAutoscalingRevertAllToDefaultsButton().click();
+        await createOSDWizardPage.clusterAutoscalingCloseButton().click();
+      });
 
       test(`Machine pool labels field validations`, async ({ page, createOSDWizardPage }) => {
         await createOSDWizardPage.addNodeLabelLink().scrollIntoViewIfNeeded();
@@ -783,116 +763,220 @@ Clusters.forEach((clusterProperties, index) => {
       });
 
       test(`Networking configuration field validations`, async ({ page, createOSDWizardPage }) => {
-        if (clusterProperties.CloudProvider.includes('GCP') && !isCCSCluster) {
-          console.log(
-            `Cloud provider : ${clusterProperties.CloudProvider} -${clusterProperties.SubscriptionType}-${clusterProperties.InfrastructureType} with CCS cluster=${isCCSCluster} not supported Networking configuration > Cluster privacy`,
+        await createOSDWizardPage.isNetworkingScreen();
+        await createOSDWizardPage.applicationIngressCustomSettingsRadio().check();
+
+        await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
+        await createOSDWizardPage
+          .applicationIngressRouterSelectorsInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .RouteSelector[0].UpperCharacterLimitValue,
           );
-        } else {
-          await createOSDWizardPage.isNetworkingScreen();
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .RouteSelector[0].Error,
+        );
 
-          if (isCCSCluster) {
-            await createOSDWizardPage.applicationIngressCustomSettingsRadio().check();
+        await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
+        await createOSDWizardPage
+          .applicationIngressRouterSelectorsInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .RouteSelector[1].InvalidValue,
+          );
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .RouteSelector[1].Error,
+        );
 
-            await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
-            await createOSDWizardPage
-              .applicationIngressRouterSelectorsInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .RouteSelector[0].UpperCharacterLimitValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .RouteSelector[0].Error,
-            );
+        await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
+        await createOSDWizardPage
+          .applicationIngressRouterSelectorsInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .RouteSelector[2].InvalidValue,
+          );
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .RouteSelector[2].Error,
+        );
 
-            await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
-            await createOSDWizardPage
-              .applicationIngressRouterSelectorsInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .RouteSelector[1].InvalidValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .RouteSelector[1].Error,
-            );
+        await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
+        await createOSDWizardPage
+          .applicationIngressRouterSelectorsInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .RouteSelector[3].InvalidValue,
+          );
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .RouteSelector[3].Error,
+        );
 
-            await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
-            await createOSDWizardPage
-              .applicationIngressRouterSelectorsInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .RouteSelector[2].InvalidValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .RouteSelector[2].Error,
-            );
+        await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
+        await createOSDWizardPage
+          .applicationIngressRouterSelectorsInput()
+          .fill('valid123-k.com/Hello_world2');
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .RouteSelector[0].Error,
+          false,
+        );
 
-            await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
-            await createOSDWizardPage
-              .applicationIngressRouterSelectorsInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .RouteSelector[3].InvalidValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .RouteSelector[3].Error,
-            );
+        await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
+        await createOSDWizardPage
+          .applicationIngressExcludedNamespacesInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .ExcludedNamespaces[0].UpperCharacterLimitValue,
+          );
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .ExcludedNamespaces[0].Error,
+        );
 
-            await createOSDWizardPage.applicationIngressRouterSelectorsInput().clear();
-            await createOSDWizardPage
-              .applicationIngressRouterSelectorsInput()
-              .fill('valid123-k.com/Hello_world2');
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .RouteSelector[0].Error,
-              false,
-            );
+        await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
+        await createOSDWizardPage
+          .applicationIngressExcludedNamespacesInput()
+          .fill(
+            ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+              .ExcludedNamespaces[1].InvalidValue,
+          );
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .ExcludedNamespaces[1].Error,
+        );
 
-            await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
-            await createOSDWizardPage
-              .applicationIngressExcludedNamespacesInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .ExcludedNamespaces[0].UpperCharacterLimitValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .ExcludedNamespaces[0].Error,
-            );
-
-            await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
-            await createOSDWizardPage
-              .applicationIngressExcludedNamespacesInput()
-              .fill(
-                ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                  .ExcludedNamespaces[1].InvalidValue,
-              );
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .ExcludedNamespaces[1].Error,
-            );
-
-            await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
-            await createOSDWizardPage.applicationIngressExcludedNamespacesInput().fill('abc-123');
-            await page.getByText('Route selector').click();
-            await createOSDWizardPage.isTextContainsInPage(
-              ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
-                .ExcludedNamespaces[1].Error,
-              false,
-            );
-          }
+        await createOSDWizardPage.applicationIngressExcludedNamespacesInput().clear();
+        await createOSDWizardPage.applicationIngressExcludedNamespacesInput().fill('abc-123');
+        await page.getByText('Route selector').click();
+        await createOSDWizardPage.isTextContainsInPage(
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .ExcludedNamespaces[1].Error,
+          false,
+        );
+        if (clusterProperties.AuthenticationType?.includes('Workload Identity Federation')) {
+          await createOSDWizardPage.installIntoExistingVpcCheckBox().check();
           await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.installIntoSharedVpcCheckBox().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.InstallationNote,
+          );
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.DNSZoneNote,
+          );
+
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+              .RequiredFieldError,
+          );
+          await createOSDWizardPage
+            .sharedHostProjectIdInput()
+            .fill(
+              ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+                .NonExistingProjectId,
+            );
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+              .NonExistingProjectIdError,
+          );
+          await createOSDWizardPage
+            .sharedHostProjectIdInput()
+            .fill(
+              ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+                .InvalidProjectId,
+            );
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+              .InvalidProjectIdError,
+          );
+          await createOSDWizardPage.sharedHostProjectIdInput().fill(' ');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.SharedHostProjectId
+              .WhitespaceError,
+          );
+          await createOSDWizardPage.sharedHostProjectIdInput().fill('host-project');
+
+          await createOSDWizardPage
+            .vpcNameInput()
+            .fill(
+              ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ExistingVPCName
+                .InvalidVPCName,
+            );
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ExistingVPCName
+              .InvalidVPCNameError,
+          );
+          await createOSDWizardPage.vpcNameInput().fill(' ');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ExistingVPCName
+              .WhitespaceError,
+          );
+          await createOSDWizardPage.vpcNameInput().fill('vpc-name');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ExistingVPCName
+              .RequiredFieldError,
+          );
+          await createOSDWizardPage
+            .controlPlaneSubnetInput()
+            .fill(
+              ClustersValidation.Networking.Configuration.InstallIntoExistingVPC
+                .ControlPlaneSubnetName.InvalidControlPlaneSubnetName,
+            );
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC
+              .ControlPlaneSubnetName.InvalidControlPlaneSubnetNameError,
+          );
+          await createOSDWizardPage.controlPlaneSubnetInput().fill(' ');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC
+              .ControlPlaneSubnetName.WhitespaceError,
+          );
+          await createOSDWizardPage.controlPlaneSubnetInput().fill('control-plane-subnet');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC
+              .ControlPlaneSubnetName.RequiredFieldError,
+          );
+          await createOSDWizardPage
+            .computeSubnetInput()
+            .fill(
+              ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ComputeSubnetName
+                .InvalidComputeSubnetName,
+            );
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ComputeSubnetName
+              .InvalidComputeSubnetNameError,
+          );
+          await createOSDWizardPage.computeSubnetInput().fill(' ');
+          await createOSDWizardPage.wizardNextButton().click();
+          await createOSDWizardPage.isTextContainsInPage(
+            ClustersValidation.Networking.Configuration.InstallIntoExistingVPC.ComputeSubnetName
+              .WhitespaceError,
+          );
+          await createOSDWizardPage.computeSubnetInput().fill('compute-subnet');
+          await createOSDWizardPage.wizardBackButton().click();
+          await createOSDWizardPage.installIntoExistingVpcCheckBox().uncheck();
         }
+        await createOSDWizardPage.wizardNextButton().click();
       });
 
       test(`CIDR field validations`, async ({ createOSDWizardPage }) => {

--- a/playwright/e2e/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.spec.ts
@@ -1,0 +1,293 @@
+import { test, expect } from '../../fixtures/pages';
+
+const clusterProperties = require('../../fixtures/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.json');
+
+const clusterName = `${clusterProperties.ClusterName}-${Math.random().toString(36).substring(7)}`;
+const QE_GCP_WIF_CONFIG = process.env.QE_GCP_WIF_CONFIG || '';
+const QE_INFRA_GCP = JSON.parse(process.env.QE_INFRA_GCP || '{}');
+const SHARED_VPC_INFRA = QE_INFRA_GCP['SHARED_VPC_INFRA'] || {};
+const region = SHARED_VPC_INFRA['REGION'] || clusterProperties.Region.split(',')[0];
+
+test.describe.serial(
+  'OSD GCP Curated Marketplace WIF Shared VPC DNS PSC cluster creation tests (OCMUI-3888)',
+  { tag: ['@smoke', '@osd', '@curated', '@sharedvpc', '@psc', '@dns'] },
+  () => {
+    test.beforeAll(async ({ navigateTo }) => {
+      if (!QE_GCP_WIF_CONFIG?.trim()) {
+        throw new Error(
+          'QE_GCP_WIF_CONFIG must be set for curated GCP WIF Shared VPC DNS PSC tests',
+        );
+      }
+      // Navigate directly to curated OSD GCP wizard
+      await navigateTo('create/osdgcp');
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Billing model`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isBillingModelScreen();
+      await createOSDWizardPage.isCuratedBillingModelEnabledAndSelected();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Cluster Settings - Cloud provider definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isOnlyGCPCloudProviderSelectionScreen();
+      await createOSDWizardPage.selectWorkloadIdentityConfiguration(QE_GCP_WIF_CONFIG);
+      await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Cluster Settings - Cluster details definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isClusterDetailsScreen();
+      await page.locator(createOSDWizardPage.clusterNameInput).fill(clusterName);
+      await createOSDWizardPage.hideClusterNameValidation();
+      await createOSDWizardPage.createCustomDomainPrefixCheckbox().check();
+      await createOSDWizardPage.domainPrefixInput().fill(clusterProperties.DomainPrefix);
+      await createOSDWizardPage.hideClusterNameValidation();
+      await createOSDWizardPage.selectRegion(region);
+
+      if (clusterProperties.Version) {
+        await createOSDWizardPage.selectVersion(clusterProperties.Version);
+      }
+
+      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
+      await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
+      await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
+      await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Cluster Settings - Default machinepool definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isMachinePoolScreen();
+      await createOSDWizardPage.selectComputeNodeType(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await createOSDWizardPage.selectComputeNodeCount(clusterProperties.MachinePools[0].NodeCount);
+      await createOSDWizardPage.addNodeLabelLink().click();
+      await createOSDWizardPage.addNodeLabelKeyAndValue(
+        clusterProperties.MachinePools[0].Labels[0].Key,
+        clusterProperties.MachinePools[0].Labels[0].Value,
+      );
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Networking configuration - cluster privacy definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
+      await expect(createOSDWizardPage.installIntoExistingVpcCheckBox()).toBeChecked();
+      await expect(createOSDWizardPage.usePrivateServiceConnectCheckBox()).toBeChecked();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : VPC Settings definitions`, async ({
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isVPCSubnetScreen();
+      await createOSDWizardPage.installIntoSharedVpcCheckBox().check();
+      await createOSDWizardPage
+        .sharedHostProjectIdInput()
+        .fill(SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '');
+      await createOSDWizardPage.createDnsZoneToggle().click();
+      await expect(createOSDWizardPage.createDnsZoneCommand()).toHaveValue(
+        `ocm gcp create dns-zone --domain-prefix ${clusterProperties.DomainPrefix} --project-id <project-id> --network-project-id <network-project-id> --network-id <vpc-id>`,
+      );
+      await createOSDWizardPage.selectDnsZone(clusterProperties.DomainPrefix, true);
+      await createOSDWizardPage.vpcNameInput().fill(SHARED_VPC_INFRA['VPC_NAME'] || '');
+      await createOSDWizardPage
+        .controlPlaneSubnetInput()
+        .fill(SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '');
+      await createOSDWizardPage.computeSubnetInput().fill(SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '');
+      await createOSDWizardPage
+        .privateServiceConnectSubnetInput()
+        .fill(SHARED_VPC_INFRA['PRIVATE_SERVICE_CONNECT_SUBNET'] || '');
+      await createOSDWizardPage.wizardNextButton().click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Networking configuration - CIDR ranges definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isCIDRScreen();
+      await createOSDWizardPage.useCIDRDefaultValues(false);
+      await createOSDWizardPage.useCIDRDefaultValues(true);
+
+      await expect(createOSDWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixInput()).toHaveValue(clusterProperties.HostPrefix);
+
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Cluster updates definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isUpdatesScreen();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Review and create page definitions`, async ({
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isReviewScreen();
+
+      await expect(createOSDWizardPage.subscriptionTypeValue()).toContainText(
+        clusterProperties.SubscriptionType,
+      );
+      await expect(createOSDWizardPage.infrastructureTypeValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(createOSDWizardPage.cloudProviderValue()).toContainText(
+        clusterProperties.CloudProvider,
+      );
+
+      await expect(createOSDWizardPage.authenticationTypeValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+      await expect(createOSDWizardPage.clusterNameValue()).toContainText(clusterName);
+      await expect(createOSDWizardPage.regionValue()).toContainText(region);
+      await expect(createOSDWizardPage.availabilityValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(createOSDWizardPage.securebootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(createOSDWizardPage.userWorkloadMonitoringValue()).toContainText(
+        clusterProperties.UserWorkloadMonitoring,
+      );
+      await expect(createOSDWizardPage.additionalEtcdEncryptionValue()).toContainText(
+        clusterProperties.AdditionalEncryption,
+      );
+      await expect(createOSDWizardPage.fipsCryptographyValue()).toContainText(
+        clusterProperties.FIPSCryptography,
+      );
+      await expect(createOSDWizardPage.nodeInstanceTypeValue()).toContainText(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await expect(createOSDWizardPage.autoscalingValue()).toContainText(
+        clusterProperties.MachinePools[0].Autoscaling,
+      );
+
+      await expect(createOSDWizardPage.computeNodeCountValue()).toContainText(
+        `${clusterProperties.MachinePools[0].NodeCount} (× 3 zones = ${clusterProperties.MachinePools[0].NodeCount * 3} compute nodes)`,
+      );
+
+      const label = `${clusterProperties.MachinePools[0].Labels[0].Key} = ${clusterProperties.MachinePools[0].Labels[0].Value}`;
+      await expect(createOSDWizardPage.nodeLabelsValue(label)).toBeVisible();
+      await expect(createOSDWizardPage.clusterPrivacyValue()).toContainText(
+        clusterProperties.ClusterPrivacy,
+      );
+      await expect(createOSDWizardPage.installIntoExistingVpcValue()).toContainText(
+        clusterProperties.InstallIntoExistingVPC,
+      );
+
+      if (clusterProperties.hasOwnProperty('UsePrivateServiceConnect')) {
+        await expect(createOSDWizardPage.privateServiceConnectValue()).toContainText(
+          clusterProperties.UsePrivateServiceConnect,
+        );
+      }
+
+      await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRValue()).toContainText(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixValue()).toContainText(
+        clusterProperties.HostPrefix,
+      );
+      await expect(createOSDWizardPage.applicationIngressValue()).toContainText(
+        clusterProperties.ApplicationIngress,
+      );
+      await expect(createOSDWizardPage.updateStratergyValue()).toContainText(
+        clusterProperties.UpdateStrategy,
+      );
+      await expect(createOSDWizardPage.nodeDrainingValue()).toContainText(
+        clusterProperties.NodeDraining,
+      );
+    });
+
+    test(`OSD GCP curated wizard - Shared VPC DNS PSC : Cluster submission & overview definitions`, async ({
+      createOSDWizardPage,
+      clusterDetailsPage,
+    }) => {
+      await createOSDWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toContainText(
+        'Installing cluster',
+      );
+      await expect(clusterDetailsPage.clusterInstallationExpectedText()).toContainText(
+        'Cluster creation usually takes 30 to 60 minutes to complete',
+      );
+      await expect(clusterDetailsPage.downloadOcCliLink()).toContainText('Download OC CLI');
+
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+
+      await expect(clusterDetailsPage.clusterTypeLabelValue()).toContainText(
+        clusterProperties.Type,
+      );
+      await expect(clusterDetailsPage.clusterRegionLabelValue()).toContainText(region);
+      await expect(clusterDetailsPage.clusterAvailabilityLabelValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(clusterDetailsPage.clusterMachineCIDRLabelValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(clusterDetailsPage.clusterServiceCIDRLabelValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(clusterDetailsPage.clusterPodCIDRLabelValue()).toContainText(
+        clusterProperties.PodCIDR,
+      );
+      await expect(clusterDetailsPage.clusterHostPrefixLabelValue()).toContainText(
+        clusterProperties.HostPrefix.replace('/', ''),
+      );
+      await expect(clusterDetailsPage.clusterSubscriptionBillingModelValue()).toContainText(
+        `On-demand via ${clusterProperties.Marketplace}`,
+      );
+      await expect(clusterDetailsPage.clusterInfrastructureBillingModelValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(clusterDetailsPage.clusterSecureBootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(clusterDetailsPage.clusterAuthenticationTypeLabelValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+    });
+
+    test('Delete OSD GCP curated cluster', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.actionsDropdownToggle().click();
+      await clusterDetailsPage.deleteClusterDropdownItem().click();
+      await clusterDetailsPage.deleteClusterNameInput().clear();
+      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+      await clusterDetailsPage.deleteClusterConfirm().click();
+      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    });
+  },
+);

--- a/playwright/e2e/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.spec.ts
@@ -12,6 +12,8 @@ test.describe.serial(
   'OSD GCP Curated Marketplace WIF Shared VPC DNS PSC cluster creation tests (OCMUI-3888)',
   { tag: ['@smoke', '@osd', '@curated', '@sharedvpc', '@psc', '@dns'] },
   () => {
+    let clusterSubmitted = false;
+
     test.beforeAll(async ({ navigateTo }) => {
       if (!QE_GCP_WIF_CONFIG?.trim()) {
         throw new Error(
@@ -57,7 +59,6 @@ test.describe.serial(
         await createOSDWizardPage.selectVersion(clusterProperties.Version);
       }
 
-      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
       await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
       await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
       await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
@@ -162,6 +163,7 @@ test.describe.serial(
       await expect(createOSDWizardPage.authenticationTypeValue()).toContainText(
         clusterProperties.AuthenticationType,
       );
+      await expect(createOSDWizardPage.wifConfigurationValue()).toContainText(QE_GCP_WIF_CONFIG);
       await expect(createOSDWizardPage.clusterNameValue()).toContainText(clusterName);
       await expect(createOSDWizardPage.regionValue()).toContainText(region);
       await expect(createOSDWizardPage.availabilityValue()).toContainText(
@@ -199,11 +201,30 @@ test.describe.serial(
         clusterProperties.InstallIntoExistingVPC,
       );
 
-      if (clusterProperties.hasOwnProperty('UsePrivateServiceConnect')) {
+      if ('UsePrivateServiceConnect' in clusterProperties) {
         await expect(createOSDWizardPage.privateServiceConnectValue()).toContainText(
           clusterProperties.UsePrivateServiceConnect,
         );
       }
+
+      await expect(createOSDWizardPage.sharedHostProjectIdValue()).toContainText(
+        SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '',
+      );
+      await expect(createOSDWizardPage.dnsZoneValue()).toContainText(
+        clusterProperties.DomainPrefix,
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['VPC_NAME'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['PRIVATE_SERVICE_CONNECT_SUBNET'] || '',
+      );
 
       await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
         clusterProperties.MachineCIDR,
@@ -231,6 +252,7 @@ test.describe.serial(
       clusterDetailsPage,
     }) => {
       await createOSDWizardPage.createClusterButton().click();
+      clusterSubmitted = true;
       await clusterDetailsPage.waitForInstallerScreenToLoad();
 
       await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
@@ -281,13 +303,18 @@ test.describe.serial(
       );
     });
 
-    test('Delete OSD GCP curated cluster', async ({ clusterDetailsPage }) => {
-      await clusterDetailsPage.actionsDropdownToggle().click();
-      await clusterDetailsPage.deleteClusterDropdownItem().click();
-      await clusterDetailsPage.deleteClusterNameInput().clear();
-      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
-      await clusterDetailsPage.deleteClusterConfirm().click();
-      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    test.afterAll(async ({ clusterDetailsPage }) => {
+      if (!clusterSubmitted) return;
+      try {
+        await clusterDetailsPage.actionsDropdownToggle().click();
+        await clusterDetailsPage.deleteClusterDropdownItem().click();
+        await clusterDetailsPage.deleteClusterNameInput().clear();
+        await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+        await clusterDetailsPage.deleteClusterConfirm().click();
+        await clusterDetailsPage.waitForDeleteClusterActionComplete();
+      } catch (error) {
+        console.error(`Cleanup failed for cluster "${clusterName}":`, error);
+      }
     });
   },
 );

--- a/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.ts
@@ -1,0 +1,300 @@
+import { test, expect } from '../../fixtures/pages';
+const clusterProperties = require('../../fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.json');
+const clusterName = `${clusterProperties.ClusterName}-${Math.random().toString(36).substring(7)}`;
+
+// Environment variables
+const QE_GCP_WIF_CONFIG = process.env.QE_GCP_WIF_CONFIG || '';
+const QE_INFRA_GCP = JSON.parse(process.env.QE_INFRA_GCP || '{}');
+const SHARED_VPC_INFRA = QE_INFRA_GCP['SHARED_VPC_INFRA'] || {};
+const region = SHARED_VPC_INFRA['REGION'] || clusterProperties.Region.split(',')[0];
+
+test.describe.serial(
+  'OSD Marketplace GCP WIF Shared VPC cluster creation tests',
+  { tag: ['@smoke', '@osd', '@wif', '@sharedvpc'] },
+  () => {
+    test.beforeAll(async ({ navigateTo }) => {
+      // Navigate to create
+      await navigateTo('create');
+    });
+    test(`Launch OSD - GCP shared VPC  zone cluster wizard`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.waitAndClick(createOSDWizardPage.osdCreateClusterButton());
+      await createOSDWizardPage.isCreateOSDPage();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone : Billing model and its definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isBillingModelScreen();
+      await createOSDWizardPage.selectSubscriptionType(clusterProperties.SubscriptionType);
+      await createOSDWizardPage.selectInfrastructureType(clusterProperties.InfrastructureType);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone : Cluster Settings - Cloud provider definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.workloadIdentityFederationButton().click();
+      await createOSDWizardPage.selectWorkloadIdentityConfiguration(QE_GCP_WIF_CONFIG);
+      await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone : Cluster Settings - Cluster details definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isClusterDetailsScreen();
+      await page.locator(createOSDWizardPage.clusterNameInput).fill(clusterName);
+      await createOSDWizardPage.hideClusterNameValidation();
+      await createOSDWizardPage.selectRegion(region);
+      await createOSDWizardPage.selectVersion(
+        clusterProperties.Version || process.env.VERSION || '',
+      );
+      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
+      await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
+      await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
+      await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone  : Cluster Settings - Default machinepool definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isMachinePoolScreen();
+      await createOSDWizardPage.selectComputeNodeType(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await createOSDWizardPage.selectComputeNodeCount(clusterProperties.MachinePools[0].NodeCount);
+      await createOSDWizardPage.addNodeLabelLink().click();
+      await createOSDWizardPage.addNodeLabelKeyAndValue(
+        clusterProperties.MachinePools[0].Labels[0].Key,
+        clusterProperties.MachinePools[0].Labels[0].Value,
+      );
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone : Networking configuration - cluster privacy definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
+      await createOSDWizardPage.installIntoExistingVpcCheckBox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone  : VPC Settings definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isVPCSubnetScreen();
+      await createOSDWizardPage.installIntoSharedVpcCheckBox().check();
+      await createOSDWizardPage
+        .sharedHostProjectIdInput()
+        .fill(SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '');
+      await createOSDWizardPage.vpcNameInput().fill(SHARED_VPC_INFRA['VPC_NAME'] || '');
+      await createOSDWizardPage
+        .controlPlaneSubnetInput()
+        .fill(SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '');
+      await createOSDWizardPage.computeSubnetInput().fill(SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '');
+      await createOSDWizardPage.wizardNextButton().click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone  : Networking configuration - CIDR ranges definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isCIDRScreen();
+      await createOSDWizardPage.useCIDRDefaultValues(false);
+      await createOSDWizardPage.useCIDRDefaultValues(true);
+
+      await expect(createOSDWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixInput()).toHaveValue(clusterProperties.HostPrefix);
+
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone : Cluster updates definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isUpdatesScreen();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC  zone  : Review and create page definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isReviewScreen();
+
+      await expect(createOSDWizardPage.subscriptionTypeValue()).toContainText(
+        clusterProperties.SubscriptionType,
+      );
+      await expect(createOSDWizardPage.infrastructureTypeValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(createOSDWizardPage.cloudProviderValue()).toContainText(
+        clusterProperties.CloudProvider,
+      );
+
+      await expect(createOSDWizardPage.authenticationTypeValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+      if (clusterProperties.AuthenticationType.includes('Workload Identity Federation')) {
+        await expect(createOSDWizardPage.wifConfigurationValue()).toContainText(QE_GCP_WIF_CONFIG);
+      }
+
+      await expect(createOSDWizardPage.clusterNameValue()).toContainText(clusterName);
+      await expect(createOSDWizardPage.regionValue()).toContainText(region);
+      await expect(createOSDWizardPage.availabilityValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(createOSDWizardPage.securebootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(createOSDWizardPage.userWorkloadMonitoringValue()).toContainText(
+        clusterProperties.UserWorkloadMonitoring,
+      );
+      await expect(createOSDWizardPage.additionalEtcdEncryptionValue()).toContainText(
+        clusterProperties.AdditionalEncryption,
+      );
+      await expect(createOSDWizardPage.fipsCryptographyValue()).toContainText(
+        clusterProperties.FIPSCryptography,
+      );
+      await expect(createOSDWizardPage.nodeInstanceTypeValue()).toContainText(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await expect(createOSDWizardPage.autoscalingValue()).toContainText(
+        clusterProperties.MachinePools[0].Autoscaling,
+      );
+
+      await expect(createOSDWizardPage.computeNodeCountValue()).toContainText(
+        `${clusterProperties.MachinePools[0].NodeCount} (× 3 zones = ${clusterProperties.MachinePools[0].NodeCount * 3} compute nodes)`,
+      );
+      const label = `${clusterProperties.MachinePools[0].Labels[0].Key} = ${clusterProperties.MachinePools[0].Labels[0].Value}`;
+      await expect(createOSDWizardPage.nodeLabelsValue(label)).toBeVisible();
+      await expect(createOSDWizardPage.clusterPrivacyValue()).toContainText(
+        clusterProperties.ClusterPrivacy,
+      );
+      await expect(createOSDWizardPage.installIntoExistingVpcValue()).toContainText(
+        clusterProperties.InstallIntoExistingVPC,
+      );
+      await expect(createOSDWizardPage.sharedHostProjectIdValue()).toContainText(
+        SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '',
+      );
+      await expect(createOSDWizardPage.dnsZoneValue()).not.toBeVisible();
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['VPC_NAME'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '',
+      );
+
+      await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRValue()).toContainText(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixValue()).toContainText(
+        clusterProperties.HostPrefix,
+      );
+      await expect(createOSDWizardPage.applicationIngressValue()).toContainText(
+        clusterProperties.ApplicationIngress,
+      );
+      await expect(createOSDWizardPage.updateStratergyValue()).toContainText(
+        clusterProperties.UpdateStrategy,
+      );
+      await expect(createOSDWizardPage.nodeDrainingValue()).toContainText(
+        clusterProperties.NodeDraining,
+      );
+    });
+
+    test(`OSD wizard -  GCP shared VPC  zone  : Cluster submission & overview definitions`, async ({
+      createOSDWizardPage,
+      clusterDetailsPage,
+    }) => {
+      await createOSDWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toContainText(
+        'Installing cluster',
+      );
+      await expect(clusterDetailsPage.clusterInstallationExpectedText()).toContainText(
+        'Cluster creation usually takes 30 to 60 minutes to complete',
+      );
+      await expect(clusterDetailsPage.downloadOcCliLink()).toContainText('Download OC CLI');
+
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+
+      await expect(clusterDetailsPage.clusterTypeLabelValue()).toContainText(
+        clusterProperties.Type,
+      );
+      await expect(clusterDetailsPage.clusterRegionLabelValue()).toContainText(region);
+      await expect(clusterDetailsPage.clusterAvailabilityLabelValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(clusterDetailsPage.clusterMachineCIDRLabelValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(clusterDetailsPage.clusterServiceCIDRLabelValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(clusterDetailsPage.clusterPodCIDRLabelValue()).toContainText(
+        clusterProperties.PodCIDR,
+      );
+      await expect(clusterDetailsPage.clusterHostPrefixLabelValue()).toContainText(
+        clusterProperties.HostPrefix.replace('/', ''),
+      );
+      await expect(clusterDetailsPage.clusterSubscriptionBillingModelValue()).toContainText(
+        `On-demand via ${clusterProperties.Marketplace}`,
+      );
+      await expect(clusterDetailsPage.clusterInfrastructureBillingModelValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(clusterDetailsPage.clusterSecureBootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(clusterDetailsPage.clusterAuthenticationTypeLabelValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+
+      if (clusterProperties.AuthenticationType.includes('Workload Identity Federation')) {
+        await expect(clusterDetailsPage.clusterWifConfigurationValue()).toContainText(
+          QE_GCP_WIF_CONFIG,
+        );
+      }
+    });
+
+    test('Delete OSD cluster', async ({ page, clusterDetailsPage }) => {
+      await clusterDetailsPage.actionsDropdownToggle().click();
+      await clusterDetailsPage.deleteClusterDropdownItem().click();
+      await clusterDetailsPage.deleteClusterNameInput().clear();
+      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+      await clusterDetailsPage.deleteClusterConfirm().click();
+      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    });
+  },
+);

--- a/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.ts
@@ -12,8 +12,14 @@ test.describe.serial(
   'OSD Marketplace GCP WIF Shared VPC cluster creation tests',
   { tag: ['@smoke', '@osd', '@wif', '@sharedvpc'] },
   () => {
+    let clusterSubmitted = false;
+
     test.beforeAll(async ({ navigateTo }) => {
-      // Navigate to create
+      if (!QE_GCP_WIF_CONFIG?.trim()) {
+        throw new Error(
+          'QE_GCP_WIF_CONFIG must be set for GCP WIF Shared VPC tests',
+        );
+      }
       await navigateTo('create');
     });
     test(`Launch OSD - GCP shared VPC  zone cluster wizard`, async ({
@@ -55,7 +61,6 @@ test.describe.serial(
       await createOSDWizardPage.selectVersion(
         clusterProperties.Version || process.env.VERSION || '',
       );
-      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
       await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
       await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
       await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
@@ -195,7 +200,6 @@ test.describe.serial(
       await expect(createOSDWizardPage.sharedHostProjectIdValue()).toContainText(
         SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '',
       );
-      await expect(createOSDWizardPage.dnsZoneValue()).not.toBeVisible();
       await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
         SHARED_VPC_INFRA['VPC_NAME'] || '',
       );
@@ -205,7 +209,7 @@ test.describe.serial(
       await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
         SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '',
       );
-
+      await expect(createOSDWizardPage.dnsZoneValue()).not.toBeVisible();
       await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
         clusterProperties.MachineCIDR,
       );
@@ -232,6 +236,7 @@ test.describe.serial(
       clusterDetailsPage,
     }) => {
       await createOSDWizardPage.createClusterButton().click();
+      clusterSubmitted = true;
       await clusterDetailsPage.waitForInstallerScreenToLoad();
 
       await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
@@ -288,13 +293,18 @@ test.describe.serial(
       }
     });
 
-    test('Delete OSD cluster', async ({ page, clusterDetailsPage }) => {
-      await clusterDetailsPage.actionsDropdownToggle().click();
-      await clusterDetailsPage.deleteClusterDropdownItem().click();
-      await clusterDetailsPage.deleteClusterNameInput().clear();
-      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
-      await clusterDetailsPage.deleteClusterConfirm().click();
-      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    test.afterAll(async ({ clusterDetailsPage }) => {
+      if (!clusterSubmitted) return;
+      try {
+        await clusterDetailsPage.actionsDropdownToggle().click();
+        await clusterDetailsPage.deleteClusterDropdownItem().click();
+        await clusterDetailsPage.deleteClusterNameInput().clear();
+        await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+        await clusterDetailsPage.deleteClusterConfirm().click();
+        await clusterDetailsPage.waitForDeleteClusterActionComplete();
+      } catch (error) {
+        console.error(`Cleanup failed for cluster "${clusterName}":`, error);
+      }
     });
   },
 );

--- a/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.ts
@@ -12,8 +12,14 @@ test.describe.serial(
   'OSD Marketplace GCP WIF Shared VPC DNS cluster creation tests',
   { tag: ['@smoke', '@osd', '@wif', '@sharedvpc', '@dns'] },
   () => {
+    let clusterSubmitted = false;
+
     test.beforeAll(async ({ navigateTo }) => {
-      // Navigate to create
+      if (!QE_GCP_WIF_CONFIG?.trim()) {
+        throw new Error(
+          'QE_GCP_WIF_CONFIG must be set for GCP WIF Shared VPC DNS tests',
+        );
+      }
       await navigateTo('create');
     });
     test(`Launch OSD - GCP shared VPC DNS zone cluster wizard`, async ({
@@ -57,7 +63,6 @@ test.describe.serial(
       await createOSDWizardPage.selectVersion(
         clusterProperties.Version || process.env.VERSION || '',
       );
-      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
       await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
       await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
       await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
@@ -202,7 +207,7 @@ test.describe.serial(
       await expect(createOSDWizardPage.sharedHostProjectIdValue()).toContainText(
         SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '',
       );
-      await expect(createOSDWizardPage.dnsZoneValue()).not.toBeVisible();
+      await expect(createOSDWizardPage.dnsZoneValue()).toContainText(clusterProperties.DomainPrefix);
       await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
         SHARED_VPC_INFRA['VPC_NAME'] || '',
       );
@@ -239,6 +244,7 @@ test.describe.serial(
       clusterDetailsPage,
     }) => {
       await createOSDWizardPage.createClusterButton().click();
+      clusterSubmitted = true;
       await clusterDetailsPage.waitForInstallerScreenToLoad();
 
       await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
@@ -295,13 +301,18 @@ test.describe.serial(
       }
     });
 
-    test('Delete OSD cluster', async ({ page, clusterDetailsPage }) => {
-      await clusterDetailsPage.actionsDropdownToggle().click();
-      await clusterDetailsPage.deleteClusterDropdownItem().click();
-      await clusterDetailsPage.deleteClusterNameInput().clear();
-      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
-      await clusterDetailsPage.deleteClusterConfirm().click();
-      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    test.afterAll(async ({ clusterDetailsPage }) => {
+      if (!clusterSubmitted) return;
+      try {
+        await clusterDetailsPage.actionsDropdownToggle().click();
+        await clusterDetailsPage.deleteClusterDropdownItem().click();
+        await clusterDetailsPage.deleteClusterNameInput().clear();
+        await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+        await clusterDetailsPage.deleteClusterConfirm().click();
+        await clusterDetailsPage.waitForDeleteClusterActionComplete();
+      } catch (error) {
+        console.error(`Cleanup failed for cluster "${clusterName}":`, error);
+      }
     });
   },
 );

--- a/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.ts
@@ -1,0 +1,307 @@
+import { test, expect } from '../../fixtures/pages';
+const clusterProperties = require('../../fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.json');
+const clusterName = `${clusterProperties.ClusterName}-${Math.random().toString(36).substring(7)}`;
+
+// Environment variables
+const QE_GCP_WIF_CONFIG = process.env.QE_GCP_WIF_CONFIG || '';
+const QE_INFRA_GCP = JSON.parse(process.env.QE_INFRA_GCP || '{}');
+const SHARED_VPC_INFRA = QE_INFRA_GCP['SHARED_VPC_INFRA'] || {};
+const region = SHARED_VPC_INFRA['REGION'] || clusterProperties.Region.split(',')[0];
+
+test.describe.serial(
+  'OSD Marketplace GCP WIF Shared VPC DNS cluster creation tests',
+  { tag: ['@smoke', '@osd', '@wif', '@sharedvpc', '@dns'] },
+  () => {
+    test.beforeAll(async ({ navigateTo }) => {
+      // Navigate to create
+      await navigateTo('create');
+    });
+    test(`Launch OSD - GCP shared VPC DNS zone cluster wizard`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.waitAndClick(createOSDWizardPage.osdCreateClusterButton());
+      await createOSDWizardPage.isCreateOSDPage();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone : Billing model and its definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isBillingModelScreen();
+      await createOSDWizardPage.selectSubscriptionType(clusterProperties.SubscriptionType);
+      await createOSDWizardPage.selectInfrastructureType(clusterProperties.InfrastructureType);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone : Cluster Settings - Cloud provider definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.workloadIdentityFederationButton().click();
+      await createOSDWizardPage.selectWorkloadIdentityConfiguration(QE_GCP_WIF_CONFIG);
+      await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone : Cluster Settings - Cluster details definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isClusterDetailsScreen();
+      await page.locator(createOSDWizardPage.clusterNameInput).fill(clusterName);
+      await createOSDWizardPage.createCustomDomainPrefixCheckbox().check();
+      await createOSDWizardPage.domainPrefixInput().fill(clusterProperties.DomainPrefix);
+      await createOSDWizardPage.hideClusterNameValidation();
+      await createOSDWizardPage.selectRegion(region);
+      await createOSDWizardPage.selectVersion(
+        clusterProperties.Version || process.env.VERSION || '',
+      );
+      await createOSDWizardPage.singleZoneAvilabilityRadio().check();
+      await createOSDWizardPage.selectAvailabilityZone(clusterProperties.Availability);
+      await createOSDWizardPage.enableAdditionalEtcdEncryption(true, true);
+      await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone  : Cluster Settings - Default machinepool definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isMachinePoolScreen();
+      await createOSDWizardPage.selectComputeNodeType(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await createOSDWizardPage.selectComputeNodeCount(clusterProperties.MachinePools[0].NodeCount);
+      await createOSDWizardPage.addNodeLabelLink().click();
+      await createOSDWizardPage.addNodeLabelKeyAndValue(
+        clusterProperties.MachinePools[0].Labels[0].Key,
+        clusterProperties.MachinePools[0].Labels[0].Value,
+      );
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone : Networking configuration - cluster privacy definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
+      await createOSDWizardPage.installIntoExistingVpcCheckBox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone  : VPC Settings definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isVPCSubnetScreen();
+      await createOSDWizardPage.installIntoSharedVpcCheckBox().check();
+      await createOSDWizardPage
+        .sharedHostProjectIdInput()
+        .fill(SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '');
+      await createOSDWizardPage.createDnsZoneToggle().click();
+      await expect(createOSDWizardPage.createDnsZoneCommand()).toHaveValue(
+        `ocm gcp create dns-zone --domain-prefix ${clusterProperties.DomainPrefix} --project-id <project-id> --network-project-id <network-project-id> --network-id <vpc-id>`,
+      );
+      await createOSDWizardPage.selectDnsZone(clusterProperties.DomainPrefix, true);
+      await createOSDWizardPage.vpcNameInput().fill(SHARED_VPC_INFRA['VPC_NAME'] || '');
+      await createOSDWizardPage
+        .controlPlaneSubnetInput()
+        .fill(SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '');
+      await createOSDWizardPage.computeSubnetInput().fill(SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '');
+      await createOSDWizardPage.wizardNextButton().click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone  : Networking configuration - CIDR ranges definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isCIDRScreen();
+      await createOSDWizardPage.useCIDRDefaultValues(false);
+      await createOSDWizardPage.useCIDRDefaultValues(true);
+
+      await expect(createOSDWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixInput()).toHaveValue(clusterProperties.HostPrefix);
+
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone : Cluster updates definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isUpdatesScreen();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD wizard - GCP shared VPC DNS zone  : Review and create page definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isReviewScreen();
+
+      await expect(createOSDWizardPage.subscriptionTypeValue()).toContainText(
+        clusterProperties.SubscriptionType,
+      );
+      await expect(createOSDWizardPage.infrastructureTypeValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(createOSDWizardPage.cloudProviderValue()).toContainText(
+        clusterProperties.CloudProvider,
+      );
+
+      await expect(createOSDWizardPage.authenticationTypeValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+      if (clusterProperties.AuthenticationType.includes('Workload Identity Federation')) {
+        await expect(createOSDWizardPage.wifConfigurationValue()).toContainText(QE_GCP_WIF_CONFIG);
+      }
+
+      await expect(createOSDWizardPage.clusterNameValue()).toContainText(clusterName);
+      await expect(createOSDWizardPage.regionValue()).toContainText(region);
+      await expect(createOSDWizardPage.availabilityValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(createOSDWizardPage.securebootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(createOSDWizardPage.userWorkloadMonitoringValue()).toContainText(
+        clusterProperties.UserWorkloadMonitoring,
+      );
+      await expect(createOSDWizardPage.additionalEtcdEncryptionValue()).toContainText(
+        clusterProperties.AdditionalEncryption,
+      );
+      await expect(createOSDWizardPage.fipsCryptographyValue()).toContainText(
+        clusterProperties.FIPSCryptography,
+      );
+      await expect(createOSDWizardPage.nodeInstanceTypeValue()).toContainText(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await expect(createOSDWizardPage.autoscalingValue()).toContainText(
+        clusterProperties.MachinePools[0].Autoscaling,
+      );
+
+      await expect(createOSDWizardPage.computeNodeCountValue()).toContainText(
+        `${clusterProperties.MachinePools[0].NodeCount} (× 3 zones = ${clusterProperties.MachinePools[0].NodeCount * 3} compute nodes)`,
+      );
+      const label = `${clusterProperties.MachinePools[0].Labels[0].Key} = ${clusterProperties.MachinePools[0].Labels[0].Value}`;
+      await expect(createOSDWizardPage.nodeLabelsValue(label)).toBeVisible();
+      await expect(createOSDWizardPage.clusterPrivacyValue()).toContainText(
+        clusterProperties.ClusterPrivacy,
+      );
+      await expect(createOSDWizardPage.installIntoExistingVpcValue()).toContainText(
+        clusterProperties.InstallIntoExistingVPC,
+      );
+      await expect(createOSDWizardPage.sharedHostProjectIdValue()).toContainText(
+        SHARED_VPC_INFRA['HOST_PROJECT_ID'] || '',
+      );
+      await expect(createOSDWizardPage.dnsZoneValue()).not.toBeVisible();
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['VPC_NAME'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['CONTROLPLANE_SUBNET'] || '',
+      );
+      await expect(createOSDWizardPage.vpcSubnetSettingsValue()).toContainText(
+        SHARED_VPC_INFRA['COMPUTE_SUBNET'] || '',
+      );
+
+      await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRValue()).toContainText(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixValue()).toContainText(
+        clusterProperties.HostPrefix,
+      );
+      await expect(createOSDWizardPage.applicationIngressValue()).toContainText(
+        clusterProperties.ApplicationIngress,
+      );
+      await expect(createOSDWizardPage.updateStratergyValue()).toContainText(
+        clusterProperties.UpdateStrategy,
+      );
+      await expect(createOSDWizardPage.nodeDrainingValue()).toContainText(
+        clusterProperties.NodeDraining,
+      );
+    });
+
+    test(`OSD wizard -  GCP shared VPC DNS zone  : Cluster submission & overview definitions`, async ({
+      createOSDWizardPage,
+      clusterDetailsPage,
+    }) => {
+      await createOSDWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toContainText(
+        'Installing cluster',
+      );
+      await expect(clusterDetailsPage.clusterInstallationExpectedText()).toContainText(
+        'Cluster creation usually takes 30 to 60 minutes to complete',
+      );
+      await expect(clusterDetailsPage.downloadOcCliLink()).toContainText('Download OC CLI');
+
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+
+      await expect(clusterDetailsPage.clusterTypeLabelValue()).toContainText(
+        clusterProperties.Type,
+      );
+      await expect(clusterDetailsPage.clusterRegionLabelValue()).toContainText(region);
+      await expect(clusterDetailsPage.clusterAvailabilityLabelValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(clusterDetailsPage.clusterMachineCIDRLabelValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(clusterDetailsPage.clusterServiceCIDRLabelValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(clusterDetailsPage.clusterPodCIDRLabelValue()).toContainText(
+        clusterProperties.PodCIDR,
+      );
+      await expect(clusterDetailsPage.clusterHostPrefixLabelValue()).toContainText(
+        clusterProperties.HostPrefix.replace('/', ''),
+      );
+      await expect(clusterDetailsPage.clusterSubscriptionBillingModelValue()).toContainText(
+        `On-demand via ${clusterProperties.Marketplace}`,
+      );
+      await expect(clusterDetailsPage.clusterInfrastructureBillingModelValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(clusterDetailsPage.clusterSecureBootSupportForShieldedVMsValue()).toContainText(
+        clusterProperties.SecureBootSupportForShieldedVMs,
+      );
+      await expect(clusterDetailsPage.clusterAuthenticationTypeLabelValue()).toContainText(
+        clusterProperties.AuthenticationType,
+      );
+
+      if (clusterProperties.AuthenticationType.includes('Workload Identity Federation')) {
+        await expect(clusterDetailsPage.clusterWifConfigurationValue()).toContainText(
+          QE_GCP_WIF_CONFIG,
+        );
+      }
+    });
+
+    test('Delete OSD cluster', async ({ page, clusterDetailsPage }) => {
+      await clusterDetailsPage.actionsDropdownToggle().click();
+      await clusterDetailsPage.deleteClusterDropdownItem().click();
+      await clusterDetailsPage.deleteClusterNameInput().clear();
+      await clusterDetailsPage.deleteClusterNameInput().fill(clusterName);
+      await clusterDetailsPage.deleteClusterConfirm().click();
+      await clusterDetailsPage.waitForDeleteClusterActionComplete();
+    });
+  },
+);

--- a/playwright/fixtures/osd-gcp/osd-ccs-gcp-wizard-validation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ccs-gcp-wizard-validation.spec.json
@@ -82,18 +82,6 @@
               "UpperLimitError": "Input cannot be more than 83",
               "MinAndMaxLimitDependencyError": "Max nodes cannot be less than min nodes"
             }
-          },
-          "NonCCS": {
-            "SingleZone": {
-              "LowerLimitError": "Input cannot be less than 4",
-              "UpperLimitError": "Input cannot be more than 249",
-              "MinAndMaxLimitDependencyError": "Max nodes cannot be less than min nodes"
-            },
-            "MultiZone": {
-              "LowerLimitError": "Input cannot be less than 3",
-              "UpperLimitError": "Input cannot be more than 83",
-              "MinAndMaxLimitDependencyError": "Max nodes cannot be less than min nodes"
-            }
           }
         },
         "Common": {
@@ -166,6 +154,35 @@
                 }
               ]
             }
+          }
+        },
+        "InstallIntoExistingVPC": {
+          "InstallationNote": "NOTE: To install a cluster into a shared VPC, the shared VPC administrator must enable a project as a host project in their Google Cloud console. Then you can attach service projects to the host project",
+          "DNSZoneNote": "To create and select a DNS zone, you must first specify a Custom domain prefix",
+          "SharedHostProjectId": {
+            "NonExistingProjectId": "t1",
+            "NonExistingProjectIdError": "Not a valid hosted project ID. This must be an existing Google Cloud project ID within which all networks are defined",
+            "InvalidProjectId": "t@#$%^&*()_+=[]{}|;:'\",.<>/?",
+            "InvalidProjectIdError": "Not a valid hosted project ID. This must be an existing Google Cloud project ID within which all networks are defined",
+            "RequiredFieldError": "Field is required"
+          },
+          "ExistingVPCName": {
+            "InvalidVPCName": "D@#$%^&*()_+=[]{}|;:'\",.<>/?",
+            "InvalidVPCNameError": "Name should contain only lowercase letters, numbers and hyphens",
+            "RequiredFieldError": "Field is required",
+            "WhitespaceError": "Name must not contain whitespaces"
+          },
+          "ControlPlaneSubnetName": {
+            "InvalidControlPlaneSubnetName": "D@#$%^&*()_+=[]{}|;:'\",.<>/?",
+            "InvalidControlPlaneSubnetNameError": "Name should contain only lowercase letters, numbers and hyphens",
+            "RequiredFieldError": "Field is required",
+            "WhitespaceError": "Name must not contain whitespaces"
+          },
+          "ComputeSubnetName": {
+            "InvalidComputeSubnetName": "D@#$%^&*()_+=[]{}|;:'\",.<>/?",
+            "InvalidComputeSubnetNameError": "Name should contain only lowercase letters, numbers and hyphens",
+            "RequiredFieldError": "Field is required",
+            "WhitespaceError": "Name must not contain whitespaces"
           }
         }
       },

--- a/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.json
+++ b/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.json
@@ -1,0 +1,57 @@
+{
+  "ClusterName": "ocmui-curated-smoke-osd-psc-sharedvpc-wif",
+  "Type": "OSD",
+  "DomainPrefix": "plyautos1",
+  "CloudProvider": "Google Cloud",
+  "SubscriptionType": "On-Demand: Flexible usage billed through Google Cloud Marketplace",
+  "Marketplace": "Google Cloud Marketplace",
+  "InfrastructureType": "Customer cloud subscription",
+  "AuthenticationType": "Workload Identity Federation",
+  "Region": "us-central1, Council Bluffs, Iowa, USA",
+  "Availability": "Multi-zone",
+  "SecureBootSupportForShieldedVMs": "Enabled",
+  "UserWorkloadMonitoring": "Enabled",
+  "FIPSCryptography": "Enabled",
+  "EncryptionLevel": "FIPS Cryptography enabled",
+  "EncryptVolumesWithCustomerKeys": "Disabled",
+  "AdditionalEncryption": "Enabled",
+  "Nodes": {
+    "Control plane": "3/3",
+    "Infra": "2/2",
+    "Compute": "3/3"
+  },
+  "ClusterAutoscaling": "Disabled",
+  "InstallIntoExistingVPC": "Enabled",
+  "UsePrivateServiceConnect": "Enabled",
+  "ClusterPrivacy": "Private",
+  "MachineCIDR": "10.0.0.0/16",
+  "ServiceCIDR": "172.30.0.0/16",
+  "PodCIDR": "10.128.0.0/14",
+  "HostPrefix": "/23",
+  "ApplicationIngress": "Use default settings",
+  "UpdateStrategy": "Individual updates",
+  "NodeDraining": "60 minutes",
+  "MachinePools": [
+    {
+      "Name": "worker",
+      "InstanceType": "e2-standard-4",
+      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
+      "NodeCount": 1,
+      "Autoscaling": "Disabled",
+      "Labels": [
+        {
+          "Key": "ocmplaywright-tests",
+          "Value": "osd-gcp-sharedvpc-dns-psc-curated"
+        }
+      ]
+    }
+  ],
+  "networking": {
+    "CIDRRanges": {
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "Hostprefix": "/23"
+    }
+  }
+}

--- a/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.json
+++ b/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.json
@@ -35,7 +35,6 @@
     {
       "Name": "worker",
       "InstanceType": "e2-standard-4",
-      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
       "NodeCount": 1,
       "Autoscaling": "Disabled",
       "Labels": [

--- a/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.json
@@ -34,7 +34,6 @@
     {
       "Name": "worker",
       "InstanceType": "e2-standard-4",
-      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
       "NodeCount": 1,
       "Autoscaling": "Disabled",
       "Labels": [

--- a/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.json
@@ -1,0 +1,56 @@
+{
+  "ClusterName": "ocmui-smoke-osd-sharedvpc-wif-gcp",
+  "DomainPrefix": "plyautos2",
+  "Type": "OSD",
+  "CloudProvider": "Google Cloud",
+  "SubscriptionType": "On-Demand: Flexible usage billed through Google Cloud Marketplace",
+  "Marketplace": "Google Cloud Marketplace",
+  "InfrastructureType": "Customer cloud subscription",
+  "AuthenticationType": "Workload Identity Federation",
+  "Region": "us-central1, Council Bluffs, Iowa, USA",
+  "Availability": "Multi-zone",
+  "SecureBootSupportForShieldedVMs": "Enabled",
+  "UserWorkloadMonitoring": "Enabled",
+  "FIPSCryptography": "Enabled",
+  "EncryptionLevel": "FIPS Cryptography enabled",
+  "EncryptVolumesWithCustomerKeys": "Disabled",
+  "AdditionalEncryption": "Enabled",
+  "Nodes": {
+    "Control plane": "3/3",
+    "Infra": "2/2",
+    "Compute": "3/3"
+  },
+  "ClusterAutoscaling": "Disabled",
+  "InstallIntoExistingVPC": "Enabled",
+  "ClusterPrivacy": "Public",
+  "MachineCIDR": "10.0.0.0/16",
+  "ServiceCIDR": "172.30.0.0/16",
+  "PodCIDR": "10.128.0.0/14",
+  "HostPrefix": "/23",
+  "ApplicationIngress": "Use default settings",
+  "UpdateStrategy": "Individual updates",
+  "NodeDraining": "60 minutes",
+  "MachinePools": [
+    {
+      "Name": "worker",
+      "InstanceType": "e2-standard-4",
+      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
+      "NodeCount": 1,
+      "Autoscaling": "Disabled",
+      "Labels": [
+        {
+          "Key": "ocmplaywright-tests",
+          "Value": "osd-gcp-sharedvpc"
+        }
+      ]
+    }
+  ],
+  "networking": {
+    "CIDRRanges": {
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "Hostprefix": "/23"
+    }
+  }
+}

--- a/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.json
@@ -34,7 +34,6 @@
     {
       "Name": "worker",
       "InstanceType": "e2-standard-4",
-      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
       "NodeCount": 1,
       "Autoscaling": "Disabled",
       "Labels": [

--- a/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.json
@@ -1,0 +1,56 @@
+{
+  "ClusterName": "ocmui-pw-smoke-osd-sharedvpc-dns-wif-gcp",
+  "DomainPrefix": "plyautos",
+  "Type": "OSD",
+  "CloudProvider": "Google Cloud",
+  "SubscriptionType": "On-Demand: Flexible usage billed through Google Cloud Marketplace",
+  "Marketplace": "Google Cloud Marketplace",
+  "InfrastructureType": "Customer cloud subscription",
+  "AuthenticationType": "Workload Identity Federation",
+  "Region": "us-central1, Council Bluffs, Iowa, USA",
+  "Availability": "Multi-zone",
+  "SecureBootSupportForShieldedVMs": "Enabled",
+  "UserWorkloadMonitoring": "Enabled",
+  "FIPSCryptography": "Enabled",
+  "EncryptionLevel": "FIPS Cryptography enabled",
+  "EncryptVolumesWithCustomerKeys": "Disabled",
+  "AdditionalEncryption": "Enabled",
+  "Nodes": {
+    "Control plane": "3/3",
+    "Infra": "2/2",
+    "Compute": "3/3"
+  },
+  "ClusterAutoscaling": "Disabled",
+  "InstallIntoExistingVPC": "Enabled",
+  "ClusterPrivacy": "Public",
+  "MachineCIDR": "10.0.0.0/16",
+  "ServiceCIDR": "172.30.0.0/16",
+  "PodCIDR": "10.128.0.0/14",
+  "HostPrefix": "/23",
+  "ApplicationIngress": "Use default settings",
+  "UpdateStrategy": "Individual updates",
+  "NodeDraining": "60 minutes",
+  "MachinePools": [
+    {
+      "Name": "worker",
+      "InstanceType": "e2-standard-4",
+      "AvailabilityZones": "us-west-2a, us-west-2b, us-west-2c",
+      "NodeCount": 1,
+      "Autoscaling": "Disabled",
+      "Labels": [
+        {
+          "Key": "ocmplaywright-tests",
+          "Value": "osd-gcp-sharedvpc-dns"
+        }
+      ]
+    }
+  ],
+  "networking": {
+    "CIDRRanges": {
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "Hostprefix": "/23"
+    }
+  }
+}

--- a/playwright/page-objects/create-osd-wizard-page.ts
+++ b/playwright/page-objects/create-osd-wizard-page.ts
@@ -362,10 +362,12 @@ export class CreateOSDWizardPage extends BasePage {
     await this.dnsZoneDropdown().click();
     await this.dnsZoneFilterInput().clear();
     await this.dnsZoneFilterInput().fill(dnsZone);
-    const option = partialMatch
-      ? this.page.getByRole('option').filter({ hasText: new RegExp(`^${dnsZone}`) })
+    const escapedDnsZone = dnsZone.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const options = partialMatch
+      ? this.page.getByRole('option').filter({ hasText: new RegExp(`^${escapedDnsZone}`) })
       : this.page.getByRole('option', { name: dnsZone });
-    await option.click();
+    await expect(options).toHaveCount(1);
+    await options.first().click();
   }
 
   installIntoExistingVpcCheckBox(): Locator {

--- a/playwright/page-objects/create-osd-wizard-page.ts
+++ b/playwright/page-objects/create-osd-wizard-page.ts
@@ -334,6 +334,40 @@ export class CreateOSDWizardPage extends BasePage {
     }
   }
 
+  installIntoSharedVpcCheckBox(): Locator {
+    return this.page.getByRole('checkbox', { name: 'Install into Google Cloud Shared VPC' });
+  }
+
+  sharedHostProjectIdInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Host project ID' });
+  }
+
+  createDnsZoneToggle(): Locator {
+    return this.page.getByRole('button', { name: 'Create DNS Zone' });
+  }
+
+  createDnsZoneCommand(): Locator {
+    return this.page.getByLabel('Copyable create DNS zone command');
+  }
+
+  dnsZoneDropdown(): Locator {
+    return this.page.getByRole('button', { name: 'Options menu' });
+  }
+
+  dnsZoneFilterInput(): Locator {
+    return this.page.getByLabel('Filter by DNS zone name');
+  }
+
+  async selectDnsZone(dnsZone: string, partialMatch: boolean = false): Promise<void> {
+    await this.dnsZoneDropdown().click();
+    await this.dnsZoneFilterInput().clear();
+    await this.dnsZoneFilterInput().fill(dnsZone);
+    const option = partialMatch
+      ? this.page.getByRole('option').filter({ hasText: new RegExp(`^${dnsZone}`) })
+      : this.page.getByRole('option', { name: dnsZone });
+    await option.click();
+  }
+
   installIntoExistingVpcCheckBox(): Locator {
     return this.page.locator('input[id="install_to_vpc"]');
   }
@@ -349,6 +383,18 @@ export class CreateOSDWizardPage extends BasePage {
     ).toBeVisible();
   }
 
+  vpcNameInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Existing VPC name' });
+  }
+
+  controlPlaneSubnetInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Control plane subnet name' });
+  }
+
+  computeSubnetInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Compute subnet name' });
+  }
+
   async selectGcpVPC(vpcName: string): Promise<void> {
     await this.page.locator('select[aria-label="Existing VPC name"]').selectOption(vpcName);
   }
@@ -361,6 +407,10 @@ export class CreateOSDWizardPage extends BasePage {
 
   async selectComputeSubnetName(subnetName: string): Promise<void> {
     await this.page.locator('select[aria-label="Compute subnet name"]').selectOption(subnetName);
+  }
+
+  privateServiceConnectSubnetInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Private Service Connect subnet name' });
   }
 
   async selectPrivateServiceConnectSubnetName(pscName: string): Promise<void> {
@@ -483,6 +533,18 @@ export class CreateOSDWizardPage extends BasePage {
 
   privateServiceConnectValue(): Locator {
     return this.page.getByLabel('Networking').getByTestId('Private-service-connect').locator('div');
+  }
+
+  sharedHostProjectIdValue(): Locator {
+    return this.page.getByTestId('Google-Cloud-shared-host-project-ID').locator('div');
+  }
+
+  dnsZoneValue(): Locator {
+    return this.page.getByTestId('DNS-zone').locator('div');
+  }
+
+  vpcSubnetSettingsValue(): Locator {
+    return this.page.getByTestId('VPC-subnet-settings');
   }
 
   applicationIngressValue(): Locator {


### PR DESCRIPTION
# Summary

New playwright e2e specs on shared VPC, DNS zone GCP wizard areas

# Jira
Fixes [OCMUI-4223](https://issues.redhat.com/browse/OCMUI-4223)

# Additional information

**New test cases**
- Created three new test spec to cover the shared VPC functionality
-  osd-curated-gcp-wif-sharedvpc-psc-cluster-creation.spec.ts - covers shared VPC functionality along with DNS zone definition and private service connect
-  osd-ondemand-gcp-wif-sharedvpc-cluster-creation.spec.ts - covers shared VPC functionality without DNS zone definition
- osd-ondemand-gcp-wif-sharedvpc-dns-cluster-creation.spec.ts - covers shared VPC functionality along with DNS zone definition and public privacy.
- Updated fixture definition and page utilities as part of the PR.

**Test case updates**

- osd-ccs-gcp-wizard-validation.spec.ts - 
      Refactored few outdated non ccs osd definition in test specs. 
      Updated validation of missing shared vpc definitions.

 
# How to Test

1.Download the test case change PR(current PR) in other location, configure the playwright.env.json and run the test case command.
2. Configure your playwright.env.json with following definitions
**Note: If you are using the Dev OCM account, only update the following definitions:
TEST_WITHQUOTA_USER
TEST_WITHQUOTA_PASSWORD
QE_GCP_OSDCCSADMIN_JSON
All other definitions should remain unchanged.**
```
{
  "TEST_WITHQUOTA_USER": "<your username ends with -ocm configured in Dev ocm org>",
  "TEST_WITHQUOTA_PASSWORD": "<your passoword>",
  "QE_GCP_OSDCCSADMIN_JSON": {service account json definition},
  "QE_GCP_WIF_CONFIG": "ocmui-test-wif",
  "QE_INFRA_GCP": {
    "SHARED_VPC_INFRA": {
      "HOST_PROJECT_ID": "ocm-ui-dev-shared-vpc",
      "SERVICE_PROJECT_ID": "ocm-ui-dev",
      "VPC_NAME": "shared-ocmui-testing-vpc",
      "REGION": "us-central1",
      "CONTROLPLANE_SUBNET": "shared-ocmui-testing-control-plane",
      "COMPUTE_SUBNET": "shared-ocmui-testing-worker",
      "PRIVATE_SERVICE_CONNECT_SUBNET": "shared-ocmui-testing-psc"
    }
  }
}
```
5. Run the below test cases.
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test --grep "@sharedvpc" --workers 3
``` 

# Screen Captures

```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test --grep "@sharedvpc" --workers 3
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 32 tests using 3 workers
  32 passed (1.8m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 107.90s.


```

[OCMUI-4223]: https://redhat.atlassian.net/browse/OCMUI-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ