### PR TITLE
OCMUI-4269 - Allow value of 0 for min-replicas field in Rosa HCP wizard

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolNodesSummary.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePoolNodesSummary.tsx
@@ -15,7 +15,14 @@ const MachinePoolNodesSummary = ({
     return `${machinePool.desired || machinePool.replicas}`;
   }
 
-  const autoScaleNodesText = `Min: ${machinePool.autoscaling.min_replicas}, Max: ${machinePool.autoscaling.max_replicas}`;
+  const minNodes = (replicas: number | undefined) => {
+    if (replicas === undefined) {
+      return 0;
+    }
+    return replicas;
+  };
+
+  const autoScaleNodesText = `Min: ${minNodes(machinePool.autoscaling.min_replicas)}, Max: ${machinePool.autoscaling.max_replicas}`;
   if (isMultiZoneCluster) {
     return (
       <Popover

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
@@ -1,6 +1,10 @@
 import { ClusterFromSubscription } from '~/types/types';
 
-import { countReplicasWithoutTaints, getClusterMinNodes } from './machinePoolsHelper';
+import {
+  countReplicasWithoutTaints,
+  getClusterMinNodes,
+  getMinNodesRequiredMaxReplicas,
+} from './machinePoolsHelper';
 
 const hcpCluster = {
   product: { id: 'ROSA' },
@@ -257,6 +261,41 @@ describe('machinePoolsHelper', () => {
 
         // First pool being added to empty cluster needs minimum 2
         expect(result).toBe(2);
+      });
+    });
+  });
+
+  describe('getMinNodesRequiredMaxReplicas', () => {
+    describe('Hypershift with autoscaling enabled', () => {
+      it('returns 2 when there is 1 machine pool', () => {
+        expect(getMinNodesRequiredMaxReplicas(true, 0, 1, true)).toBe(2);
+      });
+
+      it('returns 1 when there are multiple machine pools', () => {
+        expect(getMinNodesRequiredMaxReplicas(true, 0, 3, true)).toBe(1);
+      });
+
+      it('returns 2 when pools are reduced from 3 to 1', () => {
+        expect(getMinNodesRequiredMaxReplicas(true, 0, 3, true)).toBe(1);
+        expect(getMinNodesRequiredMaxReplicas(true, 0, 1, true)).toBe(2);
+      });
+    });
+
+    describe('Hypershift without autoscaling', () => {
+      it('returns minNodes when autoscaling is disabled', () => {
+        expect(getMinNodesRequiredMaxReplicas(true, 2, 1, false)).toBe(2);
+        expect(getMinNodesRequiredMaxReplicas(true, 1, 3, false)).toBe(1);
+      });
+    });
+
+    describe('non-Hypershift', () => {
+      it('returns minNodes regardless of pool count or autoscaling', () => {
+        expect(getMinNodesRequiredMaxReplicas(false, 4, 1, true)).toBe(4);
+        expect(getMinNodesRequiredMaxReplicas(false, 2, 3, false)).toBe(2);
+      });
+
+      it('returns undefined when minNodes is undefined', () => {
+        expect(getMinNodesRequiredMaxReplicas(false, undefined, 1, false)).toBeUndefined();
       });
     });
   });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
@@ -64,7 +64,10 @@ const getMinNodesRequiredNonHypershift = (
  * @param {number | undefined=} numMachinePools
  * @returns number
  */
-const getMinNodesRequiredHypershift = (numMachinePools?: number) => {
+const getMinNodesRequiredHypershift = (numMachinePools?: number, isAutoscaleEnabled?: boolean) => {
+  if (isAutoscaleEnabled) {
+    return 0;
+  }
   if (numMachinePools === undefined) {
     // day 2 operation (Add/Edit)
     return 1;
@@ -88,14 +91,30 @@ const getMinNodesRequired = (
   isHypershiftCluster: boolean,
   hypershiftProps?: { numMachinePools?: number },
   nonHypershiftProps?: { isDefaultMachinePool: boolean; isByoc: boolean; isMultiAz: boolean },
+  isAutoscaleEnabled?: boolean,
 ) =>
   isHypershiftCluster
-    ? getMinNodesRequiredHypershift(hypershiftProps?.numMachinePools)
+    ? getMinNodesRequiredHypershift(hypershiftProps?.numMachinePools, isAutoscaleEnabled)
     : getMinNodesRequiredNonHypershift(
         nonHypershiftProps?.isDefaultMachinePool,
         nonHypershiftProps?.isByoc,
         nonHypershiftProps?.isMultiAz,
       );
+
+const getMinNodesRequiredMaxReplicas = (
+  isHypershiftCluster: boolean,
+  minNodes: number | undefined,
+  numMachinePools: number,
+  isAutoscaleEnabled: boolean,
+) => {
+  if (isHypershiftCluster && isAutoscaleEnabled) {
+    if (numMachinePools > 1) {
+      return 1;
+    }
+    return 2;
+  }
+  return minNodes;
+};
 
 const isEnforcedDefaultMachinePool = (
   currentMachinePoolId: string | undefined,
@@ -365,6 +384,7 @@ export {
   countReplicasWithoutTaints,
   getClusterMinNodes,
   getMinNodesRequired,
+  getMinNodesRequiredMaxReplicas,
   getNodeIncrement,
   getNodeIncrementHypershift,
   getSubnetIds,

--- a/src/components/clusters/common/ScaleSection/AutoScaleSection/AutoScaleHelper.js
+++ b/src/components/clusters/common/ScaleSection/AutoScaleSection/AutoScaleHelper.js
@@ -17,7 +17,12 @@ const getMinNodesAllowed = ({
   autoScaleMinNodesValue = null,
   defaultMinAllowed = 0,
   isHypershiftWizard = false,
+  isAutoscaleEnabled,
 }) => {
+  if (isHypershiftWizard && isAutoscaleEnabled) {
+    return 0;
+  }
+
   let currMinNodes = parseInt(autoScaleMinNodesValue, 10) || 0;
   if (isMultiAz && !isHypershiftWizard) {
     currMinNodes *= 3;

--- a/src/components/clusters/common/ScaleSection/AutoScaleSection/AutoScaleHelper.test.js
+++ b/src/components/clusters/common/ScaleSection/AutoScaleSection/AutoScaleHelper.test.js
@@ -1,3 +1,4 @@
+import { normalizedProducts } from '~/common/subscriptionTypes';
 import { constants } from '~/components/clusters/common/CreateOSDFormConstants';
 import {
   DEFAULT_NODE_COUNT_CUSTOMER_MULTI_AZ,
@@ -6,9 +7,169 @@ import {
   DEFAULT_NODE_COUNT_REDHAT_SINGLE_AZ,
 } from '~/components/clusters/wizards/common/constants';
 
-import { computeNodeHintText, getMinReplicasCount, getNodesCount } from './AutoScaleHelper';
+import getMinNodesAllowed, {
+  computeNodeHintText,
+  getMinReplicasCount,
+  getNodesCount,
+} from './AutoScaleHelper';
 
 describe('AutoScaleHelper.js', () => {
+  describe('getMinNodesAllowed', () => {
+    const base = {
+      isAutoscaleEnabled: false,
+    };
+
+    it('returns 0 when Hypershift wizard and autoscaling is enabled', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isHypershiftWizard: true,
+          isAutoscaleEnabled: true,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: false,
+        }),
+      ).toBe(0);
+    });
+
+    it('uses BYOC or ROSA default pool minimums: 3 multi-AZ, 2 single-AZ', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: true,
+          isMultiAz: true,
+        }),
+      ).toBe(3);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: true,
+          isMultiAz: false,
+        }),
+      ).toBe(2);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.ROSA,
+          isBYOC: false,
+          isMultiAz: true,
+        }),
+      ).toBe(3);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.ROSA,
+          isBYOC: false,
+          isMultiAz: false,
+        }),
+      ).toBe(2);
+    });
+
+    it('uses non-BYOC OSD default pool minimums: 9 multi-AZ, 4 single-AZ', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: true,
+        }),
+      ).toBe(9);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: false,
+        }),
+      ).toBe(4);
+    });
+
+    it('uses defaultMinAllowed for non-default machine pools when it is the effective max', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: false,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: true,
+          defaultMinAllowed: 0,
+        }),
+      ).toBe(0);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: false,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: false,
+          defaultMinAllowed: 7,
+        }),
+      ).toBe(7);
+    });
+
+    it('returns the greater of scaled autoScaleMinNodesValue and default-pool floor', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: false,
+          autoScaleMinNodesValue: 8,
+        }),
+      ).toBe(8);
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: true,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: true,
+          autoScaleMinNodesValue: 5,
+        }),
+      ).toBe(15);
+    });
+
+    it('multiplies autoScaleMinNodesValue by 3 for multi-AZ when not Hypershift before taking max', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isDefaultMachinePool: false,
+          product: normalizedProducts.OSD,
+          isBYOC: false,
+          isMultiAz: true,
+          autoScaleMinNodesValue: 2,
+          defaultMinAllowed: 0,
+        }),
+      ).toBe(6);
+    });
+
+    it('does not multiply autoScaleMinNodesValue by 3 for multi-AZ when Hypershift wizard (autoscale off)', () => {
+      expect(
+        getMinNodesAllowed({
+          ...base,
+          isHypershiftWizard: true,
+          isAutoscaleEnabled: false,
+          isDefaultMachinePool: false,
+          product: normalizedProducts.ROSA,
+          isBYOC: true,
+          isMultiAz: true,
+          autoScaleMinNodesValue: 2,
+          defaultMinAllowed: 0,
+        }),
+      ).toBe(2);
+    });
+  });
+
   describe('computeNodeHintText', () => {
     it('returns HCP wizard help text', () => {
       const isHypershiftWizard = true;

--- a/src/components/clusters/common/totalNodesDataSelector.ts
+++ b/src/components/clusters/common/totalNodesDataSelector.ts
@@ -33,12 +33,17 @@ const totalNodesDataSelector = <E extends ClusterFromSubscription>(
     machinePools.forEach((machinePool) => {
       if (machinePool.autoscaling) {
         hasMachinePoolWithAutoscaling = true;
-
         const autoscaling = machinePool.autoscaling as NodePoolAutoscaling;
-        if (isHypershift && (autoscaling?.min_replica || autoscaling?.max_replica)) {
+        if (
+          isHypershift &&
+          (autoscaling?.min_replica || autoscaling?.min_replica === 0 || autoscaling?.max_replica)
+        ) {
           // if hypershift then NodePool type
           totalMinNodesCount += autoscaling?.min_replica ?? NaN;
-          totalMaxNodesCount += autoscaling?.max_replica ?? NaN;
+          totalMaxNodesCount +=
+            autoscaling?.max_replica ??
+            (autoscaling as { max_replicas?: number }).max_replicas ??
+            NaN;
         } else {
           // otherwise MachinePool type
           totalMinNodesCount += (machinePool as MachinePool).autoscaling?.min_replicas ?? NaN;

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
@@ -9,7 +9,7 @@ import { AutoScaleEnabledInputs } from './AutoScaleEnabledInputs';
 describe('AutoScaleEnabledInputs', () => {
   const initialValues = {
     [RosaFieldId.Hypershift]: 'true',
-    [RosaFieldId.AutoscalingEnabled]: 'true',
+    [RosaFieldId.AutoscalingEnabled]: true,
     [RosaFieldId.MachinePoolsSubnets]: ['subnet1', 'subnet2'],
     [RosaFieldId.MultiAz]: 'false',
     [RosaFieldId.MinReplicas]: '2',

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
@@ -142,7 +142,7 @@ describe('AutoScaleEnabledInputs', () => {
       );
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(2);
-      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
+      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(2);
     });
 
     it('sets minimum value when value is not set for 1 subnet !isHypershift', async () => {
@@ -170,7 +170,7 @@ describe('AutoScaleEnabledInputs', () => {
       );
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(1);
-      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
+      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(1);
     });
 
     it('shows max warning when user changes subnets', async () => {

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
@@ -44,14 +44,12 @@ describe('AutoScaleEnabledInputs', () => {
       await user.type(screen.getByLabelText('Minimum nodes'), '0');
 
       expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
-      expect(screen.getByText('Input cannot be less than 2.')).toBeInTheDocument();
 
       // Test for right amount - above minimum value and below max nodes
       await user.clear(screen.getByLabelText('Minimum nodes'));
       await user.type(screen.getByLabelText('Minimum nodes'), '3');
 
       expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(3);
-      expect(screen.queryByText('Input cannot be less than 2.')).not.toBeInTheDocument();
 
       // Test for minimum more than maximum
       await user.clear(screen.getByLabelText('Minimum nodes'));
@@ -61,7 +59,7 @@ describe('AutoScaleEnabledInputs', () => {
       expect(screen.getByText('Max nodes cannot be less than min nodes.')).toBeInTheDocument();
     });
 
-    it('validates min nodes input correctly for more than 1 subnet', async () => {
+    it('validates min nodes input correctly for more than 1 subnet isHypershift', async () => {
       const { user } = render(
         buildTestComponent({
           [RosaFieldId.Hypershift]: 'true',
@@ -73,7 +71,22 @@ describe('AutoScaleEnabledInputs', () => {
       await user.type(screen.getByLabelText('Minimum nodes'), '0');
 
       expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
-      expect(screen.getByText('Input cannot be less than 1.')).toBeInTheDocument();
+      expect(screen.queryByText('Input cannot be less than 1.')).not.toBeInTheDocument();
+    });
+
+    it('validates min nodes input correctly for more than 1 subnet !isHypershift', async () => {
+      const { user } = render(
+        buildTestComponent({
+          [RosaFieldId.Hypershift]: 'false',
+          [RosaFieldId.MachinePoolsSubnets]: ['subnet1', 'subnet2'],
+        }),
+      );
+      // Test for too few
+      await user.clear(screen.getByLabelText('Minimum nodes'));
+      await user.type(screen.getByLabelText('Minimum nodes'), '0');
+
+      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
+      expect(screen.getByText('Input cannot be less than 2.')).toBeInTheDocument();
     });
 
     it('validates max nodes input correctly', async () => {
@@ -88,7 +101,7 @@ describe('AutoScaleEnabledInputs', () => {
       await user.type(screen.getByLabelText('Maximum nodes'), '0');
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(0);
-      expect(screen.getByText('Input cannot be less than 2.')).toBeInTheDocument();
+      expect(screen.getByText('Max nodes cannot be less than min nodes.')).toBeInTheDocument();
 
       // Test for right amount - above minimum value
       await user.clear(screen.getByLabelText('Maximum nodes'));
@@ -118,7 +131,7 @@ describe('AutoScaleEnabledInputs', () => {
       expect(screen.getByText('Max nodes cannot be less than min nodes.')).toBeInTheDocument();
     });
 
-    it('sets minimum value when value is not set for 1 subnet', async () => {
+    it('sets minimum value when value is not set for 1 subnet isHypershift', async () => {
       render(
         buildTestComponent({
           [RosaFieldId.Hypershift]: 'true',
@@ -129,10 +142,24 @@ describe('AutoScaleEnabledInputs', () => {
       );
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(2);
+      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
+    });
+
+    it('sets minimum value when value is not set for 1 subnet !isHypershift', async () => {
+      render(
+        buildTestComponent({
+          [RosaFieldId.Hypershift]: 'false',
+          [RosaFieldId.MachinePoolsSubnets]: ['subnet1'],
+          [RosaFieldId.MinReplicas]: '',
+          [RosaFieldId.MaxReplicas]: '',
+        }),
+      );
+
+      expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(2);
       expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(2);
     });
 
-    it('sets minimum value when value is not set for 1 subnet', async () => {
+    it('sets minimum value when value is not set for 1 subnet isHypershift', async () => {
       render(
         buildTestComponent({
           [RosaFieldId.Hypershift]: 'true',
@@ -143,7 +170,7 @@ describe('AutoScaleEnabledInputs', () => {
       );
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(1);
-      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(1);
+      expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(0);
     });
 
     it('shows max warning when user changes subnets', async () => {

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
@@ -101,7 +101,7 @@ describe('AutoScaleEnabledInputs', () => {
       await user.type(screen.getByLabelText('Maximum nodes'), '0');
 
       expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(0);
-      expect(screen.getByText('Max nodes cannot be less than min nodes.')).toBeInTheDocument();
+      expect(screen.getByText('Maximum nodes cannot be less than 2.')).toBeInTheDocument();
 
       // Test for right amount - above minimum value
       await user.clear(screen.getByLabelText('Maximum nodes'));
@@ -194,6 +194,57 @@ describe('AutoScaleEnabledInputs', () => {
         }),
       );
       expect(screen.getByText('Max nodes cannot be less than min nodes.')).toBeInTheDocument();
+    });
+
+    it('shows validation error when max nodes is manually set to 0 with 1 subnet', async () => {
+      const { user } = render(
+        buildTestComponent({
+          [RosaFieldId.Hypershift]: 'true',
+          [RosaFieldId.MachinePoolsSubnets]: ['subnet1'],
+          [RosaFieldId.MinReplicas]: '0',
+          [RosaFieldId.MaxReplicas]: '2',
+        }),
+      );
+
+      await user.clear(screen.getByLabelText('Maximum nodes'));
+      await user.type(screen.getByLabelText('Maximum nodes'), '0');
+
+      expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(0);
+      expect(screen.getByText('Maximum nodes cannot be less than 2.')).toBeInTheDocument();
+    });
+
+    it('shows validation error when max nodes is manually set to 1 with 1 subnet', async () => {
+      const { user } = render(
+        buildTestComponent({
+          [RosaFieldId.Hypershift]: 'true',
+          [RosaFieldId.MachinePoolsSubnets]: ['subnet1'],
+          [RosaFieldId.MinReplicas]: '0',
+          [RosaFieldId.MaxReplicas]: '2',
+        }),
+      );
+
+      await user.clear(screen.getByLabelText('Maximum nodes'));
+      await user.type(screen.getByLabelText('Maximum nodes'), '1');
+
+      expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(1);
+      expect(screen.getByText('Maximum nodes cannot be less than 2.')).toBeInTheDocument();
+    });
+
+    it('allows max nodes of 1 when there are multiple subnets', async () => {
+      const { user } = render(
+        buildTestComponent({
+          [RosaFieldId.Hypershift]: 'true',
+          [RosaFieldId.MachinePoolsSubnets]: ['subnet1', 'subnet2'],
+          [RosaFieldId.MinReplicas]: '0',
+          [RosaFieldId.MaxReplicas]: '1',
+        }),
+      );
+
+      await user.clear(screen.getByLabelText('Maximum nodes'));
+      await user.type(screen.getByLabelText('Maximum nodes'), '1');
+
+      expect(await screen.findByLabelText('Maximum nodes')).toHaveValue(1);
+      expect(screen.queryByText(/Maximum nodes cannot be less than/)).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.test.tsx
@@ -159,7 +159,7 @@ describe('AutoScaleEnabledInputs', () => {
       expect(await screen.findByLabelText('Minimum nodes')).toHaveValue(2);
     });
 
-    it('sets minimum value when value is not set for 1 subnet isHypershift', async () => {
+    it('sets minimum value when value is not set for 2 subnets isHypershift', async () => {
       render(
         buildTestComponent({
           [RosaFieldId.Hypershift]: 'true',

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
@@ -7,7 +7,10 @@ import { Flex, FormGroup } from '@patternfly/react-core';
 import docLinks from '~/common/docLinks.mjs';
 import { normalizedProducts } from '~/common/subscriptionTypes';
 import { required, validateNumericInput } from '~/common/validators';
-import { getMinNodesRequired } from '~/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper';
+import {
+  getMinNodesRequired,
+  getMinNodesRequiredMaxReplicas,
+} from '~/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper';
 import { constants } from '~/components/clusters/common/CreateOSDFormConstants';
 import { MAX_NODES_INSUFFICIEN_VERSION as MAX_NODES_180 } from '~/components/clusters/common/machinePools/constants';
 import { getMaxNodesHCP, getMaxWorkerNodes } from '~/components/clusters/common/machinePools/utils';
@@ -42,7 +45,6 @@ export const AutoScaleEnabledInputs = () => {
       [RosaFieldId.ClusterVersion]: clusterVersion,
     },
   } = useFormState();
-
   const allow249NodesOSDCCSROSA = useFeatureGate(MAX_NODES_TOTAL_249);
 
   const poolsLength = useMemo(
@@ -76,16 +78,23 @@ export const AutoScaleEnabledInputs = () => {
         isHypershiftSelected,
         { numMachinePools: poolsLength },
         { isDefaultMachinePool: !isHypershiftSelected, isByoc, isMultiAz },
+        autoscalingEnabled,
       ),
-    [poolsLength, isHypershiftSelected, isByoc, isMultiAz],
+    [poolsLength, isHypershiftSelected, isByoc, isMultiAz, autoscalingEnabled],
   );
 
   const defaultMinAllowed = useMemo(() => {
+    if (isHypershiftSelected && autoscalingEnabled) {
+      return 0;
+    }
+
     if (isHypershiftSelected) {
       return poolsLength > 1 ? 1 : 2;
     }
     return minNodesRequired;
-  }, [isHypershiftSelected, minNodesRequired, poolsLength]);
+  }, [isHypershiftSelected, minNodesRequired, poolsLength, autoscalingEnabled]);
+
+  const hasMin = (min: number | undefined) => min !== undefined && min !== null;
 
   const helperText = (
     message: React.ReactNode,
@@ -115,13 +124,13 @@ export const AutoScaleEnabledInputs = () => {
       autoScaleMinNodesValue: undefined,
       defaultMinAllowed,
       isHypershiftWizard: isHypershiftSelected,
+      isAutoscaleEnabled: autoscalingEnabled,
     });
-
-    if (minNodesAllowed) {
+    if (hasMin(minNodesAllowed)) {
       return minNodesAllowed / (isMultiAz && !isHypershiftSelected ? 3 : 1);
     }
     return undefined;
-  }, [product, isByoc, isMultiAz, defaultMinAllowed, isHypershiftSelected]);
+  }, [product, isByoc, isMultiAz, defaultMinAllowed, isHypershiftSelected, autoscalingEnabled]);
 
   const maxNodes = useMemo(() => {
     const maxWorkerNodes = allow249NodesOSDCCSROSA
@@ -169,7 +178,7 @@ export const AutoScaleEnabledInputs = () => {
     if (nodesError) {
       return nodesError;
     }
-    return minReplicas && value < minReplicas
+    return hasMin(minReplicas) && value < minReplicas
       ? 'Max nodes cannot be less than min nodes.'
       : undefined;
   };
@@ -187,16 +196,22 @@ export const AutoScaleEnabledInputs = () => {
   }, [machinePoolsSubnets, prevMachinePoolsSubnets, maxReplicas]);
 
   useEffect(() => {
-    if (autoscalingEnabled && minNodes) {
-      const minAutoscaleValue = minReplicas ? parseInt(minReplicas, 10) : 0;
+    if (autoscalingEnabled && hasMin(minNodes)) {
+      const minAutoscaleValue = minReplicas || minReplicas === 0 ? parseInt(minReplicas, 10) : 0;
       const min = minAutoscaleValue < minNodes ? minNodes : minAutoscaleValue;
 
-      if (min) {
+      if (hasMin(min)) {
         setFieldValue(RosaFieldId.MinReplicas, min);
       }
       if (!maxReplicas || (maxReplicas < min && maxReplicas < minNodes)) {
-        setFieldValue(RosaFieldId.MaxReplicas, minNodes, true);
-        setMaxErrorMessage(validateMaxNodes(maxReplicas));
+        if (minNodes === 0) {
+          const increment = poolsLength > 1 ? 1 : 2;
+          setFieldValue(RosaFieldId.MaxReplicas, minNodes + increment, true);
+          setMaxErrorMessage(validateMaxNodes(maxReplicas));
+        } else {
+          setFieldValue(RosaFieldId.MaxReplicas, minNodes, true);
+          setMaxErrorMessage(validateMaxNodes(maxReplicas));
+        }
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -272,7 +287,12 @@ export const AutoScaleEnabledInputs = () => {
           displayError={(_: string, error: string) => setMaxErrorMessage(error)}
           hideError={() => setMaxErrorMessage(undefined)}
           limit="max"
-          min={minNodes}
+          min={getMinNodesRequiredMaxReplicas(
+            isHypershiftSelected,
+            minNodes,
+            poolsLength,
+            autoscalingEnabled,
+          )}
           max={maxNodes}
           input={{
             ...getFieldProps(RosaFieldId.MaxReplicas),

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
@@ -151,6 +151,17 @@ export const AutoScaleEnabledInputs = () => {
     clusterVersion?.raw_id,
   ]);
 
+  const minRequiredMaxReplicas = useMemo(
+    () =>
+      getMinNodesRequiredMaxReplicas(
+        isHypershiftSelected,
+        minNodes,
+        poolsLength,
+        autoscalingEnabled,
+      ),
+    [isHypershiftSelected, minNodes, poolsLength, autoscalingEnabled],
+  );
+
   useEffect(() => {
     if (maxReplicas) {
       // to trigger MaxReplicas field validation
@@ -178,6 +189,9 @@ export const AutoScaleEnabledInputs = () => {
     if (nodesError) {
       return nodesError;
     }
+    if (hasMin(minRequiredMaxReplicas) && value < minRequiredMaxReplicas) {
+      return `Maximum nodes cannot be less than ${minRequiredMaxReplicas}.`;
+    }
     return hasMin(minReplicas) && value < minReplicas
       ? 'Max nodes cannot be less than min nodes.'
       : undefined;
@@ -203,19 +217,20 @@ export const AutoScaleEnabledInputs = () => {
       if (hasMin(min)) {
         setFieldValue(RosaFieldId.MinReplicas, min);
       }
-      if (!maxReplicas || (maxReplicas < min && maxReplicas < minNodes)) {
-        if (minNodes === 0) {
-          const increment = poolsLength > 1 ? 1 : 2;
-          setFieldValue(RosaFieldId.MaxReplicas, minNodes + increment, true);
-          setMaxErrorMessage(validateMaxNodes(maxReplicas));
-        } else {
-          setFieldValue(RosaFieldId.MaxReplicas, minNodes, true);
-          setMaxErrorMessage(validateMaxNodes(maxReplicas));
-        }
+
+      if (
+        !maxReplicas ||
+        (hasMin(minRequiredMaxReplicas) && maxReplicas < minRequiredMaxReplicas)
+      ) {
+        const newMaxReplicas = hasMin(minRequiredMaxReplicas)
+          ? Math.max(minRequiredMaxReplicas, min)
+          : min;
+        setFieldValue(RosaFieldId.MaxReplicas, newMaxReplicas, true);
+        setMaxErrorMessage(validateMaxNodes(newMaxReplicas));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoscalingEnabled, isMultiAz, minNodes, setFieldValue]);
+  }, [autoscalingEnabled, isMultiAz, minNodes, poolsLength, setFieldValue]);
 
   return (
     <Flex
@@ -287,12 +302,7 @@ export const AutoScaleEnabledInputs = () => {
           displayError={(_: string, error: string) => setMaxErrorMessage(error)}
           hideError={() => setMaxErrorMessage(undefined)}
           limit="max"
-          min={getMinNodesRequiredMaxReplicas(
-            isHypershiftSelected,
-            minNodes,
-            poolsLength,
-            autoscalingEnabled,
-          )}
+          min={minRequiredMaxReplicas}
           max={maxNodes}
           input={{
             ...getFieldProps(RosaFieldId.MaxReplicas),

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
@@ -211,24 +211,30 @@ export const AutoScaleEnabledInputs = () => {
 
   useEffect(() => {
     if (autoscalingEnabled && hasMin(minNodes)) {
-      const minAutoscaleValue = minReplicas || minReplicas === 0 ? parseInt(minReplicas, 10) : 0;
+      let defaultMin = minNodes;
+
+      if (isHypershiftSelected) {
+        defaultMin = poolsLength > 1 ? 1 : 2;
+      }
+
+      const minAutoscaleValue =
+        minReplicas || minReplicas === 0 ? parseInt(minReplicas, 10) : defaultMin;
       const min = minAutoscaleValue < minNodes ? minNodes : minAutoscaleValue;
 
-      setFieldValue(RosaFieldId.MinReplicas, min);
+      if (hasMin(min) && min !== parseInt(minReplicas, 10)) {
+        setFieldValue(RosaFieldId.MinReplicas, min);
+      }
 
       if (
         !maxReplicas ||
         (hasMin(minRequiredMaxReplicas) && maxReplicas < minRequiredMaxReplicas)
       ) {
-        const newMaxReplicas = hasMin(minRequiredMaxReplicas)
-          ? Math.max(minRequiredMaxReplicas, min)
-          : min;
-        setFieldValue(RosaFieldId.MaxReplicas, newMaxReplicas, true);
-        setMaxErrorMessage(validateMaxNodes(newMaxReplicas));
+        setFieldValue(RosaFieldId.MaxReplicas, minRequiredMaxReplicas, true);
+        setMaxErrorMessage(validateMaxNodes(minRequiredMaxReplicas as number));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoscalingEnabled, isMultiAz, minNodes, poolsLength, setFieldValue]);
+  }, [autoscalingEnabled, isMultiAz, minNodes, minRequiredMaxReplicas, poolsLength, setFieldValue]);
 
   return (
     <Flex

--- a/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
+++ b/src/components/clusters/wizards/common/ClusterSettings/MachinePool/AutoScale/AutoScaleEnabledInputs.tsx
@@ -214,9 +214,7 @@ export const AutoScaleEnabledInputs = () => {
       const minAutoscaleValue = minReplicas || minReplicas === 0 ? parseInt(minReplicas, 10) : 0;
       const min = minAutoscaleValue < minNodes ? minNodes : minAutoscaleValue;
 
-      if (hasMin(min)) {
-        setFieldValue(RosaFieldId.MinReplicas, min);
-      }
+      setFieldValue(RosaFieldId.MinReplicas, min);
 
       if (
         !maxReplicas ||

--- a/src/components/clusters/wizards/rosa/ClusterSettings/Details/Details.tsx
+++ b/src/components/clusters/wizards/rosa/ClusterSettings/Details/Details.tsx
@@ -92,6 +92,7 @@ function Details() {
       [FieldId.DomainPrefix]: domainPrefix,
       [FieldId.ChannelGroup]: channelGroup,
       [FieldId.ClusterVersion]: selectedVersion,
+      [FieldId.AutoscalingEnabled]: autoscalingEnabled,
     },
     errors,
     getFieldProps,
@@ -316,6 +317,10 @@ function Details() {
     const mpSubnetsReset = new Array(isMultiAz ? 3 : 1).fill(emptyAWSSubnet());
     setFieldValue(FieldId.MachinePoolsSubnets, mpSubnetsReset);
     setFieldValue(FieldId.SelectedVpc, { id: '', name: '' });
+    if (isHypershiftSelected && autoscalingEnabled) {
+      setFieldValue(FieldId.MinReplicas, 2);
+      setFieldValue(FieldId.MaxReplicas, 2);
+    }
 
     // Reset the public subnet ID selection associated with cluster privacy on region change,
     // since the list of values there can change entirely based on the selected region.


### PR DESCRIPTION
# Summary

This PR adds changes to allow the minNodes field to be scaled to 0 when autoscaling is enabled

# Jira


 Fixes [OCMUI-4269](https://issues.redhat.com/browse/OCMUI-4269) 

# Additional information

Fixed additional checks for the days 2 operations that were resulting in the min replicas value showing as NaN in the UI due to 0 being a falsy value

Assisted by Cursor/claude-4.6-opus
# How to Test

1. Begin creating a ROSA Hypershift cluster
2. Proceed to the Cluster setting --> Machine pool step
3. Check the enable autoscaling box and ensure the "Minimum nodes per machine pool" field allows 0
4. Add 1, 2 or 3 subnets, the minReplicas value should allow 0 for any amount of subnets
5. Create the cluster and ensure it builds without error 

# Screen Captures
<img width="1166" height="694" alt="ocmui4269_after" src="https://github.com/user-attachments/assets/62daf74c-4823-4aa8-aee4-a967ff4cc162" />



| Cluster Details Before                                           | Cluster Details After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1224" height="442" alt="ocmui4269_detailsRight_before" src="https://github.com/user-attachments/assets/e8bfab65-6dee-4bfc-8c87-f13de893aaa6" /> | <img width="1139" height="419" alt="ocmui4269_detailsRight_after" src="https://github.com/user-attachments/assets/4d9b8013-1140-41ab-8ecc-c548e153a76c" /> |



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4269]: https://redhat.atlassian.net/browse/OCMUI-4269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ