### PR TITLE
OCMUI-4273: Remove code that replaced the history stack making back not work properly

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/TabsRow/TabsRow.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/TabsRow/TabsRow.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
 import { trackEvents } from '~/common/analytics';
-import { useClusterListPath, useNavigate } from '~/common/routing';
+import { useNavigate } from '~/common/routing';
 import useAnalytics from '~/hooks/useAnalytics';
 
 import { ClusterTabsId } from '../common/ClusterTabIds';
@@ -22,7 +22,6 @@ const TabsRow = ({ tabsInfo, onTabSelected, initTabOpen }: TabsRowProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const track = useAnalytics();
-  const clusterListPath = useClusterListPath();
 
   const [tabs, setTabs] = React.useState<TabsRowTabType[]>();
   const [activeTab, setActiveTab] = React.useState<TabsRowTabType>();
@@ -95,22 +94,17 @@ const TabsRow = ({ tabsInfo, onTabSelected, initTabOpen }: TabsRowProps) => {
     if (tabs?.length) {
       const targetTab = tabs.find((tab) => `#${tab.id}` === location.hash);
 
-      /* Checking if tab exists,
-          otherwise we navigate to overview
-          if the user did not click on back button,
-          in that case we navigate to cluster list page */
+      /* No hash or unknown/disabled tab: normalize URL to #overview on this page.
+       * Do not navigate to cluster list — replacing the details URL with the list path
+       * drops the previous history entry (e.g. Cluster Requests) and breaks browser Back. */
       if (!targetTab?.show || targetTab.isDisabled) {
-        if (location.hash === '') {
-          navigate(clusterListPath, { replace: true });
-        } else {
-          setInitialTab(tabs.find((tab) => tab.id === ClusterTabsId.OVERVIEW) || tabs[0]);
-          navigate(
-            {
-              hash: `#${ClusterTabsId.OVERVIEW}`,
-            },
-            { replace: true },
-          );
-        }
+        setInitialTab(tabs.find((tab) => tab.id === ClusterTabsId.OVERVIEW) || tabs[0]);
+        navigate(
+          {
+            hash: `#${ClusterTabsId.OVERVIEW}`,
+          },
+          { replace: true },
+        );
       }
       handleTabChange(
         targetTab?.isDisabled || !targetTab?.show ? ClusterTabsId.OVERVIEW : targetTab.id,
@@ -152,9 +146,14 @@ const TabsRow = ({ tabsInfo, onTabSelected, initTabOpen }: TabsRowProps) => {
         track(trackEvents.ClusterTabs, {
           customProperties: trackingProperties,
         });
-        navigate({
-          hash: `#${activeTab?.id}`,
-        });
+        /* Initial tab sync must use replace — otherwise we push a second details entry
+         * (hash normalization + this navigate) and Chrome requires Back twice to leave. */
+        navigate(
+          {
+            hash: `#${activeTab?.id}`,
+          },
+          { replace: !previousTab?.id },
+        );
       }
     }
   }, [activeTab, initialTab, historyPush, previousTab, navigate, redirectedToOverview, track]);

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/TabsRow/TabsRow.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/TabsRow/TabsRow.tsx
@@ -91,28 +91,37 @@ const TabsRow = ({ tabsInfo, onTabSelected, initTabOpen }: TabsRowProps) => {
   }, [tabs, initialTab, handleTabChange]);
 
   React.useEffect(() => {
-    if (tabs?.length) {
-      const targetTab = tabs.find((tab) => `#${tab.id}` === location.hash);
+    if (!tabs?.length) return;
 
-      /* No hash or unknown/disabled tab: normalize URL to #overview on this page.
-       * Do not navigate to cluster list — replacing the details URL with the list path
-       * drops the previous history entry (e.g. Cluster Requests) and breaks browser Back. */
-      if (!targetTab?.show || targetTab.isDisabled) {
-        setInitialTab(tabs.find((tab) => tab.id === ClusterTabsId.OVERVIEW) || tabs[0]);
-        navigate(
-          {
-            hash: `#${ClusterTabsId.OVERVIEW}`,
-          },
-          { replace: true },
-        );
-      }
-      handleTabChange(
-        targetTab?.isDisabled || !targetTab?.show ? ClusterTabsId.OVERVIEW : targetTab.id,
-        false,
+    /* Empty hash: initial tab + hash sync are handled by the other effects. Without this guard,
+     * adding deps below would duplicate handleTabChange and fight initTabOpen. */
+    if (location.hash === '') {
+      return;
+    }
+
+    const targetTab = tabs.find((tab) => `#${tab.id}` === location.hash);
+
+    /* No hash or unknown/disabled tab: normalize URL to #overview on this page.
+     * Do not navigate to cluster list — replacing the details URL with the list path
+     * drops the previous history entry (e.g. Cluster Requests) and breaks browser Back. */
+    if (!targetTab?.show || targetTab.isDisabled) {
+      setInitialTab(tabs.find((tab) => tab.id === ClusterTabsId.OVERVIEW) || tabs[0]);
+      navigate(
+        {
+          hash: `#${ClusterTabsId.OVERVIEW}`,
+        },
+        { replace: true },
       );
     }
+    handleTabChange(
+      targetTab?.isDisabled || !targetTab?.show ? ClusterTabsId.OVERVIEW : targetTab.id,
+      false,
+    );
+    /* Use tabs?.length (not `tabs`) so this runs when the list first resolves or its size changes,
+     * without re-running on every new array reference from setTabs(getTabs(...)).
+     * navigate, setInitialTab, handleTabChange: see exhaustive-deps disable below. */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.hash]); // eslint wants dependencies, but we only need to listen to location.hash changes
+  }, [location.hash, tabs?.length]);
 
   React.useEffect(() => {
     if (activeTab && !activeTab.show) {


### PR DESCRIPTION
# Summary

The back button on all browsers was not properly going from the cluster details pages back to the cluster requests tab.  The issue was that the history stack built into the browser was explicitly being replaced when there was no hash on the overview page.  But I have no idea why the code was written in the first place.  Git log shows when it was added but there is no explanation or test for what issue was being solved.

I have tested extensively with both firefox and chrome on the overview (details) pages with their tabs and the new Clusters tabs and thing look fine.

I do worry there is some strange edge case that was fixed for something.  However in the 2 years since these lines were added, so much has changed with the router code and our navigation in general.

Assisted by: Cursor/composer-2-fast

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4273](https://issues.redhat.com/browse/OCMUI-4273)

# How to Test
1. You need to create a rosa classic cluster that you can transfer or have data already in the Cluster Transfer list on openshift/clusters/requests
2. Go to the list of cluster transfer items. Click on one of the clusters - it is alright if it is archived or deleted.
3. Once you get into the cluster details page, simply press back and verify you go back to the requests page.

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4273]: https://redhat.atlassian.net/browse/OCMUI-4273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ