### PR TITLE
OCMUI-3253: Disable Save button until form is dirty

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
@@ -259,7 +259,7 @@ export function ExternalAuthProviderModal(props: ExternalAuthProviderModalProps)
             <Button
               key="add-ext-auth-provider"
               variant="primary"
-              isDisabled={isPending || !formik.dirty}
+              isDisabled={isPending || !formik.dirty || !formik.isValid}
               isLoading={isPending}
               onClick={formik.submitForm}
             >

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/ExternalAuthProviderModal.tsx
@@ -259,7 +259,7 @@ export function ExternalAuthProviderModal(props: ExternalAuthProviderModalProps)
             <Button
               key="add-ext-auth-provider"
               variant="primary"
-              isDisabled={isPending}
+              isDisabled={isPending || !formik.dirty}
               isLoading={isPending}
               onClick={formik.submitForm}
             >

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
@@ -63,6 +63,34 @@ describe('<ExternalAuthProviderModal />', () => {
     expect(mockModalData.onClose).toHaveBeenCalled();
   });
 
+  it('disables Add until the user changes the form', () => {
+    render(
+      <ExternalAuthProviderModal
+        clusterID={mockModalData.clusterId}
+        onClose={mockModalData.onClose}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+  });
+
+  it('disables Save until the form is edited', async () => {
+    const { user } = render(
+      <ExternalAuthProviderModal
+        clusterID={mockModalData.clusterId}
+        onClose={mockModalData.onClose}
+        externalAuthProvider={mockModalData.provider as any}
+        isEdit
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    expect(saveButton).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox', { name: 'Issuer URL' }), 'x');
+
+    expect(saveButton).not.toBeDisabled();
+  });
+
   it('calls post api on Add', async () => {
     const apiReturnValue = {
       data: {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
@@ -104,6 +104,13 @@ describe('<ExternalAuthProviderModal />', () => {
     const issuerInput = screen.getByRole('textbox', { name: 'Issuer URL' });
     await user.clear(issuerInput);
     await user.type(issuerInput, 'http://redhat.com');
+    await user.tab();
+
+    expect(await screen.findByText('URL must be https')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Issuer URL' })).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ExternalAuthentication/__tests__/ExternalAuthProviderModal.test.tsx
@@ -91,6 +91,23 @@ describe('<ExternalAuthProviderModal />', () => {
     expect(saveButton).not.toBeDisabled();
   });
 
+  it('disables Save when the form is dirty but has validation errors', async () => {
+    const { user } = render(
+      <ExternalAuthProviderModal
+        clusterID={mockModalData.clusterId}
+        onClose={mockModalData.onClose}
+        externalAuthProvider={mockModalData.provider as any}
+        isEdit
+      />,
+    );
+
+    const issuerInput = screen.getByRole('textbox', { name: 'Issuer URL' });
+    await user.clear(issuerInput);
+    await user.type(issuerInput, 'http://redhat.com');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
   it('calls post api on Add', async () => {
     const apiReturnValue = {
       data: {
@@ -138,6 +155,7 @@ describe('<ExternalAuthProviderModal />', () => {
     await user.type(screen.getByRole('textbox', { name: 'Console client secret' }), 'thissecret');
 
     expect(screen.queryByText(/Client ID must be a member of the audiences/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
   }, 80_000);
 
   it('calls post api on Add including console client', async () => {


### PR DESCRIPTION
# Summary

The External Authentication feature is available for HCP ROSA clusters.  Once the cluster is ready, you can add an external authentication provider.  After adding the provider, if you re-open the provider edit modal, the save button is currently enabled even though nothing has changed on the form.

I added a dirty check on the form and added a test case.

# Jira


Fixes [OCMUI-3253](https://issues.redhat.com/browse/OCMUI-3253)

# How to Test

1. Build an HCP ROSA cluster with EXTERNAL AUTHENTICATION turned on.  You can do this with the UI
2. Once the cluster is ready, go to the details page and then click the Access control tab.  You should see "Add external authentication provider"
3. Add an external provider - you can make up all the values that are required
4. Save it and then use the action menu to "Edit"
5. When the modal appears with the form, the "Save" should be disabled until you change a form entry.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="527" height="432" alt="Screenshot From 2026-04-13 15-56-16" src="https://github.com/user-attachments/assets/3d198e6e-0092-4b1b-89c1-646304bbda5b" /> | <img width="527" height="432" alt="Screenshot From 2026-04-13 15-56-07" src="https://github.com/user-attachments/assets/a85dabf6-8ed8-4eba-b9be-c345b3fe6c45" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3253]: https://redhat.atlassian.net/browse/OCMUI-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ