### PR TITLE
OCMUI-4345: upgrade node.js / GH workflows

### DIFF
--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -1,5 +1,3 @@
-# todo - rename file to align with convention ('check-api.yml')
-
 name: Check Backend Open API changes
 
 on:

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: './node_modules'
           key: check_api-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v5

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: actions/cache@v5

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -46,7 +46,7 @@ jobs:
           key: check_api-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
           
       - name: Install yarn
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install --frozen-lockfile --cache-folder .yarn
 

--- a/.github/workflows/check-api.yml
+++ b/.github/workflows/check-api.yml
@@ -26,7 +26,7 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.CHECK_OPENAPI_APP_ID }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,8 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          # todo
-          node-version: "22"
+          node-version: "24"
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
+          # todo
           node-version: "22"
 
       - name: Install dependencies

--- a/.github/workflows/check_api_pipeline.yml
+++ b/.github/workflows/check_api_pipeline.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       node-version:
-        # todo
-        default: '22.x'
+        default: '24.x'
         description: 'NodeJs version'
       swap-branch-name:
         default: 'openapi'
@@ -16,8 +15,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  # todo
-  NODE_VERSION: ${{ github.event.inputs.node-version || '22.x' }}
+  NODE_VERSION: ${{ github.event.inputs.node-version || '24.x' }}
   SWAP_BRANCH_NAME: ${{ github.event.inputs.swap-branch-name || 'openapi' }}
   BASE_BRANCH_NAME: ${{ github.ref_name || 'main' }}
 

--- a/.github/workflows/check_api_pipeline.yml
+++ b/.github/workflows/check_api_pipeline.yml
@@ -1,9 +1,12 @@
+# todo - rename file to align with convention ('check-api.yml')
+
 name: Check Backend Open API changes
 
 on:
   workflow_dispatch:
     inputs:
       node-version:
+        # todo
         default: '22.x'
         description: 'NodeJs version'
       swap-branch-name:
@@ -13,6 +16,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
+  # todo
   NODE_VERSION: ${{ github.event.inputs.node-version || '22.x' }}
   SWAP_BRANCH_NAME: ${{ github.event.inputs.swap-branch-name || 'openapi' }}
   BASE_BRANCH_NAME: ${{ github.ref_name || 'main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v5
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -47,6 +48,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -74,6 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -101,6 +104,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -128,6 +132,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -48,8 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,8 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -104,8 +101,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -132,8 +128,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           cmd: test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./unitTestCoverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: './node_modules'
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           path: './node_modules'
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
       - name: Check uncommitted changes
@@ -62,7 +62,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           fail-on-cache-miss: true
       - name: Build
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: build
   lint:
@@ -89,7 +89,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           fail-on-cache-miss: true
       - name: Lint
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: lint-prettier
   unitary-test:
@@ -116,7 +116,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           fail-on-cache-miss: true
       - name: Test
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: test
   circular-dependencies:
@@ -143,6 +143,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           fail-on-cache-miss: true
       - name: Find Circular Dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: find-circular-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   install:
-    name: ${{ matrix.os }} - Install - Node ${{ matrix.node-version }}
+    name: Install
     concurrency:
       group: install-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true
@@ -39,7 +39,7 @@ jobs:
         # The `git` command exits with 1 and fails the build if there are any uncommitted changes.
         run: git diff HEAD --exit-code
   build:
-    name: ${{ matrix.os }} - Build - Node ${{ matrix.node-version }}
+    name: Build
     concurrency:
       group: build-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true
@@ -66,7 +66,7 @@ jobs:
         with:
           cmd: build
   lint:
-    name: ${{ matrix.os }} - Lint - Node ${{ matrix.node-version }}
+    name: Lint
     concurrency:
       group: lint-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true
@@ -93,7 +93,7 @@ jobs:
         with:
           cmd: lint-prettier
   unitary-test:
-    name: ${{ matrix.os }} - Unitary Tests - Node ${{ matrix.node-version }}
+    name: Unitary Tests
     concurrency:
       group: unitary-test-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true
@@ -129,7 +129,7 @@ jobs:
           fail_ci_if_error: false
           verbose: true
   circular-dependencies:
-    name: ${{ matrix.os }} - Circular Dependencies - Node ${{ matrix.node-version }}
+    name: Circular Dependencies
     concurrency:
       group: circular-dependencies-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,10 @@ jobs:
         uses: borales/actions-yarn@v5
         with:
           cmd: lint-prettier
-  unitary-test:
-    name: Unitary Tests
+  unit-tests:
+    name: Unit Tests
     concurrency:
-      group: unitary-test-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
+      group: unit-tests-${{ github.event_name }}-${{ github.head_ref }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true
     needs: [build]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v5
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache/restore@v4

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        # todo
         node-version: [22.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -51,7 +51,7 @@ jobs:
           path: './node_modules'
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
       - name: Check uncommitted changes

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -35,8 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # todo
-        node-version: [22.x]
+        node-version: [24.x]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v5

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -28,7 +28,7 @@ on:
           - '4'
 jobs:
   playwright-e2e-test:
-    name: Playwright E2E - ${{ matrix.os }} - e2e Tests - Node ${{ matrix.node-version }}
+    name: Playwright E2E Tests
     concurrency:
       group: playwright-e2e-test-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}-${{ matrix.os }}-${{ matrix.node-version }}
       cancel-in-progress: true

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -1,4 +1,4 @@
-name: e2e CI Playwright Tests
+name: E2E CI Playwright Tests
 
 on:
   push:

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: './node_modules'
           key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: main
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v5

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -52,18 +52,21 @@ on:
 jobs:
   playwright-tests:
     name: Playwright Tests (${{ inputs.grep_tags || '@smoke' }})
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [24.x]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref }}
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
         uses: actions/cache@v4

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: './node_modules'
-          key: ${{ runner.os }}-24.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         uses: borales/actions-yarn@v5

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -60,15 +60,18 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
 
+      # todo
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
+          # todo
           node-version: 22.x
 
       - name: Cache node modules
         uses: actions/cache@v4
         with:
           path: './node_modules'
+          # todo
           key: ${{ runner.os }}-22.x-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -69,7 +69,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: './node_modules'
           key: ${{ runner.os }}-24.x-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -51,7 +51,7 @@ on:
 
 jobs:
   playwright-tests:
-    name: Playwright Tests (${{ inputs.grep_tags || '@smoke' }})
+    name: Playwright E2E Tests (${{ inputs.grep_tags || '@smoke' }})
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -1,4 +1,4 @@
-name: E2e Smoke Playwright
+name: E2E Smoke Playwright
 
 on:
   schedule:

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -60,19 +60,16 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
 
-      # todo
-      - name: Use Node.js 22.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          # todo
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Cache node modules
         uses: actions/cache@v4
         with:
           path: './node_modules'
-          # todo
-          key: ${{ runner.os }}-22.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-24.x-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         uses: borales/actions-yarn@v4

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -75,7 +75,7 @@ jobs:
           key: ${{ runner.os }}-24.x-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v5
         with:
           cmd: install
 


### PR DESCRIPTION

# Summary

update github workflows to use node.js version 24.


# Jira

addresses [OCMUI-4345][1]


# Additional information

### changes

##### enhancement

- 53adce97f2657f9e124ca11e1bc2ebe39674288d: update explicit version references in GH workflows from 22 to 24
- upgrade GH actions to support 24:
  - e85b1b56bad198247362c3c813fd8ea5f9a66284:  `actions/cache`   v4 → v5
  - ba502e952e01b2a4dd81b42c76bc4d721f7ef7ba:  `actions/create-github-app-token`  v2 → v3
  - f006cea06cd7c0c2d29bfa28b1bb525961bbd097 / 4361daeb1f4ac1bcbd08019b3b8fadfafafe70ff:  `actions/setup-node`  v4 → v5 → v6
  - 9aee8474b55ecd422594ce3afba0d55d6ec972b0:  `borales/actions-yarn`  v4 → v5
  - 632c4d06692504d4e0caa094a453523e8cc943e9:  `codecov/codecov-action`  v4 → v6

##### refactor

- 378b9d80fb9654febbde7bc653c1a19dd5fa4621: rename check_api_pipeline.yml to check-api.yml, to align with current convention
- 235d8d2da0c1e1f498e9d8fb3e52d26886ad6970 / 6ae464d5cf6076357a90db98f259ffc302747603: refactor e2e-smoke-playwright workflow for reuse: declare OS and node-version under `strategy`, and reference it where needed
- ee9696c69a2531c320bde5902607c1d14dd7ac42: update workflow names to fix acronym letter-case
- 6b7eee24a1d8d853706ecf6e88a5859e63f1cfed: remove OS and node-version from job names as redundant (it was also unnecessarily rigid - it required updating the repo settings on any OS or node-version change)
- 0bac5a44e759facbad891c407ebf687e85b7f863: rename 'unitary test' to 'unit tests' anywhere

### notes

- v5 of `borales/actions-yarn` (which this PR upgrades to) still doesn't officially support node 24, only node 20
- `borales/actions-yarn` becomes obsolete with yarn->npm migration, and will be removed with #438.  
   i'll mark this PR as depending on #438, to make its scope complete and don't leave any gaps in impl'
- some checks can only be verified after merge  (these are: 'check API', 'check links', 'E2E CI playwright', 'E2E smoke playwright')
- additional changes are needed in the repo 'rulesets' settings, to update the required checks for PRs.  please see the jira ticket for details



# Dependencies

-  #438 (soft dep', some changes were made to improve current action-package, and it'll be finally removed with that PR)


# How to Test

- make sure all CI checks pass and work correctly
- inspect the logs for each check and verify the node version used is '24'


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no feature-testing.




[1]: https://redhat.atlassian.net/browse/OCMUI-4345



[OCMUI-4345]: https://redhat.atlassian.net/browse/OCMUI-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ