### PR TITLE
OCMUI-4338: Adjust toolbar content so the filter labels are always on a second line

### DIFF
--- a/src/components/clusters/ClusterListMultiRegion/ClusterList.jsx
+++ b/src/components/clusters/ClusterListMultiRegion/ClusterList.jsx
@@ -426,12 +426,13 @@ const ClusterList = ({
                   </ToolbarItem>
                 )}
                 <ClusterListActions showTabbedView={showTabbedView} />
+              </ToolbarContent>
+              <ToolbarContent>
                 <ViewOnlyMyClustersToggle
                   view={CLUSTERS_VIEW}
                   bodyContent="Show only the clusters you previously created, or all clusters in your organization."
                   localStorageKey={ONLY_MY_CLUSTERS_TOGGLE_CLUSTERS_LIST}
                 />
-
                 {isRestrictedEnv() ? null : (
                   <ToolbarItem>
                     <ClusterListFilterChipGroup />


### PR DESCRIPTION
# Summary

When the clusters list page is shown in a very large resolution (or you zoom out), the filter setting chips align on the same line as the input fields which is contrary to pattern fly guidelines.

I have added a new toolbar content to ensure the filter chips are always on the second line no matter the resolution.

# Jira


Fixes [OCMUI-4338](https://issues.redhat.com/browse/OCMUI-4338)


# How to Test

1. Go to the clusters list page
2. Set a filter for "Cluster Type = ROSA"
3. Zoom out (ctrl -) until you have enough resolution to have everything fit on one line (50% should work)
4. Verify the filter chips are on the second line

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1496" height="394" alt="Screenshot From 2026-04-09 09-45-19" src="https://github.com/user-attachments/assets/46c7b4e8-34a3-4231-b023-b3222d3468ec" /> | <img width="1552" height="248" alt="Screenshot From 2026-04-09 09-59-05" src="https://github.com/user-attachments/assets/d5b6b69c-6b89-4a7b-85a9-2dd17c05784e" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4338]: https://redhat.atlassian.net/browse/OCMUI-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ