### PR TITLE
feat: move OpenShift widgets source code from landing-page-frontend

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
-import webpack from 'webpack';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -66,12 +65,6 @@ const config: StorybookConfig = {
         }),
       ];
     }
-    config.plugins = [
-      ...(config.plugins ?? []),
-      new webpack.DefinePlugin({
-        APP_DEV_SERVER: JSON.stringify(false),
-      }),
-    ];
     return config;
   },
   core: {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-webpack5';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+import webpack from 'webpack';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -65,6 +66,12 @@ const config: StorybookConfig = {
         }),
       ];
     }
+    config.plugins = [
+      ...(config.plugins ?? []),
+      new webpack.DefinePlugin({
+        APP_DEV_SERVER: JSON.stringify(false),
+      }),
+    ];
     return config;
   },
   core: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -79,6 +79,14 @@ module.exports = {
     ],
     exposes: {
       './RootApp': path.resolve(__dirname, 'src/chrome-main.tsx'),
+      './OpenShiftWidget': path.resolve(
+        __dirname,
+        './src/components/Widgets/openshift-widget.tsx'
+      ),
+      './OpenShiftAiWidget': path.resolve(
+        __dirname,
+        './src/components/Widgets/openshift-ai-widget.tsx'
+      ),
     },
   },
 };

--- a/src/components/Widgets/openshift-ai-widget.stories.tsx
+++ b/src/components/Widgets/openshift-ai-widget.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from '@storybook/test';
+
+import OpenShiftAiWidget from './openshift-ai-widget';
+
+const meta: Meta<typeof OpenShiftAiWidget> = {
+  title: 'Widgets/OpenShiftAiWidget',
+  component: OpenShiftAiWidget,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '400px', margin: '1em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OpenShiftAiWidget>;
+
+export const Default: Story = {
+  name: 'Default',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Verify the widget body text is rendered
+    const bodyText = await canvas.findByText(
+      /Create, train, and serve artificial intelligence and machine learning \(AI\/ML\) models\./,
+    );
+    await expect(bodyText).toBeInTheDocument();
+
+    // Verify the link text is rendered
+    const link = await canvas.findByRole('link', { name: /OpenShift AI/i });
+    await expect(link).toBeInTheDocument();
+
+    // Verify the link points to the correct external URL
+    await expect(link).toHaveAttribute(
+      'href',
+      'https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial',
+    );
+
+    // Verify external link attributes (target="_blank" and rel="noopener noreferrer")
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  },
+};

--- a/src/components/Widgets/openshift-ai-widget.test.tsx
+++ b/src/components/Widgets/openshift-ai-widget.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { render, screen } from '~/testUtils';
+
+import OpenShiftAiWidget from './openshift-ai-widget';
+
+describe('OpenShiftAiWidget', () => {
+  it('should render the description body text', () => {
+    render(<OpenShiftAiWidget />);
+
+    expect(
+      screen.getByText(
+        'Create, train, and serve artificial intelligence and machine learning (AI/ML) models.',
+        { exact: false },
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the "OpenShift AI" link with correct text', () => {
+    render(<OpenShiftAiWidget />);
+
+    expect(screen.getByText('OpenShift AI')).toBeInTheDocument();
+  });
+
+  it('should link to the correct external URL', () => {
+    render(<OpenShiftAiWidget />);
+
+    const link = screen.getByRole('link', { name: /OpenShift AI/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial',
+    );
+  });
+
+  it('should open the link in a new tab', () => {
+    render(<OpenShiftAiWidget />);
+
+    const link = screen.getByRole('link', { name: /OpenShift AI/i });
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('should have secure rel attributes on the external link', () => {
+    render(<OpenShiftAiWidget />);
+
+    const link = screen.getByRole('link', { name: /OpenShift AI/i });
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should render as an anchor tag (not a router Link) since it is external', () => {
+    render(<OpenShiftAiWidget />);
+
+    const link = screen.getByRole('link', { name: /OpenShift AI/i });
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', expect.stringContaining('https://'));
+  });
+});

--- a/src/components/Widgets/openshift-ai-widget.tsx
+++ b/src/components/Widgets/openshift-ai-widget.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { SimpleServiceWidget } from './simple-service-widget';
+
+const OpenShiftAiWidget: React.FunctionComponent = () => (
+  <SimpleServiceWidget
+    id={6}
+    body="Create, train, and serve artificial intelligence and machine learning (AI/ML) models."
+    linkTitle="OpenShift AI"
+    url="https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai/trial"
+    isExternal
+  />
+);
+
+export default OpenShiftAiWidget;

--- a/src/components/Widgets/openshift-widget.stories.tsx
+++ b/src/components/Widgets/openshift-widget.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from '@storybook/test';
+
+import OpenShiftWidget from './openshift-widget';
+
+const meta: Meta<typeof OpenShiftWidget> = {
+  title: 'Widgets/OpenShiftWidget',
+  component: OpenShiftWidget,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '400px', padding: '1em' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OpenShiftWidget>;
+
+export const Default: Story = {
+  name: 'Default',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Verify the widget body text renders
+    await expect(
+      await canvas.findByText(/Build, run, and scale container-based applications/),
+    ).toBeInTheDocument();
+
+    // Verify the link text renders
+    const link = await canvas.findByRole('link', { name: /OpenShift/i });
+    await expect(link).toBeInTheDocument();
+
+    // Verify the link points to the correct internal route
+    await expect(link).toHaveAttribute('href', '/openshift');
+
+    // Verify the card structure is present (PatternFly plain card)
+    const card = canvasElement.querySelector('.pf-v6-c-card');
+    await expect(card).toBeInTheDocument();
+  },
+};

--- a/src/components/Widgets/openshift-widget.test.tsx
+++ b/src/components/Widgets/openshift-widget.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { render, screen } from '~/testUtils';
+
+import OpenShiftWidget from './openshift-widget';
+
+describe('OpenShiftWidget', () => {
+  it('should render the OpenShift description text', () => {
+    render(<OpenShiftWidget />);
+    expect(
+      screen.getByText(
+        /Build, run, and scale container-based applications - now with developer tools, CI\/CD, and release management\./,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render an internal link titled "OpenShift" pointing to /openshift', () => {
+    render(<OpenShiftWidget />);
+    const link = screen.getByRole('link', { name: /OpenShift/ });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expect.stringContaining('/openshift'));
+  });
+
+  it('should render an internal link, not an external one', () => {
+    render(<OpenShiftWidget />);
+    const link = screen.getByRole('link', { name: /OpenShift/ });
+    // OpenShiftWidget does not pass isExternal, so it should use the internal Link component
+    expect(link).not.toHaveAttribute('target', '_blank');
+    expect(link).not.toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/components/Widgets/openshift-widget.tsx
+++ b/src/components/Widgets/openshift-widget.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { SimpleServiceWidget } from './simple-service-widget';
+
+const OpenShiftWidget: React.FunctionComponent = () => (
+  <SimpleServiceWidget
+    id={1}
+    body="Build, run, and scale container-based applications - now with developer tools, CI/CD, and release management."
+    linkTitle="OpenShift"
+    url="/openshift"
+  />
+);
+
+export default OpenShiftWidget;

--- a/src/components/Widgets/simple-service-widget.test.tsx
+++ b/src/components/Widgets/simple-service-widget.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { render, screen } from '~/testUtils';
+
+import { SimpleServiceWidget } from './simple-service-widget';
+
+describe('SimpleServiceWidget', () => {
+  const defaultProps = {
+    id: 1,
+    body: 'Test widget body text',
+    linkTitle: 'Test Link',
+    url: '/test-url',
+  };
+
+  it('should render the body text', () => {
+    render(<SimpleServiceWidget {...defaultProps} />);
+    expect(screen.getByText(/Test widget body text/)).toBeInTheDocument();
+  });
+
+  it('should render an internal link with the link title when isExternal is not set', () => {
+    render(<SimpleServiceWidget {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /Test Link/ });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', expect.stringContaining('/test-url'));
+    // Internal links should not open in a new tab
+    expect(link).not.toHaveAttribute('target', '_blank');
+  });
+
+  it('should render an external anchor tag when isExternal is true', () => {
+    const externalProps = {
+      ...defaultProps,
+      url: 'https://example.com/external',
+      isExternal: true,
+    };
+    render(<SimpleServiceWidget {...externalProps} />);
+    const link = screen.getByRole('link', { name: /Test Link/ });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/external');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should render the link title text in the footer', () => {
+    render(<SimpleServiceWidget {...defaultProps} />);
+    expect(screen.getByText('Test Link')).toBeInTheDocument();
+  });
+
+  it('should use isExternal=false by default', () => {
+    render(<SimpleServiceWidget {...defaultProps} />);
+    const link = screen.getByRole('link', { name: /Test Link/ });
+    // When isExternal is not set, it should render as a react-router Link (no target="_blank")
+    expect(link).not.toHaveAttribute('target');
+    // And the href should contain the internal URL path
+    expect(link).toHaveAttribute('href', expect.stringContaining('/test-url'));
+  });
+});

--- a/src/components/Widgets/simple-service-widget.tsx
+++ b/src/components/Widgets/simple-service-widget.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { Card, CardBody, CardFooter } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
+import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
+import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+
+import { Link } from '~/common/routing';
+
+interface SimpleServiceWidgetProps {
+  id: number;
+  body: string;
+  linkTitle: string;
+  url: string;
+  isExternal?: boolean;
+}
+
+export const SimpleServiceWidget: React.FunctionComponent<SimpleServiceWidgetProps> = ({
+  id,
+  body,
+  linkTitle,
+  url,
+  isExternal,
+}) => (
+  <Card isPlain>
+    <CardBody className="pf-v6-u-p-md pf-v6-u-pb-0">
+      <Content key={id} className="pf-v6-u-display-flex pf-v6-u-flex-direction-column">
+        <Content component="p" className="pf-v6-u-flex-grow-1">
+          {body}{' '}
+        </Content>
+      </Content>
+    </CardBody>
+    <CardFooter className="pf-v6-u-p-md">
+      {isExternal ? (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          {linkTitle}
+          <Icon className="pf-v6-u-ml-sm" isInline>
+            <ExternalLinkAltIcon />
+          </Icon>
+        </a>
+      ) : (
+        <Link to={url}>
+          {linkTitle}
+          <Icon className="pf-v6-u-ml-sm" isInline>
+            <ArrowRightIcon />
+          </Icon>
+        </Link>
+      )}
+    </CardFooter>
+  </Card>
+);

--- a/src/components/Widgets/simple-service-widget.tsx
+++ b/src/components/Widgets/simple-service-widget.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
 import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
-import { Link } from '~/common/routing';
+import { Link } from '~/common/routing/Link';
 
 interface SimpleServiceWidgetProps {
   id: number;


### PR DESCRIPTION
## Summary
- Moves the `OpenShiftWidget` and `OpenShiftAiWidget` module federation exposes from `landing-page-frontend` into this repo
- Adds widget source files (`openshift-widget.tsx`, `openshift-ai-widget.tsx`, `simple-service-widget.tsx`, `simple-service-widget.scss`)
- Updates `fec.config.js` to expose `./OpenShiftWidget` and `./OpenShiftAiWidget`

Part of [RHCLOUD-40474](https://redhat.atlassian.net/browse/RHCLOUD-40474) — decoupling widget dashboard backend from Chrome service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The source code for the widgets are getting [transferred from here in the landing-page-repo](https://github.com/RedHatInsights/landing-page-frontend/tree/master/src/components/widgets).

[RHCLOUD-40474]: https://redhat.atlassian.net/browse/RHCLOUD-40474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ