### PR TITLE
chore: upgrade konflux remote-pipeline

### DIFF
--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -32,11 +32,6 @@ spec:
     value: build-tools/Dockerfile
   - name: e2e-app-port
     value: "8000"
-
-  # todo - remove before merge - this is a workaround until konflux-pipelines #227 is merged
-  - name: workspace-setup-script
-    value: "echo 'wat'"
-
   - name: unit-tests-script
     value: |
       #!/bin/bash

--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/platform-ui/docker-build-run-all-tests.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/platform-ui/docker-build-run-all-tests-v2.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: ocm-ui
@@ -32,6 +32,11 @@ spec:
     value: build-tools/Dockerfile
   - name: e2e-app-port
     value: "8000"
+
+  # todo - remove before merge - this is a workaround until konflux-pipelines #227 is merged
+  - name: workspace-setup-script
+    value: "echo 'wat'"
+
   - name: unit-tests-script
     value: |
       #!/bin/bash
@@ -193,7 +198,7 @@ spec:
   - name: e2e-hcc-env-url
     value: https://console.dev.redhat.com
   pipelineRef:
-    name: docker-build
+    name: docker-build-v2
   taskRunTemplate:
     serviceAccountName: build-pipeline-uhc-portal
   taskRunSpecs:


### PR DESCRIPTION
> [!important]
> 
> this PR fixes current CI failures

# Summary

update the remote pipeline `docker-build-run-all-tests` to `docker-build-run-all-tests-v2`.


# Jira

no ticket; split from [OCMUI-4344][1].


# Additional information

the remote-pipeline config is only used in 'pull-request' pipelines (no need to update 'push' pipelines).

this work was split from the node.js konflux migration scope (see [OCMUI-4344][1]), and was originally introduced to allow control of node.js version.

it was made urgent due to the need to work around CI failures from the past few days (which the update to v2 fixes).


# Dependencies

- https://github.com/RedHatInsights/konflux-pipelines/pull/227

# How to Test

no manual testing.  ensure CI passes.



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no feature-testing.




[1]: https://redhat.atlassian.net/browse/OCMUI-4344



[OCMUI-4344]: https://redhat.atlassian.net/browse/OCMUI-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ