### PR TITLE
OCMUI-3779: Fix Save button enabled when taint Effect changed without key

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useField, useFormikContext } from 'formik';
+import { useField } from 'formik';
 
 import { SelectOption } from '@patternfly/react-core';
 
@@ -12,22 +12,19 @@ export type TaintEffect = 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
 type TaintEffectFieldProps = {
   fieldId: string;
   isDisabled: boolean;
+  setFieldTouched?: (field: string, touched: boolean, shouldValidate?: boolean) => void;
 };
 
-const TaintEffectField = ({ fieldId, isDisabled }: TaintEffectFieldProps) => {
+const TaintEffectField = ({ fieldId, isDisabled, setFieldTouched }: TaintEffectFieldProps) => {
   const [field] = useField<TaintEffect>(fieldId);
-  const { setFieldTouched } = useFormikContext();
   const onChangeEffect = useFormikOnChange(fieldId);
 
-  const onChange = React.useCallback(
-    (value: string) => {
-      onChangeEffect(value);
-      // Touch the sibling key field so validation errors display there
-      const keyFieldId = fieldId.replace(/\.effect$/, '.key');
-      setTimeout(() => setFieldTouched(keyFieldId, true, true));
-    },
-    [onChangeEffect, fieldId, setFieldTouched],
-  );
+  const onChange = (value: string) => {
+    onChangeEffect(value);
+    // Touch the sibling key field so validation errors display there
+    const keyFieldId = fieldId.replace(/\.effect$/, '.key');
+    setFieldTouched?.(keyFieldId, true, true);
+  };
 
   return (
     <SelectField value={field.value} fieldId={fieldId} onSelect={onChange} isDisabled={isDisabled}>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useField } from 'formik';
+import { useField, useFormikContext } from 'formik';
 
 import { SelectOption } from '@patternfly/react-core';
 
@@ -11,18 +11,17 @@ export type TaintEffect = 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
 
 type TaintEffectFieldProps = {
   fieldId: string;
+  keyFieldId: string;
   isDisabled: boolean;
-  setFieldTouched: (field: string, touched: boolean, shouldValidate?: boolean) => void;
 };
 
-const TaintEffectField = ({ fieldId, isDisabled, setFieldTouched }: TaintEffectFieldProps) => {
+const TaintEffectField = ({ fieldId, keyFieldId, isDisabled }: TaintEffectFieldProps) => {
   const [field] = useField<TaintEffect>(fieldId);
+  const { setFieldTouched } = useFormikContext();
   const onChangeEffect = useFormikOnChange(fieldId);
 
   const onChange = (value: string) => {
     onChangeEffect(value);
-    // Touch the sibling key field so validation errors display there
-    const keyFieldId = fieldId.replace(/\.effect$/, '.key');
     setFieldTouched(keyFieldId, true, true);
   };
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
@@ -12,7 +12,7 @@ export type TaintEffect = 'NoSchedule' | 'NoExecute' | 'PreferNoSchedule';
 type TaintEffectFieldProps = {
   fieldId: string;
   isDisabled: boolean;
-  setFieldTouched?: (field: string, touched: boolean, shouldValidate?: boolean) => void;
+  setFieldTouched: (field: string, touched: boolean, shouldValidate?: boolean) => void;
 };
 
 const TaintEffectField = ({ fieldId, isDisabled, setFieldTouched }: TaintEffectFieldProps) => {
@@ -23,7 +23,7 @@ const TaintEffectField = ({ fieldId, isDisabled, setFieldTouched }: TaintEffectF
     onChangeEffect(value);
     // Touch the sibling key field so validation errors display there
     const keyFieldId = fieldId.replace(/\.effect$/, '.key');
-    setFieldTouched?.(keyFieldId, true, true);
+    setFieldTouched(keyFieldId, true, true);
   };
 
   return (

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/TaintEffectField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useField } from 'formik';
+import { useField, useFormikContext } from 'formik';
 
 import { SelectOption } from '@patternfly/react-core';
 
@@ -16,7 +16,19 @@ type TaintEffectFieldProps = {
 
 const TaintEffectField = ({ fieldId, isDisabled }: TaintEffectFieldProps) => {
   const [field] = useField<TaintEffect>(fieldId);
-  const onChange = useFormikOnChange(fieldId);
+  const { setFieldTouched } = useFormikContext();
+  const onChangeEffect = useFormikOnChange(fieldId);
+
+  const onChange = React.useCallback(
+    (value: string) => {
+      onChangeEffect(value);
+      // Touch the sibling key field so validation errors display there
+      const keyFieldId = fieldId.replace(/\.effect$/, '.key');
+      setTimeout(() => setFieldTouched(keyFieldId, true, true));
+    },
+    [onChangeEffect, fieldId, setFieldTouched],
+  );
+
   return (
     <SelectField value={field.value} fieldId={fieldId} onSelect={onChange} isDisabled={isDisabled}>
       <SelectOption value="NoSchedule">NoSchedule</SelectOption>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -542,9 +542,12 @@ describe('useMachinePoolFormik', () => {
           taints: [{ key: '', value: 'test', effect: 'NoSchedule' }],
         };
 
-        // Value field validation should fail when key is empty
-        await expect(validationSchema.validateAt('taints[0].value', values)).rejects.toThrow(
-          'Taint key has to be defined',
+        // Effect validation catches this case and reports error on key field
+        await expect(validationSchema.validateAt('taints[0].effect', values)).rejects.toMatchObject(
+          {
+            message: 'Taint key has to be defined',
+            path: 'taints[0].key',
+          },
         );
       });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -460,7 +460,7 @@ describe('useMachinePoolFormik', () => {
       });
     });
 
-    describe('Regression: OCMUI-3779 - taints validation', () => {
+    describe('taints validation', () => {
       it('allows initial empty taint row with default effect', async () => {
         const { validationSchema } = renderHook(() =>
           useMachinePoolFormik({

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -459,5 +459,116 @@ describe('useMachinePoolFormik', () => {
         expect(result).toBe('cr-12345678901234567');
       });
     });
+
+    describe('Regression: OCMUI-3779 - taints validation', () => {
+      it('allows initial empty taint row with default effect', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          taints: [{ key: '', value: '', effect: 'NoSchedule' }],
+        };
+
+        // Initial empty taint row should be valid
+        await expect(validationSchema.validateAt('taints[0].effect', values)).resolves.toBe(
+          'NoSchedule',
+        );
+      });
+
+      it('requires taint key when effect is changed from default', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          taints: [{ key: '', value: '', effect: 'NoExecute' }],
+        };
+
+        // Changing effect without key should fail validation
+        await expect(validationSchema.validateAt('taints[0].effect', values)).rejects.toThrow(
+          'Taint key has to be defined',
+        );
+      });
+
+      it('allows taint with effect when key is provided', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          taints: [{ key: 'app', value: '', effect: 'NoExecute' }],
+        };
+
+        // Taint with key and changed effect should be valid
+        await expect(validationSchema.validateAt('taints[0].effect', values)).resolves.toBe(
+          'NoExecute',
+        );
+      });
+
+      it('requires taint key even when effect is default but value is set', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          taints: [{ key: '', value: 'test', effect: 'NoSchedule' }],
+        };
+
+        // Value field validation should fail when key is empty
+        await expect(validationSchema.validateAt('taints[0].value', values)).rejects.toThrow(
+          'Taint key has to be defined',
+        );
+      });
+
+      it('allows complete taint with key, value, and effect', async () => {
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: defaultCluster,
+            machinePool: defaultMachinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: defaultMachinePools,
+          }),
+        ).result.current;
+
+        const values = {
+          ...defaultExpectedInitialValues,
+          taints: [{ key: 'app', value: 'frontend', effect: 'NoSchedule' }],
+        };
+
+        // Complete taint should be valid
+        await expect(validationSchema.validateAt('taints[0].effect', values)).resolves.toBe(
+          'NoSchedule',
+        );
+        await expect(validationSchema.validateAt('taints[0].key', values)).resolves.toBe('app');
+        await expect(validationSchema.validateAt('taints[0].value', values)).resolves.toBe(
+          'frontend',
+        );
+      });
+    });
   });
 });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -497,9 +497,12 @@ describe('useMachinePoolFormik', () => {
           taints: [{ key: '', value: '', effect: 'NoExecute' }],
         };
 
-        // Changing effect without key should fail validation
-        await expect(validationSchema.validateAt('taints[0].effect', values)).rejects.toThrow(
-          'Taint key has to be defined',
+        // Changing effect without key should fail validation with error on key path
+        await expect(validationSchema.validateAt('taints[0].effect', values)).rejects.toMatchObject(
+          {
+            message: 'Taint key has to be defined',
+            path: 'taints[0].key',
+          },
         );
       });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -366,6 +366,27 @@ const useMachinePoolFormik = ({
                 }
                 return true;
               }),
+              effect: Yup.string().test('taint-effect', '', function test(value) {
+                const taintKey = this.parent.key;
+                const taintValue = this.parent.value;
+
+                // Allow completely empty taint row (single taint with empty key/value and default effect)
+                if (
+                  values.taints.length === 1 &&
+                  !taintKey &&
+                  !taintValue &&
+                  value === 'NoSchedule'
+                ) {
+                  return true;
+                }
+
+                // Otherwise, require key when effect is set
+                if (!taintKey) {
+                  return new Yup.ValidationError('Taint key has to be defined', value, this.path);
+                }
+
+                return true;
+              }),
             }) as any,
           ),
           autoscaleMin: values.autoscaling

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -359,11 +359,6 @@ const useMachinePoolFormik = ({
                 if (err) {
                   return new Yup.ValidationError(err, value, this.path);
                 }
-
-                const taintKey = this.parent.key;
-                if (value && !taintKey) {
-                  return new Yup.ValidationError('Taint key has to be defined', value, this.path);
-                }
                 return true;
               }),
               effect: Yup.string().test('taint-effect', '', function test(value) {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -382,7 +382,8 @@ const useMachinePoolFormik = ({
 
                 // Otherwise, require key when effect is set
                 if (!taintKey) {
-                  return new Yup.ValidationError('Taint key has to be defined', value, this.path);
+                  const keyPath = this.path?.replace(/\.effect$/, '.key') ?? this.path;
+                  return new Yup.ValidationError('Taint key has to be defined', value, keyPath);
                 }
 
                 return true;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
@@ -39,8 +39,7 @@ const EditTaintsSection = ({
   machineTypes,
 }: EditTaintsSectionProps) => {
   const [input] = useField<EditMachinePoolValues['taints']>('taints');
-  // Fallback needed for tests that mock useField but not useFormikContext
-  const { setFieldTouched } = useFormikContext() ?? {};
+  const { setFieldTouched } = useFormikContext();
   const isDefaultMP =
     !!machinePoolId &&
     isEnforcedDefaultMachinePool(machinePoolId, machinePools, machineTypes, cluster);
@@ -93,7 +92,7 @@ const EditTaintsSection = ({
                           <TextField fieldId={keyField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={4}>
-                          <div onBlur={() => setFieldTouched?.(keyField, true, true)}>
+                          <div onBlur={() => setFieldTouched(keyField, true, true)}>
                             <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
                           </div>
                         </GridItem>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
@@ -39,7 +39,8 @@ const EditTaintsSection = ({
   machineTypes,
 }: EditTaintsSectionProps) => {
   const [input] = useField<EditMachinePoolValues['taints']>('taints');
-  const { setFieldTouched } = useFormikContext() || {};
+  // Fallback needed for tests that mock useField but not useFormikContext
+  const { setFieldTouched } = useFormikContext() ?? {};
   const isDefaultMP =
     !!machinePoolId &&
     isEnforcedDefaultMachinePool(machinePoolId, machinePools, machineTypes, cluster);
@@ -92,12 +93,7 @@ const EditTaintsSection = ({
                           <TextField fieldId={keyField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={4}>
-                          <div
-                            onBlur={() =>
-                              setFieldTouched &&
-                              setTimeout(() => setFieldTouched(keyField, true, true))
-                            }
-                          >
+                          <div onBlur={() => setFieldTouched?.(keyField, true, true)}>
                             <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
                           </div>
                         </GridItem>
@@ -105,6 +101,7 @@ const EditTaintsSection = ({
                           <TaintEffectField
                             fieldId={effectField}
                             isDisabled={!!taintsDisabledReason}
+                            setFieldTouched={setFieldTouched}
                           />
                         </GridItem>
                         <GridItem span={1}>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FieldArray, useField, useFormikContext } from 'formik';
+import { FieldArray, useField } from 'formik';
 
 import {
   Button,
@@ -39,7 +39,6 @@ const EditTaintsSection = ({
   machineTypes,
 }: EditTaintsSectionProps) => {
   const [input] = useField<EditMachinePoolValues['taints']>('taints');
-  const { setFieldTouched } = useFormikContext();
   const isDefaultMP =
     !!machinePoolId &&
     isEnforcedDefaultMachinePool(machinePoolId, machinePools, machineTypes, cluster);
@@ -92,15 +91,13 @@ const EditTaintsSection = ({
                           <TextField fieldId={keyField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={4}>
-                          <div onBlur={() => setFieldTouched(keyField, true, true)}>
-                            <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
-                          </div>
+                          <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={3}>
                           <TaintEffectField
                             fieldId={effectField}
+                            keyFieldId={keyField}
                             isDisabled={!!taintsDisabledReason}
-                            setFieldTouched={setFieldTouched}
                           />
                         </GridItem>
                         <GridItem span={1}>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FieldArray, useField } from 'formik';
+import { FieldArray, useField, useFormikContext } from 'formik';
 
 import {
   Button,
@@ -39,6 +39,7 @@ const EditTaintsSection = ({
   machineTypes,
 }: EditTaintsSectionProps) => {
   const [input] = useField<EditMachinePoolValues['taints']>('taints');
+  const { setFieldTouched } = useFormikContext() || {};
   const isDefaultMP =
     !!machinePoolId &&
     isEnforcedDefaultMachinePool(machinePoolId, machinePools, machineTypes, cluster);
@@ -91,7 +92,14 @@ const EditTaintsSection = ({
                           <TextField fieldId={keyField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={4}>
-                          <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
+                          <div
+                            onBlur={() =>
+                              setFieldTouched &&
+                              setTimeout(() => setFieldTouched(keyField, true, true))
+                            }
+                          >
+                            <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
+                          </div>
                         </GridItem>
                         <GridItem span={3}>
                           <TaintEffectField

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditTaintsSection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FieldArray, useField } from 'formik';
+import { FieldArray, useField, useFormikContext } from 'formik';
 
 import {
   Button,
@@ -39,6 +39,7 @@ const EditTaintsSection = ({
   machineTypes,
 }: EditTaintsSectionProps) => {
   const [input] = useField<EditMachinePoolValues['taints']>('taints');
+  const { setFieldTouched } = useFormikContext();
   const isDefaultMP =
     !!machinePoolId &&
     isEnforcedDefaultMachinePool(machinePoolId, machinePools, machineTypes, cluster);
@@ -91,7 +92,9 @@ const EditTaintsSection = ({
                           <TextField fieldId={keyField} isDisabled={!!taintsDisabledReason} />
                         </GridItem>
                         <GridItem span={4}>
-                          <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
+                          <div onBlur={() => setFieldTouched(keyField, true, true)}>
+                            <TextField fieldId={valueField} isDisabled={!!taintsDisabledReason} />
+                          </div>
                         </GridItem>
                         <GridItem span={3}>
                           <TaintEffectField

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/subtabs/LabelsTagsTaintsSubTab.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/subtabs/LabelsTagsTaintsSubTab.test.tsx
@@ -14,6 +14,9 @@ jest.mock('formik', () => ({
       value: [],
     },
   ]),
+  useFormikContext: jest.fn().mockReturnValue({
+    setFieldTouched: jest.fn(),
+  }),
 }));
 
 describe('LabelsTagsTaintsSubTab', () => {


### PR DESCRIPTION
# Summary

Fixes form validation bug where the Save button in Edit Machine Pool modal was incorrectly enabled when users changed the taint Effect dropdown without defining a taint key-value pair.

Created by: Ambient OCMUI bugfix workflow using Claude Sonnet 4.5

# Jira

Fixes [OCMUI-3779](https://issues.redhat.com/browse/OCMUI-3779)

# Additional information

**Root Cause:**  
The taints validation schema in `useMachinePoolFormik.ts` only validated `key` and `value` fields, but not the `effect` field. When a user changed the Effect dropdown (e.g., from "NoSchedule" to "NoExecute") without providing a key, Formik detected a form change (making it "dirty") but the validation still passed, which enabled the Save button despite the incomplete taint definition.

**Fix:**  
Added validation for the `effect` field that:
- Allows the initial empty taint row (single taint with `key='', value='', effect='NoSchedule'`)
- Requires a non-empty key when the effect is changed from default or when key/value are set
- Follows the same pattern as existing `value` field validation

# How to Test

**Manual Testing (Reproducing the bug scenario):**

1. Open any ROSA/OSD cluster in console.dev.redhat.com
2. Navigate to the **Machine Pools** tab
3. Select a machine pool that **does not have any existing taints** defined
4. Click the kebab menu (⋮) and select **Edit**
5. In the Edit Machine Pool modal, scroll to **"Labels, Taints and AWS tags"** section
6. Under the Taints section, change only the **Effect** dropdown (e.g., from "NoSchedule" to "NoExecute")
   - **Do not** enter a key or value
7. Observe the **Save** button state

**Expected behavior (after fix):**
- ✅ Save button remains **disabled** (form is invalid)
- ✅ Enter a taint Key, Save button becomes enabled

**Before fix:**
- ❌ Save button becomes **enabled** (incorrectly)

**Additional scenarios to test:**
- Add a taint key → Save button becomes enabled ✅
- Remove the taint key → Save button becomes disabled again ✅
- Add complete taint (key + value + effect) → Save button enabled ✅

**Unit Test Verification:**
```bash
yarn test src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
```

All tests should pass, including the new regression tests.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="799" height="444" alt="CleanShot 2026-04-10 at 13 42 46" src="https://github.com/user-attachments/assets/b6246602-872a-4b00-b227-2cec0fd677a1" /> | <img width="790" height="438" alt="CleanShot 2026-04-10 at 13 43 15" src="https://github.com/user-attachments/assets/5bbdc815-cfa1-4808-b65e-2a1cd193414b" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

**Requirements:**
- 2 developer approvals
- 1 QE approval
- CodeRabbit review addressed
- All CI checks passing

[OCMUI-3779]: https://redhat.atlassian.net/browse/OCMUI-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ