### PR TITLE
OCMUI-4146: Fix cluster transfer list data when cluster has been deprovisioned

### DIFF
--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.test.tsx
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.test.tsx
@@ -85,6 +85,40 @@ describe('<ClusterTransferList />', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders cluster name as plain text without a details link when subscription id is unknown', () => {
+    const displayName = 'cluster-without-subscription-id';
+    useFetchClusterTransferDetailMock.useFetchClusterTransferDetail.mockReturnValue({
+      data: {
+        items: [
+          {
+            ...fixtures.clusterDetails.cluster,
+            status: ClusterTransferStatus.Completed.toLowerCase(),
+            owner: testOwner,
+            name: displayName,
+            subscription: {
+              display_name: displayName,
+            },
+            version: {
+              raw_id: '4.17',
+            },
+            recipient: testRecipient,
+          },
+        ],
+      },
+      isLoading: false,
+      errors: [],
+      isError: false,
+    });
+    const state = {
+      userProfile: { keycloakProfile: { username: testOwner } },
+    };
+    withState(state).render(<ClusterTransferList />);
+
+    const nameEl = screen.getByText(displayName);
+    expect(nameEl.closest('a')).toBeNull();
+    expect(screen.queryByRole('link', { name: displayName })).not.toBeInTheDocument();
+  });
+
   it('Accept/Decline action button shown', async () => {
     const state = {
       userProfile: { keycloakProfile: { testRecipient } },

--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.test.tsx
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.test.tsx
@@ -75,7 +75,7 @@ describe('<ClusterTransferList />', () => {
       isError: false,
     });
     const state = {
-      userProfile: { keycloakProfile: { testOwner } },
+      userProfile: { keycloakProfile: { username: testOwner } },
     };
     withState(state).render(<ClusterTransferList />);
     expect(screen.queryByRole('button', { name: 'Refresh' })).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe('<ClusterTransferList />', () => {
 
   it('Accept/Decline action button shown', async () => {
     const state = {
-      userProfile: { keycloakProfile: { testRecipient } },
+      userProfile: { keycloakProfile: { username: testRecipient } },
     };
     useFetchClusterTransferDetailMock.useFetchClusterTransferDetail.mockReturnValue({
       data: {

--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
@@ -41,7 +41,7 @@ import { TABBED_CLUSTERS } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { viewConstants } from '~/redux/constants';
 import { useGlobalState } from '~/redux/hooks/useGlobalState';
-import { ClusterTransferStatus } from '~/types/accounts_mgmt.v1';
+import { ClusterTransferStatus, SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 import { ViewOptions } from '~/types/types';
 
 import ErrorTriangle from '../common/ErrorTriangle';
@@ -245,15 +245,16 @@ const ClusterTransferList = ({ hideRefreshButton }: { hideRefreshButton?: boolea
     const owner = transfer?.owner;
     const isOwner = owner === username;
     const isInterOrg = !transfer?.subscription && !isOwner;
-    const clusterName =
-      isInterOrg || subscriptionId === undefined ? (
-        transfer?.name
-      ) : (
-        <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
-      );
+    const clusterName = isInterOrg ? (
+      transfer?.name
+    ) : (
+      <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
+    );
     const clusterStatus = transfer.status;
     const transferAction = !!(
-      transfer.id && transfer?.status === ClusterTransferStatus.Pending.toLowerCase()
+      transfer.id &&
+      transfer?.status === ClusterTransferStatus.Pending.toLowerCase() &&
+      transfer?.subscription?.status !== SubscriptionCommonFieldsStatus.Deprovisioned
     );
     return (
       <Tr key={transfer?.id}>
@@ -268,7 +269,11 @@ const ClusterTransferList = ({ hideRefreshButton }: { hideRefreshButton?: boolea
             />
           ) : null}
         </Td>
-        <Td dataLabel={columnNames.type}>{transfer?.product?.id?.toUpperCase()}</Td>
+        <Td dataLabel={columnNames.type}>
+          {transfer?.product?.id === 'Unknown'
+            ? transfer?.product?.id
+            : transfer?.product?.id?.toUpperCase()}
+        </Td>
         <Td dataLabel={columnNames.version}>{transfer?.version?.raw_id}</Td>
         <Td dataLabel={columnNames.requested}>
           {isInterOrg ? (

--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
@@ -245,11 +245,12 @@ const ClusterTransferList = ({ hideRefreshButton }: { hideRefreshButton?: boolea
     const owner = transfer?.owner;
     const isOwner = owner === username;
     const isInterOrg = !transfer?.subscription && !isOwner;
-    const clusterName = isInterOrg ? (
-      transfer?.name
-    ) : (
-      <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
-    );
+    const clusterName =
+      isInterOrg || subscriptionId === undefined ? (
+        transfer?.name
+      ) : (
+        <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
+      );
     const clusterStatus = transfer.status;
     const transferAction = !!(
       transfer.id && transfer?.status === ClusterTransferStatus.Pending.toLowerCase()

--- a/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
+++ b/src/components/clusters/ClusterTransfer/ClusterTransferList.tsx
@@ -245,11 +245,12 @@ const ClusterTransferList = ({ hideRefreshButton }: { hideRefreshButton?: boolea
     const owner = transfer?.owner;
     const isOwner = owner === username;
     const isInterOrg = !transfer?.subscription && !isOwner;
-    const clusterName = isInterOrg ? (
-      transfer?.name
-    ) : (
-      <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
-    );
+    const clusterName =
+      isInterOrg || !subscriptionId ? (
+        transfer?.name
+      ) : (
+        <Link to={`/details/s/${subscriptionId}`}>{transfer?.name}</Link>
+      );
     const clusterStatus = transfer.status;
     const transferAction = !!(
       transfer.id &&
@@ -282,7 +283,7 @@ const ClusterTransferList = ({ hideRefreshButton }: { hideRefreshButton?: boolea
               <Tooltip
                 content={
                   <div>
-                    <p>This Transfer is from another user outside of your orgaization.</p>
+                    <p>This Transfer is from another user outside of your organization.</p>
                   </div>
                 }
               >

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
@@ -365,6 +365,7 @@ function actionResolver(
   const showTransferClusterOwnership =
     cluster.canEdit &&
     canTransferClusterOwnership &&
+    cluster.subscription &&
     (isAllowedProducts ||
       (allowAutoTransferClusterOwnership && isClusterOwner && isClusterReady)) &&
     subscriptionStatus !== SubscriptionCommonFieldsStatus.Archived &&

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
@@ -343,8 +343,8 @@ function actionResolver(
     !isProductOSDTrial &&
     !isHypershiftCluster(cluster);
   const showEditMachinePool = cluster.canEdit && cluster.managed;
-  const isArchived =
-    get(cluster, 'subscription.status', false) === SubscriptionCommonFieldsStatus.Archived;
+  const subscriptionStatus = get(cluster, 'subscription.status');
+  const isArchived = subscriptionStatus === SubscriptionCommonFieldsStatus.Archived;
   const showArchive = cluster.canEdit && !cluster.managed && cluster.subscription && !isArchived;
   const showUnarchive = cluster.canEdit && !cluster.managed && cluster.subscription && isArchived;
   const showEditURL =
@@ -367,7 +367,8 @@ function actionResolver(
     canTransferClusterOwnership &&
     (isAllowedProducts ||
       (allowAutoTransferClusterOwnership && isClusterOwner && isClusterReady)) &&
-    get(cluster, 'subscription.status') !== SubscriptionCommonFieldsStatus.Archived;
+    subscriptionStatus !== SubscriptionCommonFieldsStatus.Archived &&
+    subscriptionStatus !== SubscriptionCommonFieldsStatus.Deprovisioned;
   const showUpgradeTrialCluster = isClusterReady && cluster.canEdit && isProductOSDTrial;
 
   return [

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransferDetails.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransferDetails.tsx
@@ -47,35 +47,39 @@ export const useFetchClusterTransferDetail = ({
     error: errorSubscriptionData,
   } = useFetchSubscriptionsByExternalId(externalIds);
 
-  const clusterTransferDetails: ClusterTransferDetail[] = [];
-  dataTransfers?.items?.forEach((transfer: ClusterTransferDetail) => {
-    const transferDetails: ClusterTransferDetail = {
-      ...transfer,
-      name: transfer.cluster_uuid,
-      version: { raw_id: 'Unknown' },
-      product: { id: 'Unknown' },
-    };
-    const subscription = subscriptionData?.items?.find(
-      (sub: Subscription) => sub.external_cluster_id === transfer.cluster_uuid,
-    );
+  const clusterTransferDetails: ClusterTransferDetail[] =
+    dataTransfers?.items?.map((transfer: ClusterTransferDetail) => {
+      const subscription = subscriptionData?.items?.find(
+        (sub: Subscription) => sub.external_cluster_id === transfer.cluster_uuid,
+      );
 
-    if (subscription) {
-      transferDetails.name = subscription.display_name || transfer.cluster_uuid;
-      transferDetails.state = ClusterState.unknown;
-      transferDetails.subscription = subscription;
+      if (!subscription) {
+        return {
+          ...transfer,
+          name: transfer.cluster_uuid,
+          version: { raw_id: 'Unknown' },
+          product: { id: 'Unknown' },
+        };
+      }
+
       const version =
         subscription.status === SubscriptionCommonFieldsStatus.Deprovisioned
           ? 'Deleted'
           : subscription.metrics?.[0]?.openshift_version || 'Unknown';
-      transferDetails.product = {
-        id: normalizeProductID(subscription.plan?.type ?? subscription.plan?.id),
+
+      return {
+        ...transfer,
+        name: subscription.display_name || transfer.cluster_uuid,
+        state: ClusterState.unknown,
+        subscription,
+        product: {
+          id: normalizeProductID(subscription.plan?.type ?? subscription.plan?.id),
+        },
+        version: {
+          raw_id: version,
+        },
       };
-      transferDetails.version = {
-        raw_id: version,
-      };
-    }
-    clusterTransferDetails.push(transferDetails);
-  });
+    }) ?? [];
 
   if (isErrorTransfers || isErrorSubscriptionData) {
     // const formattedError = formatErrorData(isLoadingTransfers, isErrorTransfers, errorTransfers);

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransferDetails.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransferDetails.tsx
@@ -1,11 +1,16 @@
+import { normalizeProductID } from '~/common/normalize';
 import { queryClient } from '~/components/App/queryClient';
 // import { formatErrorData } from '~/queries/helpers';
 import { queryConstants } from '~/queries/queriesConstants';
-import { ClusterTransfer } from '~/types/accounts_mgmt.v1';
+import {
+  ClusterTransfer,
+  Subscription,
+  SubscriptionCommonFieldsStatus,
+} from '~/types/accounts_mgmt.v1';
 import { ClusterState } from '~/types/clusters_mgmt.v1/enums';
 import { ClusterFromSubscription } from '~/types/types';
 
-import { useFetchClusterByExternalId } from '../useFetchClusterByExternalId';
+import { useFetchSubscriptionsByExternalId } from '../useFetchSubscriptionsByExternalId';
 
 import { useFetchClusterTransfer } from './useFetchClusterTransfer';
 
@@ -36,11 +41,11 @@ export const useFetchClusterTransferDetail = ({
   const externalIds =
     dataTransfers?.items?.map((transfer) => `'${transfer.cluster_uuid}'`).join(',') || '';
   const {
-    data: clusterData,
-    isLoading: isLoadingClusterData,
-    isError: isErrorClusterData,
-    error: errorClusterData,
-  } = useFetchClusterByExternalId(externalIds);
+    data: subscriptionData,
+    isLoading: isLoadingSubscriptionData,
+    isError: isErrorSubscriptionData,
+    error: errorSubscriptionData,
+  } = useFetchSubscriptionsByExternalId(externalIds);
 
   const clusterTransferDetails: ClusterTransferDetail[] = [];
   dataTransfers?.items?.forEach((transfer: ClusterTransferDetail) => {
@@ -50,34 +55,41 @@ export const useFetchClusterTransferDetail = ({
       version: { raw_id: 'Unknown' },
       product: { id: 'Unknown' },
     };
-    const cluster = clusterData?.find(
-      (cluster: Partial<ClusterFromSubscription>) => cluster.external_id === transfer.cluster_uuid,
+    const subscription = subscriptionData?.items?.find(
+      (sub: Subscription) => sub.external_cluster_id === transfer.cluster_uuid,
     );
 
-    if (cluster) {
-      transferDetails.name =
-        cluster?.subscription?.display_name || cluster?.name || transfer.cluster_uuid;
-      transferDetails.state = cluster?.state || ClusterState.unknown;
-      transferDetails.subscription = cluster?.subscription;
-      transferDetails.product = cluster?.product || { id: 'Unknown' };
-      transferDetails.version = cluster?.version || { raw_id: 'Unknown' };
+    if (subscription) {
+      transferDetails.name = subscription.display_name || transfer.cluster_uuid;
+      transferDetails.state = ClusterState.unknown;
+      transferDetails.subscription = subscription;
+      const version =
+        subscription.status === SubscriptionCommonFieldsStatus.Deprovisioned
+          ? 'Deleted'
+          : subscription.metrics?.[0]?.openshift_version || 'Unknown';
+      transferDetails.product = {
+        id: normalizeProductID(subscription.plan?.type ?? subscription.plan?.id),
+      };
+      transferDetails.version = {
+        raw_id: version,
+      };
     }
     clusterTransferDetails.push(transferDetails);
   });
 
-  if (isErrorTransfers || isErrorClusterData) {
+  if (isErrorTransfers || isErrorSubscriptionData) {
     // const formattedError = formatErrorData(isLoadingTransfers, isErrorTransfers, errorTransfers);
     return {
       data: dataTransfers,
-      isLoading: isLoadingTransfers || isLoadingClusterData,
-      isError: isErrorTransfers || isErrorClusterData,
-      error: errorTransfers || errorClusterData,
+      isLoading: isLoadingTransfers || isLoadingSubscriptionData,
+      isError: isErrorTransfers || isErrorSubscriptionData,
+      error: errorTransfers || errorSubscriptionData,
     };
   }
   return {
     data: { items: clusterTransferDetails },
-    isLoading: isLoadingTransfers || isLoadingClusterData,
-    isError: isErrorTransfers || isErrorClusterData,
-    error: errorTransfers || errorClusterData,
+    isLoading: isLoadingTransfers || isLoadingSubscriptionData,
+    isError: isErrorTransfers || isErrorSubscriptionData,
+    error: errorTransfers || errorSubscriptionData,
   };
 };

--- a/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
+++ b/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
@@ -24,7 +24,7 @@ export const useFetchSubscriptionsByExternalId = (externalIds: string) => {
       const response = await accountsService.getSubscriptions({
         filter: subscriptionSearchString,
         page: 1,
-        page_size: 500,
+        page_size: queryConstants.API_PAGE_SIZE,
       });
       return response;
     },

--- a/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
+++ b/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+
+import accountsService from '~/services/accountsService';
+
+import { formatErrorData } from '../helpers';
+import { queryConstants } from '../queriesConstants';
+
+/**
+ * Query to fetch subscriptions based on external IDs
+ * @param externalIds comma-separated external IDs wrapped in single quotes (e.g., "'id1','id2','id3'")
+ * @returns query states. Loading, error and subscription data
+ */
+export const useFetchSubscriptionsByExternalId = (externalIds: string) => {
+  const subscriptionSearchString = `external_cluster_id in (${externalIds})`;
+
+  const { isLoading, data, isError, error, isFetching } = useQuery({
+    queryKey: [
+      queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
+      'accountsService',
+      'subscription',
+      externalIds,
+    ],
+    queryFn: async () => {
+      const response = await accountsService.getSubscriptions({
+        filter: subscriptionSearchString,
+        page: 1,
+        page_size: 500,
+      });
+      return response;
+    },
+    retry: false,
+    enabled: !!externalIds,
+  });
+
+  if (isError) {
+    const formattedError = formatErrorData(isLoading, isError, error);
+    return {
+      data: data?.data,
+      isLoading,
+      isError,
+      error: formattedError,
+      isFetching,
+    };
+  }
+
+  return {
+    data: data?.data,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+  };
+};

--- a/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
+++ b/src/queries/ClusterDetailsQueries/useFetchSubscriptionsByExternalId.tsx
@@ -32,22 +32,14 @@ export const useFetchSubscriptionsByExternalId = (externalIds: string) => {
     enabled: !!externalIds,
   });
 
-  if (isError) {
-    const formattedError = formatErrorData(isLoading, isError, error);
-    return {
-      data: data?.data,
-      isLoading,
-      isError,
-      error: formattedError,
-      isFetching,
-    };
-  }
+  const formattedError = isError ? formatErrorData(isLoading, isError, error) : undefined;
+  const finalError = isError ? formattedError : error;
 
   return {
     data: data?.data,
     isLoading,
     isError,
-    error,
+    error: finalError,
     isFetching,
   };
 };


### PR DESCRIPTION
# Summary

If a cluster is deleted while it is in transfer - which should probably not be allowed but alas - we do not show a valid link or information about the cluster because we were pulling information from the cluster api.  The ticket mentions correctly that even deprovisioned will show in the archive page so we do have some data to share. 

That data is contained on the subscription which we can find using the external cluster id.  I therefore changed the fetch for clusterTransferDetails to use the subscription api instead of the cluster api since the subscription seems to stick around indefinitely.  We now can show the cluster display name, the version and the product type if the cluster is deleted.  

Note: External transfer still cannot show this info because it would be restricted from the new owner until after the transfer.

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4146](https://issues.redhat.com/browse/OCMUI-4146)



# How to Test

1. Create a ROSA classic cluster to transfer
```
rosa create cluster --cluster-name test-xfer-1 --region=us-west-2 --sts 
```
2. Transfer the cluster (using the actions drop down, the owner on the details page, or the Access Control tab) to a user in your org (external transfers cannot handle any data like this due to permissions)
3. Check the Cluster Transfer list on the Cluster Requests tab on the Clusters
4. Now delete the cluster
5. Verify the basic info is still there and that there is no longer an actions button (compare to console.dev)

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1383" height="378" alt="Screenshot From 2026-04-02 08-13-22" src="https://github.com/user-attachments/assets/41e7b1c6-d3cb-45b5-a111-c6055011130d" /> | <img width="1298" height="406" alt="Screenshot From 2026-04-02 08-12-33" src="https://github.com/user-attachments/assets/8ebca327-a9bc-4ad3-bf2d-33f0b7e384fd" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4146]: https://redhat.atlassian.net/browse/OCMUI-4146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ