### PR TITLE
OCMUI-4354: Fix query key for cluster transfer ownership to prevent refetch loop 

### DIFF
--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
@@ -81,7 +81,7 @@ describe('useFetchClusterTransfer', () => {
     };
     getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
       data: listPayload,
-    } as never);
+    });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ clusterExternalID: 'ext-1' }));
 
@@ -98,7 +98,7 @@ describe('useFetchClusterTransfer', () => {
 
   it('searches by transfer ID with pagination options from view state', async () => {
     const searchResponse = { data: { items: [], total: 0 } };
-    searchClusterTransfersSpy.mockResolvedValueOnce(searchResponse as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce(searchResponse);
 
     const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 'tr-99' }));
 
@@ -127,7 +127,7 @@ describe('useFetchClusterTransfer', () => {
         },
       }),
     );
-    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't-sort' }));
 
@@ -154,7 +154,7 @@ describe('useFetchClusterTransfer', () => {
         },
       }),
     );
-    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't-asc' }));
 
@@ -178,7 +178,7 @@ describe('useFetchClusterTransfer', () => {
         },
       }),
     );
-    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ filter: `id='x'` }));
 
@@ -191,7 +191,7 @@ describe('useFetchClusterTransfer', () => {
   });
 
   it('uses custom filter when provided', async () => {
-    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ filter: `owner='org-1'` }));
 
@@ -210,7 +210,7 @@ describe('useFetchClusterTransfer', () => {
   it('dispatches total count for list/search mode when total is present', async () => {
     searchClusterTransfersSpy.mockResolvedValueOnce({
       data: { items: [], total: 42 },
-    } as never);
+    });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't1' }));
 
@@ -244,7 +244,7 @@ describe('useFetchClusterTransfer', () => {
         items: [pendingItem, { id: 'other', cluster_uuid: 'ext-p', status: 'completed' }],
         total: 2,
       },
-    } as never);
+    });
 
     const { result } = renderHook(() =>
       useFetchClusterTransfer({
@@ -268,7 +268,7 @@ describe('useFetchClusterTransfer', () => {
     };
     getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
       data: { items: [acceptedItem], total: 1 },
-    } as never);
+    });
 
     const { result } = renderHook(() =>
       useFetchClusterTransfer({
@@ -288,7 +288,7 @@ describe('useFetchClusterTransfer', () => {
         items: [{ id: 'done', cluster_uuid: 'ext-z', status: 'completed' }],
         total: 1,
       },
-    } as never);
+    });
 
     const { result } = renderHook(() =>
       useFetchClusterTransfer({
@@ -303,7 +303,7 @@ describe('useFetchClusterTransfer', () => {
   });
 
   it('does not dispatch total when search response has no total field', async () => {
-    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [] } } as never);
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [] } });
 
     const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 'no-total' }));
 

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
@@ -1,0 +1,222 @@
+import * as reactRedux from 'react-redux';
+
+import { queryClient } from '~/components/App/queryClient';
+import { queryConstants } from '~/queries/queriesConstants';
+import { viewConstants, viewPaginationConstants } from '~/redux/constants';
+import { useGlobalState } from '~/redux/hooks';
+import { accountsService } from '~/services';
+import { renderHook, waitFor } from '~/testUtils';
+import { ViewOptions } from '~/types/types';
+
+import { refetchFetchClusterTransfer, useFetchClusterTransfer } from './useFetchClusterTransfer';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('~/redux/hooks', () => ({
+  useGlobalState: jest.fn(),
+}));
+
+const useGlobalStateMock = useGlobalState as jest.Mock;
+
+const defaultViewOptions: ViewOptions = {
+  currentPage: 1,
+  pageSize: 20,
+  totalCount: 0,
+  totalPages: 0,
+  filter: '',
+  sorting: {
+    sortIndex: 0,
+    sortField: 'created_at',
+    isAscending: false,
+  },
+  flags: {},
+};
+
+describe('useFetchClusterTransfer', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockedDispatch = jest.fn();
+  let getClusterTransferByExternalIDSpy: jest.SpyInstance;
+  let searchClusterTransfersSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    useDispatchMock.mockReturnValue(mockedDispatch);
+    mockedDispatch.mockClear();
+    useGlobalStateMock.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        viewOptions: {
+          [viewConstants.CLUSTER_TRANSFER_VIEW]: defaultViewOptions,
+        },
+      }),
+    );
+    getClusterTransferByExternalIDSpy = jest.spyOn(
+      accountsService,
+      'getClusterTransferByExternalID',
+    );
+    searchClusterTransfersSpy = jest.spyOn(accountsService, 'searchClusterTransfers');
+  });
+
+  afterEach(() => {
+    getClusterTransferByExternalIDSpy.mockRestore();
+    searchClusterTransfersSpy.mockRestore();
+  });
+
+  it('does not fetch when transferID, clusterExternalID, and filter are all missing', async () => {
+    const { result } = renderHook(() => useFetchClusterTransfer({}));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(getClusterTransferByExternalIDSpy).not.toHaveBeenCalled();
+    expect(searchClusterTransfersSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches by cluster external ID and returns list data', async () => {
+    const listPayload = {
+      items: [{ id: 't1', cluster_uuid: 'ext-1', status: 'completed' }],
+      total: 1,
+    };
+    getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
+      data: listPayload,
+    } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ clusterExternalID: 'ext-1' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(getClusterTransferByExternalIDSpy).toHaveBeenCalledWith('ext-1');
+    expect(searchClusterTransfersSpy).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toEqual(listPayload);
+    expect(mockedDispatch).not.toHaveBeenCalled();
+  });
+
+  it('searches by transfer ID with pagination options from view state', async () => {
+    const searchResponse = { data: { items: [], total: 0 } };
+    searchClusterTransfersSpy.mockResolvedValueOnce(searchResponse as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 'tr-99' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(searchClusterTransfersSpy).toHaveBeenCalledWith({
+      filter: `id='tr-99'`,
+      page: 1,
+      size: 20,
+      orderBy: 'created_at desc',
+    });
+    expect(getClusterTransferByExternalIDSpy).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual(searchResponse.data);
+  });
+
+  it('uses custom filter when provided', async () => {
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ filter: `owner='org-1'` }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(searchClusterTransfersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: `owner='org-1'`,
+      }),
+    );
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('dispatches total count for list/search mode when total is present', async () => {
+    searchClusterTransfersSpy.mockResolvedValueOnce({
+      data: { items: [], total: 42 },
+    } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't1' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(mockedDispatch).toHaveBeenCalled();
+    });
+
+    expect(mockedDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: viewPaginationConstants.SET_TOTAL_ITEMS,
+        payload: expect.objectContaining({
+          viewType: viewConstants.CLUSTER_TRANSFER_VIEW,
+          totalCount: 42,
+        }),
+      }),
+    );
+  });
+
+  it('returns pending transfer slice when showPendingTransfer is true', async () => {
+    const pendingItem = {
+      id: 'tp',
+      cluster_uuid: 'ext-p',
+      status: 'pending',
+    };
+    getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
+      data: {
+        items: [pendingItem, { id: 'other', cluster_uuid: 'ext-p', status: 'completed' }],
+        total: 2,
+      },
+    } as never);
+
+    const { result } = renderHook(() =>
+      useFetchClusterTransfer({
+        clusterExternalID: 'ext-p',
+        showPendingTransfer: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({ items: [pendingItem] });
+  });
+
+  it('returns formatted error when the request fails', async () => {
+    getClusterTransferByExternalIDSpy.mockRejectedValueOnce({
+      name: 403,
+      message: 'Forbidden',
+    });
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ clusterExternalID: 'ext-err' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toEqual(
+      expect.objectContaining({
+        isError: true,
+        error: expect.objectContaining({
+          message: 'Forbidden',
+        }),
+      }),
+    );
+  });
+});
+
+describe('refetchFetchClusterTransfer', () => {
+  it('invalidates cluster transfer queries', () => {
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    refetchFetchClusterTransfer();
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: [queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY, 'fetchClusterTransfer'],
+    });
+    spy.mockRestore();
+  });
+});

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
@@ -233,7 +233,7 @@ describe('useFetchClusterTransfer', () => {
     );
   });
 
-  it('returns pending transfer slice when showPendingTransfer is true', async () => {
+  it('returns pending transfer items when showPendingTransfer is true', async () => {
     const pendingItem = {
       id: 'tp',
       cluster_uuid: 'ext-p',
@@ -260,7 +260,7 @@ describe('useFetchClusterTransfer', () => {
     expect(result.current.data).toEqual({ items: [pendingItem] });
   });
 
-  it('returns accepted transfer slice when showPendingTransfer matches accepted status', async () => {
+  it('returns accepted transfer items when showPendingTransfer matches accepted status', async () => {
     const acceptedItem = {
       id: 'ta',
       cluster_uuid: 'ext-a',

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
@@ -116,6 +116,80 @@ describe('useFetchClusterTransfer', () => {
     expect(result.current.data).toEqual(searchResponse.data);
   });
 
+  it('uses updated_at desc when sort field is empty', async () => {
+    useGlobalStateMock.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        viewOptions: {
+          [viewConstants.CLUSTER_TRANSFER_VIEW]: {
+            ...defaultViewOptions,
+            sorting: { ...defaultViewOptions.sorting, sortField: '' },
+          },
+        },
+      }),
+    );
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't-sort' }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(searchClusterTransfersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: 'updated_at desc' }),
+    );
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('uses ascending order when view sort is ascending', async () => {
+    useGlobalStateMock.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        viewOptions: {
+          [viewConstants.CLUSTER_TRANSFER_VIEW]: {
+            ...defaultViewOptions,
+            sorting: {
+              ...defaultViewOptions.sorting,
+              sortField: 'name',
+              isAscending: true,
+            },
+          },
+        },
+      }),
+    );
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 't-asc' }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(searchClusterTransfersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: 'name asc' }),
+    );
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('falls back to page 1 and size 20 when view options are zero', async () => {
+    useGlobalStateMock.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        viewOptions: {
+          [viewConstants.CLUSTER_TRANSFER_VIEW]: {
+            ...defaultViewOptions,
+            currentPage: 0,
+            pageSize: 0,
+          },
+        },
+      }),
+    );
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ filter: `id='x'` }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(searchClusterTransfersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 1, size: 20 }),
+    );
+    expect(result.current.isError).toBe(false);
+  });
+
   it('uses custom filter when provided', async () => {
     searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [], total: 0 } } as never);
 
@@ -184,6 +258,59 @@ describe('useFetchClusterTransfer', () => {
     });
 
     expect(result.current.data).toEqual({ items: [pendingItem] });
+  });
+
+  it('returns accepted transfer slice when showPendingTransfer matches accepted status', async () => {
+    const acceptedItem = {
+      id: 'ta',
+      cluster_uuid: 'ext-a',
+      status: 'accepted',
+    };
+    getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
+      data: { items: [acceptedItem], total: 1 },
+    } as never);
+
+    const { result } = renderHook(() =>
+      useFetchClusterTransfer({
+        clusterExternalID: 'ext-a',
+        showPendingTransfer: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual({ items: [acceptedItem] });
+  });
+
+  it('returns empty object in items when showPendingTransfer finds no pending or accepted row', async () => {
+    getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
+      data: {
+        items: [{ id: 'done', cluster_uuid: 'ext-z', status: 'completed' }],
+        total: 1,
+      },
+    } as never);
+
+    const { result } = renderHook(() =>
+      useFetchClusterTransfer({
+        clusterExternalID: 'ext-z',
+        showPendingTransfer: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual({ items: [{}] });
+  });
+
+  it('does not dispatch total when search response has no total field', async () => {
+    searchClusterTransfersSpy.mockResolvedValueOnce({ data: { items: [] } } as never);
+
+    const { result } = renderHook(() => useFetchClusterTransfer({ transferID: 'no-total' }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockedDispatch).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual({ items: [] });
   });
 
   it('returns formatted error when the request fails', async () => {

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
@@ -34,12 +34,17 @@ export const useFetchClusterTransfer = ({
 
   const dispatch = useDispatch();
 
+  /* Paginated search uses viewOptions in the request; external-ID lookup does not. Putting the
+   * whole viewOptions slice in the key for external-ID fetches tied query identity to Redux: this
+   * hook dispatches onSetTotal → viewOptions changes → new queryKey → refetch → loop (React #185). */
+  const isPaginatedSearch = !clusterExternalID;
+
   const { data, isLoading, isError, error } = useQuery({
     queryKey: [
       queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
       'fetchClusterTransfer',
       filter || clusterExternalID || transferID,
-      viewOptions,
+      ...(isPaginatedSearch ? [viewOptions] : []),
     ],
     queryFn: async () => {
       if (clusterExternalID) {
@@ -61,12 +66,13 @@ export const useFetchClusterTransfer = ({
     refetchInterval: queryConstants.STALE_TIME_60_SEC,
   });
 
-  // Recalculate totalPages when pageSize changes or new data arrives
+  // Recalculate totalPages when pageSize changes or new data arrives (list/search only).
   useEffect(() => {
+    if (clusterExternalID) return;
     if (data?.data?.total !== undefined) {
       dispatch(onSetTotal(data.data.total, viewType));
     }
-  }, [viewOptions.pageSize, data?.data?.total, dispatch, viewType]);
+  }, [clusterExternalID, viewOptions.pageSize, data?.data?.total, dispatch, viewType]);
 
   if (isError) {
     const formattedError = formatErrorData(isLoading, isError, error);

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
@@ -34,9 +34,7 @@ export const useFetchClusterTransfer = ({
 
   const dispatch = useDispatch();
 
-  /* Paginated search uses viewOptions in the request; external-ID lookup does not. Putting the
-   * whole viewOptions slice in the key for external-ID fetches tied query identity to Redux: this
-   * hook dispatches onSetTotal → viewOptions changes → new queryKey → refetch → loop (React #185). */
+  /* Don't worry about pagination when fetching one transfer or we might get an infinite loop. */
   const isPaginatedSearch = !clusterExternalID;
 
   const { data, isLoading, isError, error } = useQuery({


### PR DESCRIPTION
# Summary

Fix query key for cluster transfer ownership to prevent refetch loop 

Basically I set the query key to contain the viewOptions for the pagination recently added.  However, this is not needed when  fetching a single cluster transfer but still cause the key to change which then triggered a useEffect later in the code.

The fix is simply to not change the viewOptions for a single cluster since there is no pagination.

AI did help me track this down and here is the full explanation:

> In useFetchClusterTransfer.tsx the React Query queryKey included the full viewOptions object for CLUSTER_TRANSFER_VIEW, even when the request was getClusterTransferByExternalID (cluster details + modal — no pagination).

> At the same time, a useEffect dispatched onSetTotal whenever data?.data?.total was set. That updates Redux → viewOptions changes → query key changes → React Query refetches → effect runs again → repeat. Cancel/restart transfer makes refetches and responses with total more likely, so the bug can look flaky.

Assisted by: Cursor/composer-2-fast

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4354](https://issues.redhat.com/browse/OCMUI-4354)

# How to Test

1. Create a ROSA classic cluster using the default values.
2. Once the cluster is in ready status, go to the access control tab.
5. Click on the transfer ownership tab and, using the button Initiate transfer, submit the details (ask offline if you need another id to transfer to).
7. Click on the Cancel transfer button.
9. Open the transfer ownership modal again and fill in the username, account ID, and organization ID details.
11. Click on the initiate transfer button.
12. For good measure, cancel and re-initiate once more.
13. There should be no error that ocurs

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4354]: https://redhat.atlassian.net/browse/OCMUI-4354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ