### PR TITLE
OCMUI-4200 - [GCP OSD wizard]Service Account JSON validation always shows incorrect "requires osd-ccs-admin" error for client_email format issues

### DIFF
--- a/src/common/__tests__/validators.test.ts
+++ b/src/common/__tests__/validators.test.ts
@@ -25,6 +25,7 @@ import validators, {
   required,
   validateAWSKMSKeyARN,
   validateGCPKMSServiceAccount,
+  validateGCPServiceAccount,
   validateGCPSubnet,
   validateHTPasswdPassword,
   validateHTPasswdUsername,
@@ -1045,6 +1046,38 @@ describe('GCP service account JSON', () => {
     } else {
       expect(validateServiceAccountObject(testObj)).toBe(undefined);
     }
+  });
+});
+
+describe('validateGCPServiceAccount', () => {
+  const validServiceAccount = fixtures.GCPServiceAccounts[0].testObj;
+
+  it('returns undefined for valid service account JSON', () => {
+    expect(validateGCPServiceAccount(JSON.stringify(validServiceAccount))).toBeUndefined();
+  });
+
+  it('returns a clear message when client_email uses the correct local part but the wrong domain', () => {
+    const obj = {
+      ...validServiceAccount,
+      client_email: 'osd-ccs-admin@wrongdomain.com',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'client_email' must be a Google Cloud service account email ending in '.iam.gserviceaccount.com'.",
+    );
+  });
+
+  it("returns a clear message when client_email local part is not 'osd-ccs-admin'", () => {
+    const obj = {
+      ...validServiceAccount,
+      client_email: 'other-sa@exampleproj.iam.gserviceaccount.com',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'client_email' requires a service account name of 'osd-ccs-admin'.",
+    );
+  });
+
+  it('returns invalid JSON message for malformed JSON', () => {
+    expect(validateGCPServiceAccount('{ not json')).toBe('Invalid JSON format.');
   });
 });
 

--- a/src/common/__tests__/validators.test.ts
+++ b/src/common/__tests__/validators.test.ts
@@ -1079,6 +1079,66 @@ describe('validateGCPServiceAccount', () => {
   it('returns invalid JSON message for malformed JSON', () => {
     expect(validateGCPServiceAccount('{ not json')).toBe('Invalid JSON format.');
   });
+
+  it("returns 'not in the required format' when a non-client_email field fails a pattern check", () => {
+    const obj = {
+      ...validServiceAccount,
+      private_key: 'not-a-valid-key',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'private_key' is not in the required format.",
+    );
+  });
+
+  it('returns a field-level error when type has the wrong const value', () => {
+    const obj = {
+      ...validServiceAccount,
+      type: 'wrong_type',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'type' does not exactly match expected constant: service_account",
+    );
+  });
+
+  it('returns a field-level error when auth_uri has the wrong const value', () => {
+    const obj = {
+      ...validServiceAccount,
+      auth_uri: 'https://wrong.example.com',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'auth_uri' does not exactly match expected constant: https://accounts.google.com/o/oauth2/auth",
+    );
+  });
+
+  it('returns a field-level error when auth_provider_x509_cert_url has the wrong const value', () => {
+    const obj = {
+      ...validServiceAccount,
+      auth_provider_x509_cert_url: 'https://wrong.example.com',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'auth_provider_x509_cert_url' does not exactly match expected constant: https://www.googleapis.com/oauth2/v1/certs",
+    );
+  });
+
+  it('returns a field-level error when client_x509_cert_url is not a valid URI', () => {
+    const obj = {
+      ...validServiceAccount,
+      client_x509_cert_url: 'not-a-uri',
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      'The provided JSON does not meet the requirements: The field \'client_x509_cert_url\' does not conform to the "uri" format',
+    );
+  });
+
+  it('returns a field-level error when client_email is not a string', () => {
+    const obj = {
+      ...validServiceAccount,
+      client_email: 12345,
+    };
+    expect(validateGCPServiceAccount(JSON.stringify(obj))).toBe(
+      "The provided JSON does not meet the requirements: The field 'client_email' is not of a type(s) string",
+    );
+  });
 });
 
 describe('AWS Subnet ROSA / OSD', () => {

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -1414,13 +1414,24 @@ const validateGCPServiceAccount = (content: string): string | undefined => {
       return 'Invalid JSON format.';
     }
     if (e instanceof ValidationError) {
-      let errorMessage;
+      let errorMessage: string;
       if (e.property.startsWith('instance.')) {
         const errorFieldName = e.property.replace('instance.', '');
-        if (errorFieldName === 'client_email' && e.instance.split[0] !== 'osd-ccs-admin') {
+        const clientEmailLocalPart =
+          errorFieldName === 'client_email' && typeof e.instance === 'string'
+            ? e.instance.split('@')[0]
+            : undefined;
+        if (
+          errorFieldName === 'client_email' &&
+          clientEmailLocalPart !== undefined &&
+          clientEmailLocalPart !== 'osd-ccs-admin'
+        ) {
           errorMessage = `The field '${errorFieldName}' requires a service account name of 'osd-ccs-admin'.`;
         } else if (e.message.indexOf('does not match pattern') !== -1) {
-          errorMessage = `The field '${errorFieldName}' is not in the required format.`;
+          errorMessage =
+            errorFieldName === 'client_email' && clientEmailLocalPart === 'osd-ccs-admin'
+              ? `The field '${errorFieldName}' must be a Google Cloud service account email ending in '.iam.gserviceaccount.com'.`
+              : `The field '${errorFieldName}' is not in the required format.`;
         } else {
           errorMessage = `The field '${errorFieldName}' ${e.message}`;
         }


### PR DESCRIPTION
# Summary
This PR adds a fix to the validation function for the GCP service account json/file upload component. Previously if a user entered an incorrect @ domain in the client_email field, the validation would read `"The provided JSON does not meet the requirements: The field 'client_email' requires a service account name of 'osd-ccs-admin'."` This error message is unclear to the user of what is actually wrong in the format of client_email. Now the validation reads `"The provided JSON does not meet the requirements: The field 'client_email' must be a Google Cloud service account email ending in '.iam.gserviceaccount.com'."` 


Assisted by: Cursor/composer-2-fast 

# Jira

Fixes [OCMUI-4200](https://issues.redhat.com/browse/OCMUI-4200) 


# How to Test

1. Begin creating an OSD GCP CCS cluster
2. Select authentication as service account.
3. Locate the "Service account JSON" file upload field
4. Upload (or paste) a valid JSON structure where client_email has the correct service account name (osd-ccs-admin) but an incorrect domain format, for example:"client_email": "osd-ccs-admin@wrong-domain.com",
5. Check that the proper validation message displays 

 

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1078" height="355" alt="ocmui4200_before" src="https://github.com/user-attachments/assets/3f2fa23f-e9ce-4d8a-8b1a-04d42ae169a1" /> | <img width="1069" height="338" alt="ocmui4200_after" src="https://github.com/user-attachments/assets/08b61800-49cb-4a33-9f95-46a8bcc7ef2e" /> |


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4200]: https://redhat.atlassian.net/browse/OCMUI-4200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ