### PR TITLE
OCMUI-4183: Only include proxy in PATCH body when proxy fields changed

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
@@ -3,9 +3,8 @@ import type { FormikProps } from 'formik';
 import * as reactRedux from 'react-redux';
 
 import { useEditCluster } from '~/queries/ClusterDetailsQueries/useEditCluster';
-import { invalidateClusterDetailsQueries } from '~/queries/ClusterDetailsQueries/useFetchClusterDetails';
 import { useGlobalState } from '~/redux/hooks';
-import { act, render, screen, waitFor } from '~/testUtils';
+import { act, render, waitFor } from '~/testUtils';
 import type { ClusterFromSubscription } from '~/types/types';
 
 import EditClusterWideProxyDialog from './EditClusterWideProxyDialog';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import type { FormikProps } from 'formik';
+import * as reactRedux from 'react-redux';
+
+import { useEditCluster } from '~/queries/ClusterDetailsQueries/useEditCluster';
+import { invalidateClusterDetailsQueries } from '~/queries/ClusterDetailsQueries/useFetchClusterDetails';
+import { useGlobalState } from '~/redux/hooks';
+import { act, render, screen, waitFor } from '~/testUtils';
+import type { ClusterFromSubscription } from '~/types/types';
+
+import EditClusterWideProxyDialog from './EditClusterWideProxyDialog';
+
+jest.mock('~/redux/hooks', () => ({
+  useGlobalState: jest.fn(),
+}));
+
+jest.mock('~/queries/ClusterDetailsQueries/useEditCluster', () => ({
+  useEditCluster: jest.fn(),
+}));
+
+jest.mock('~/queries/ClusterDetailsQueries/useFetchClusterDetails', () => ({
+  invalidateClusterDetailsQueries: jest.fn(),
+}));
+
+// Mock the form component to expose Formik's setFieldValue and submitForm
+let formikRef: FormikProps<any> | null = null;
+
+jest.mock('./EditClusterWideProxyForm', () => {
+  const MockForm = ({ submitForm }: { submitForm: () => void }) => {
+    return (
+      <div data-testid="mock-form">
+        <button data-testid="submit-btn" onClick={submitForm}>
+          Save
+        </button>
+      </div>
+    );
+  };
+  MockForm.displayName = 'MockForm';
+  return MockForm;
+});
+
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-redux'),
+}));
+
+// Intercept Formik to capture setFieldValue
+jest.mock('formik', () => {
+  const actual = jest.requireActual('formik');
+  return {
+    ...actual,
+    Formik: (props: any) => {
+      const FormikWrapper = actual.Formik;
+      return (
+        <FormikWrapper {...props}>
+          {(formikProps: FormikProps<any>) => {
+            formikRef = formikProps;
+            return props.children(formikProps);
+          }}
+        </FormikWrapper>
+      );
+    },
+  };
+});
+
+const useGlobalStateMock = useGlobalState as jest.Mock;
+const useEditClusterMock = useEditCluster as jest.Mock;
+
+describe('<EditClusterWideProxyDialog />', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const dispatchMock = jest.fn();
+  const mutateMock = jest.fn();
+  const resetMock = jest.fn();
+
+  const baseCluster = {
+    id: 'cluster-123',
+    proxy: {
+      http_proxy: 'http://proxy.example.com:8080',
+      https_proxy: 'https://proxy.example.com:8443',
+      no_proxy: '.example.com',
+    },
+    additional_trust_bundle: undefined,
+  } as unknown as ClusterFromSubscription;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    formikRef = null;
+    useDispatchMock.mockReturnValue(dispatchMock);
+    useGlobalStateMock.mockReturnValue(true);
+
+    useEditClusterMock.mockReturnValue({
+      isPending: false,
+      isError: false,
+      error: null,
+      mutate: mutateMock,
+      reset: resetMock,
+      isSuccess: false,
+    });
+  });
+
+  describe('Regression: OCMUI-4183', () => {
+    it('does not include proxy object when only additional_trust_bundle changes', async () => {
+      // Arrange
+      render(<EditClusterWideProxyDialog cluster={baseCluster} region="us-east-1" />);
+
+      // Act - simulate changing only the trust bundle via Formik
+      await act(async () => {
+        formikRef?.setFieldValue(
+          'additional_trust_bundle',
+          '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----',
+        );
+      });
+
+      await act(async () => {
+        formikRef?.submitForm();
+      });
+
+      // Assert - mutate should be called without proxy key
+      await waitFor(() => {
+        expect(mutateMock).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mutateMock.mock.calls[0][0];
+      expect(callArgs.clusterID).toBe('cluster-123');
+      expect(callArgs.cluster).not.toHaveProperty('proxy');
+      expect(callArgs.cluster.additional_trust_bundle).toBe(
+        '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----',
+      );
+    });
+
+    it('includes proxy object when proxy fields change', async () => {
+      // Arrange - cluster with no existing proxy
+      const clusterNoProxy = {
+        ...baseCluster,
+        proxy: undefined,
+      } as unknown as ClusterFromSubscription;
+
+      render(<EditClusterWideProxyDialog cluster={clusterNoProxy} region="us-east-1" />);
+
+      // Act - change the HTTP proxy URL
+      await act(async () => {
+        formikRef?.setFieldValue('http_proxy_url', 'http://new-proxy.example.com:8080');
+      });
+
+      await act(async () => {
+        formikRef?.submitForm();
+      });
+
+      // Assert - mutate should be called with proxy key
+      await waitFor(() => {
+        expect(mutateMock).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mutateMock.mock.calls[0][0];
+      expect(callArgs.cluster).toHaveProperty('proxy');
+      expect(callArgs.cluster.proxy.http_proxy).toBe('http://new-proxy.example.com:8080');
+    });
+
+    it('includes both proxy and trust bundle when both change', async () => {
+      // Arrange - cluster with no proxy or trust bundle
+      const emptyCluster = {
+        ...baseCluster,
+        proxy: undefined,
+        additional_trust_bundle: undefined,
+      } as unknown as ClusterFromSubscription;
+
+      render(<EditClusterWideProxyDialog cluster={emptyCluster} region="us-east-1" />);
+
+      // Act - change both proxy and trust bundle
+      await act(async () => {
+        formikRef?.setFieldValue('http_proxy_url', 'http://proxy.example.com:8080');
+        formikRef?.setFieldValue(
+          'additional_trust_bundle',
+          '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----',
+        );
+      });
+
+      await act(async () => {
+        formikRef?.submitForm();
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mutateMock).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mutateMock.mock.calls[0][0];
+      expect(callArgs.cluster).toHaveProperty('proxy');
+      expect(callArgs.cluster).toHaveProperty('additional_trust_bundle');
+    });
+
+    it('omits unchanged proxy fields within proxy object', async () => {
+      // Arrange - cluster with existing proxy
+      render(<EditClusterWideProxyDialog cluster={baseCluster} region="us-east-1" />);
+
+      // Act - change only http_proxy (https_proxy and no_proxy unchanged)
+      await act(async () => {
+        formikRef?.setFieldValue('http_proxy_url', 'http://different-proxy.example.com:9090');
+      });
+
+      await act(async () => {
+        formikRef?.submitForm();
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mutateMock).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mutateMock.mock.calls[0][0];
+      expect(callArgs.cluster.proxy.http_proxy).toBe('http://different-proxy.example.com:9090');
+      // Unchanged fields should be undefined (not sent)
+      expect(callArgs.cluster.proxy.https_proxy).toBeUndefined();
+      expect(callArgs.cluster.proxy.no_proxy).toBeUndefined();
+    });
+  });
+
+  it('does not render when modal is closed', () => {
+    useGlobalStateMock.mockReturnValue(false);
+
+    const { container } = render(
+      <EditClusterWideProxyDialog cluster={baseCluster} region="us-east-1" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
@@ -26,15 +26,13 @@ jest.mock('~/queries/ClusterDetailsQueries/useFetchClusterDetails', () => ({
 let formikRef: FormikProps<any> | null = null;
 
 jest.mock('./EditClusterWideProxyForm', () => {
-  const MockForm = ({ submitForm }: { submitForm: () => void }) => {
-    return (
-      <div data-testid="mock-form">
-        <button data-testid="submit-btn" onClick={submitForm}>
-          Save
-        </button>
-      </div>
-    );
-  };
+  const MockForm = ({ submitForm }: { submitForm: () => void }) => (
+    <div data-testid="mock-form">
+      <button type="button" data-testid="submit-btn" onClick={submitForm}>
+        Save
+      </button>
+    </div>
+  );
   MockForm.displayName = 'MockForm';
   return MockForm;
 });
@@ -55,7 +53,8 @@ jest.mock('formik', () => {
         <FormikWrapper {...props}>
           {(formikProps: FormikProps<any>) => {
             formikRef = formikProps;
-            return props.children(formikProps);
+            const { children } = props;
+            return children(formikProps);
           }}
         </FormikWrapper>
       );

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
@@ -96,8 +96,8 @@ describe('<EditClusterWideProxyDialog />', () => {
     });
   });
 
-  describe('Regression: OCMUI-4183', () => {
-    it('does not include proxy object when only additional_trust_bundle changes', async () => {
+  describe('updating proxy and trust bundle', () => {
+    it('excludes proxy object when only additional_trust_bundle changes', async () => {
       // Arrange
       render(<EditClusterWideProxyDialog cluster={baseCluster} region="us-east-1" />);
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.test.tsx
@@ -211,6 +211,22 @@ describe('<EditClusterWideProxyDialog />', () => {
       expect(callArgs.cluster.proxy.https_proxy).toBeUndefined();
       expect(callArgs.cluster.proxy.no_proxy).toBeUndefined();
     });
+
+    it('skips API call and closes dialog when no fields change', async () => {
+      // Arrange
+      render(<EditClusterWideProxyDialog cluster={baseCluster} region="us-east-1" />);
+
+      // Act - submit without changing any values
+      await act(async () => {
+        formikRef?.submitForm();
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(dispatchMock).toHaveBeenCalled();
+      });
+      expect(mutateMock).not.toHaveBeenCalled();
+    });
   });
 
   it('does not render when modal is closed', () => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
@@ -73,6 +73,11 @@ const EditClusterWideProxyDialog = ({ cluster, region }: EditClusterWideProxyDia
           proxyHttpsChange !== undefined ||
           proxyNoProxyChange !== undefined;
 
+        const trustBundleChange = OnlyReturnValueIfChanged(
+          values.additional_trust_bundle,
+          initialValues.additional_trust_bundle,
+        );
+
         const clusterProxyBody = {
           ...(hasProxyChanges && {
             proxy: {
@@ -81,11 +86,15 @@ const EditClusterWideProxyDialog = ({ cluster, region }: EditClusterWideProxyDia
               no_proxy: proxyNoProxyChange,
             },
           }),
-          additional_trust_bundle: OnlyReturnValueIfChanged(
-            values.additional_trust_bundle,
-            initialValues.additional_trust_bundle,
-          ),
+          ...(trustBundleChange !== undefined && {
+            additional_trust_bundle: trustBundleChange,
+          }),
         };
+
+        if (Object.keys(clusterProxyBody).length === 0) {
+          handleClose();
+          return;
+        }
 
         mutateClusterEdit(
           {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditClusterWideProxyDialog/EditClusterWideProxyDialog.tsx
@@ -55,21 +55,32 @@ const EditClusterWideProxyDialog = ({ cluster, region }: EditClusterWideProxyDia
     <Formik
       initialValues={initialValues}
       onSubmit={async (values) => {
+        const proxyHttpChange = OnlyReturnValueIfChanged(
+          values.http_proxy_url,
+          initialValues.http_proxy_url,
+        );
+        const proxyHttpsChange = OnlyReturnValueIfChanged(
+          values.https_proxy_url,
+          initialValues.https_proxy_url,
+        );
+        const proxyNoProxyChange = OnlyReturnValueIfChanged(
+          arrayToString(values.no_proxy_domains),
+          arrayToString(initialValues.no_proxy_domains),
+        );
+
+        const hasProxyChanges =
+          proxyHttpChange !== undefined ||
+          proxyHttpsChange !== undefined ||
+          proxyNoProxyChange !== undefined;
+
         const clusterProxyBody = {
-          proxy: {
-            http_proxy: OnlyReturnValueIfChanged(
-              values.http_proxy_url,
-              initialValues.http_proxy_url,
-            ),
-            https_proxy: OnlyReturnValueIfChanged(
-              values.https_proxy_url,
-              initialValues.https_proxy_url,
-            ),
-            no_proxy: OnlyReturnValueIfChanged(
-              arrayToString(values.no_proxy_domains),
-              arrayToString(initialValues.no_proxy_domains),
-            ),
-          },
+          ...(hasProxyChanges && {
+            proxy: {
+              http_proxy: proxyHttpChange,
+              https_proxy: proxyHttpsChange,
+              no_proxy: proxyNoProxyChange,
+            },
+          }),
           additional_trust_bundle: OnlyReturnValueIfChanged(
             values.additional_trust_bundle,
             initialValues.additional_trust_bundle,


### PR DESCRIPTION
# Summary

Fix cluster-wide proxy edit to only include the `proxy` object in the PATCH request body when proxy fields have actually changed. Previously, an empty `proxy: {}` was always sent, which could reset existing proxy settings when only the additional trust bundle was modified.

Created by: Ambient OCMUI bugfix workflow
Updated by: Claude Opus 4.6 

# Jira

Fixes [OCMUI-4183](https://issues.redhat.com/browse/OCMUI-4183)

# Additional information

**Root cause:** The `onSubmit` handler in `EditClusterWideProxyDialog` always included a `proxy` object in the PATCH body, even when no proxy fields changed. The `OnlyReturnValueIfChanged` helper returned `undefined` for unchanged fields, but JSON serialization stripped these, resulting in `proxy: {}` being sent to the API. The API interprets an empty proxy object differently than omitting the field — potentially resetting existing proxy settings and causing clusteroperator degradation.

**Customer scenario (SF Case 04369846):** An OSD-GCP customer with existing proxy settings (`http_proxy`, `https_proxy`, `no_proxy`) attempted to add a CA certificate bundle via HCC > Networking > VPC > "Edit cluster-wide proxy". The customer reported:

> When we add the certificate to the proxy object in console.redhat.com if the cert contains an intermediate and then a root it degrades the operator.
> I tried the same operation but using ocm command line and it worked with the exact same certificate file.

The cluster operator error was:
```
network 4.18.30 — The configuration is invalid for proxy 'cluster'
(failed to validate trust bundle for proxy trustedCA 'user-ca-bundle':
failed parsing certificate data from ConfigMap "user-ca-bundle": Could not read any certificates)
```

Initial investigation suspected the certificate format, but the root cause was the UI sending `proxy: {}` alongside the trust bundle update, which the API interpreted as clearing/invalidating the existing proxy configuration.

**Fix:** Extract proxy field change detection into individual variables and conditionally include the `proxy` object in the request body only when at least one proxy field has actually changed.

**Validated against OCM API model:** The `PATCH /api/clusters_mgmt/v1/clusters/{id}` endpoint supports partial updates. The `Proxy` type has optional fields (`HTTPProxy`, `HTTPSProxy`, `NoProxy`). Only changed fields should be sent.

# How to Test

**Prerequisites:**
- Access to OCM staging environment
- OSD-GCP cluster with BYO VPC (required for the "Edit cluster-wide proxy" button to appear)

**Setup (Step 1 — establish initial state):**
1. Navigate to cluster details > Networking > VPC
2. Click "Edit cluster-wide proxy"
3. Add an HTTP Proxy URL (e.g., `http://squid.clarkson.edu:3128`)
4. Add an Additional Trust Bundle (paste a PEM-encoded CA cert)
5. Click Save — this sets up the initial state with both proxy and trust bundle

**Test (Step 2 — reproduce the customer scenario):**
1. Open "Edit cluster-wide proxy" again
2. **Do NOT modify any proxy fields** (HTTP/HTTPS proxy, No Proxy domains)
3. Click "Replace file" on the Additional Trust Bundle
4. Upload/paste a CA certificate
5. Open browser DevTools > Network tab
6. Click Save
7. Find the PATCH request to `/api/clusters_mgmt/v1/clusters/{id}`

**Expected results:**

| | Staging (old code) | Local with fix |
|---|---|---|
| PATCH body | `{ "additional_trust_bundle": "...", "proxy": {} }` | `{ "additional_trust_bundle": "..." }` |
| `proxy` key present? | Yes — empty object sent | No — correctly omitted |

# PR Author's Test Results

**Manually verified on two OSD-GCP clusters in staging (asia-east1, BYO VPC):**

| Cluster | Purpose | Result |
|---|---|---|
| `dt-osd-gcp-1` | Staging UI (old code) | PATCH body contains `proxy: {}` — bug confirmed |
| `dt-osd-gcp-w-fix` | Local dev (fix branch) | PATCH body contains only `additional_trust_bundle` — fix confirmed |

**Note on operator degradation:** The customer issue occurred on production with OCP 4.18 in February 2026. The current staging API (OCP 4.21) appears to treat `proxy: {}` as a no-op rather than clearing existing proxy fields, so operator degradation could not be reproduced in today's staging environment. However, the fix is correct regardless — sending `proxy: {}` when no proxy fields changed is objectively wrong and does not match the user's intent. The fix aligns the UI behavior with `ocm-cli`, which only sends changed fields.

# Screen Captures

No UI changes — the fix modifies the API request structure, not the UI appearance. DevTools Network tab screenshots confirming before/after PATCH payloads are described in the test results above.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

**Important:**
- This fix changes API request payload structure
- QE should verify using browser DevTools Network tab
- Compare behavior with ocm-cli for parity
- Test on OSD-GCP cluster with BYO VPC (original customer scenario)


[OCMUI-4183]: https://redhat.atlassian.net/browse/OCMUI-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ