### PR TITLE
OCMUI-4283 - [OSD GCP Overview page - Shared VPC] "Learn more about the permission" link under "Permission needed" banner does not open anything

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ClusterStatusMonitor/ClusterStatusMonitor.jsx
@@ -9,7 +9,7 @@ import MinusCircleIcon from '@patternfly/react-icons/dist/esm/icons/minus-circle
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import installLinks from '~/common/installLinks.mjs';
+import docLinks from '~/common/docLinks.mjs';
 import { HAD_INFLIGHT_ERROR_LOCALSTORAGE_KEY } from '~/common/localStorageConstants';
 import { emailRegex } from '~/common/regularExpressions';
 import supportLinks from '~/common/supportLinks.mjs';
@@ -364,7 +364,7 @@ const ClusterStatusMonitor = (props) => {
           <Flex direction={{ default: 'column' }}>
             <FlexItem>{reason}</FlexItem>
             <FlexItem>
-              <ExternalLink href={installLinks.GCP_VPC_PROVISIONING}>
+              <ExternalLink href={docLinks.GCP_VPC_PROVISIONING}>
                 Learn more about permissions
               </ExternalLink>
             </FlexItem>


### PR DESCRIPTION
# Summary
A link in the Cluster status monitor had a wrongly imported link. This PR updates the doc import so the link is usable 

# Jira

Fixes [OCMUI-4283](https://issues.redhat.com/browse/OCMUI-4283) 


# How to Test
 
1. Go to the cluster details page of cluster `dc-gcp10
`
2. Open the Alerts and Reccomendations expandable section 
3. In the 'Permissions needed' alert click the 'Learn more about permissions' link and make sure it opens to the vpc documentation 

# Screenshots 
<img width="901" height="408" alt="Screenshot 2026-04-07 at 9 54 04 PM" src="https://github.com/user-attachments/assets/0d5ad555-536d-4cb3-bc70-b4e8d7e886a4" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4283]: https://redhat.atlassian.net/browse/OCMUI-4283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ