### PR TITLE
OCMUI-4390 : Updated the missing checkpoint for compute node instance selection in ROSA wizard step

### DIFF
--- a/playwright/e2e/rosa/rosa-cluster-classic-creation-advanced.spec.ts
+++ b/playwright/e2e/rosa/rosa-cluster-classic-creation-advanced.spec.ts
@@ -213,6 +213,9 @@ test.describe.serial(
     test('Cluster wizard revisit - Step - cluster details - machine pool', async ({
       createRosaWizardPage,
     }) => {
+      await expect(createRosaWizardPage.computeNodeTypeButton()).toContainText(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
       await expect(createRosaWizardPage.minimumNodeInput()).toHaveValue(
         clusterProperties.MachinePools[0].MinimumNodeCount,
       );


### PR DESCRIPTION
# Summary

Updated the missing checkpoint for compute node instance selection in ROSA wizard step

# Jira

Fixes [OCMUI-4390](https://issues.redhat.com/browse/OCMUI-4390)

# Additional information

This PR introduce the missing checkpoint for previously selected compute node instance in ROSA wizard step navigations.
This also helps to avoid the flaky issue reported in smoke runs exposed by the commit -  [OCMUI-4031: unify machine-type-selection components (#360) · RedHatInsights/uhc-portal@823f5bd](https://github.com/RedHatInsights/uhc-portal/commit/823f5bd405252b5871d6c30c59841b76d2b77d5e) .


# How to Test
Ensure jq is installed locally.
Ensure ocm-role is created and linked to your OCM org
Ensure user-role is created and linked to your org
Create account roles with the prefix cypress-account-roles
Navigate to the repo root directory
Create or update playwright.env.json (refer to README) with:
```
{
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_AWS_ID": "your aws id",
  "QE_ACCOUNT_ROLE_PREFIX": "cypress-account-roles",
  "QE_INFRA_REGIONS": {}
}
```
From the repo root, run:
```
sh qe-helper-scripts/create-vpc-infrastructure.sh --vpc-name testing-hcp-<userid> --region us-west-2
```
Wait for the command to complete successfully.

Then run the test spec:
```
 BROWSER=chromium yarn playwright test playwright/e2e/rosa/rosa-cluster-classic-creation-advanced.spec.ts       
```
# Screen Captures

```
 BROWSER=chromium yarn playwright test playwright/e2e/rosa/rosa-cluster-classic-creation-advanced.spec.ts       
yarn run v1.22.22
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 21 tests using 1 worker
…ts and roles - Select Account roles, ARN definitions @smoke @rosa @rosa-classic
  21 passed (1.9m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 113.53s.

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).




[OCMUI-4390]: https://redhat.atlassian.net/browse/OCMUI-4390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ