### PR TITLE
OCMUI-4932: Use max_replicas for untainted node capacity check

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/__tests__/machinePoolsHelper.test.js
@@ -369,16 +369,6 @@ describe('isMinimumCountWithoutTaints ', () => {
       ).toBeTruthy();
     });
 
-    it('returns false if less than 2 autoscaled nodes without taints - no scaling', () => {
-      expect(
-        isMinimumCountWithoutTaints({
-          cluster,
-          machinePools: machinePoolsScaled,
-          currentMachinePoolId: 'mp-no-taints',
-        }),
-      ).toBeFalsy();
-    });
-
     it('returns true if  2 nodes without taints', () => {
       expect(
         isMinimumCountWithoutTaints({

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMinReplicasField.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/fields/AutoscaleMinReplicasField.tsx
@@ -37,7 +37,12 @@ const AutoscaleMinReplicasField = ({
   };
 
   return (
-    <FormGroup fieldId={fieldId} label="Minimum nodes count" isRequired>
+    <FormGroup
+      fieldId={fieldId}
+      data-testid="autoscale-min-group"
+      label="Minimum nodes count"
+      isRequired
+    >
       <NumberInput
         value={field.value}
         onPlus={onButtonPress(true)}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.test.ts
@@ -173,6 +173,45 @@ describe('useMachinePoolFormik', () => {
 
         await expect(validationSchema.validateAt('autoscaleMin', values)).resolves.toBe(0);
       });
+
+      it('should allow autoscaleMin of 0 when autoscaleMax meets minNodes for HCP', async () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          autoscaling: {
+            min_replicas: 0,
+            max_replicas: 1,
+          },
+        };
+
+        const otherPool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          autoscaling: {
+            min_replicas: 1,
+            max_replicas: 1,
+          },
+        };
+
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        const values = {
+          ...hyperShiftExpectedInitialValues,
+          autoscaling: true,
+          autoscaleMin: 0,
+          autoscaleMax: 1,
+        };
+
+        // autoscaleMin should allow 0 for HCP even though minNodes is 1
+        await expect(validationSchema.validateAt('autoscaleMin', values)).resolves.toBe(0);
+      });
     });
 
     describe('replicas', () => {
@@ -242,6 +281,47 @@ describe('useMachinePoolFormik', () => {
         };
 
         await expect(validationSchema.validateAt('autoscaleMax', values)).resolves.toBe(0);
+      });
+
+      it('should reject autoscaleMax below minNodes for HCP clusters', async () => {
+        const machinePool = {
+          kind: 'NodePool',
+          id: 'test-pool',
+          autoscaling: {
+            min_replicas: 0,
+            max_replicas: 1,
+          },
+        };
+
+        const otherPool = {
+          kind: 'NodePool',
+          id: 'other-pool',
+          autoscaling: {
+            min_replicas: 1,
+            max_replicas: 1,
+          },
+        };
+
+        const { validationSchema } = renderHook(() =>
+          useMachinePoolFormik({
+            cluster: hyperShiftCluster,
+            machinePool,
+            machineTypes: defaultMachineTypes,
+            machinePools: [machinePool, otherPool],
+          }),
+        ).result.current;
+
+        const values = {
+          ...hyperShiftExpectedInitialValues,
+          autoscaling: true,
+          autoscaleMin: 0,
+          autoscaleMax: 0,
+        };
+
+        // minNodes = max(0, 2 - 1) = 1, so autoscaleMax of 0 should be rejected
+        await expect(validationSchema.validateAt('autoscaleMax', values)).rejects.toThrow(
+          'Max nodes must be at least 1 to satisfy the cluster-wide untainted-node minimum.',
+        );
       });
 
       it('should reject 0 max nodes for non-HCP clusters with autoscaling enabled', async () => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/hooks/useMachinePoolFormik.ts
@@ -362,7 +362,10 @@ const useMachinePoolFormik = ({
                   'Decimals are not allowed. Enter a whole number.',
                   Number.isInteger,
                 )
-                .min(minNodes, `Input cannot be less than ${minNodes}.`)
+                .min(
+                  isHypershift ? 0 : minNodes,
+                  `Input cannot be less than ${isHypershift ? 0 : minNodes}.`,
+                )
                 .max(values.autoscaleMax, 'Min nodes cannot be more than max nodes.')
             : Yup.number(),
           autoscaleMax: values.autoscaling
@@ -385,6 +388,13 @@ const useMachinePoolFormik = ({
                   if (value !== undefined && value < 1 && !isHypershift) {
                     return new Yup.ValidationError(
                       'Max nodes must be greater than 0.',
+                      value,
+                      'autoscaleMax',
+                    );
+                  }
+                  if (isHypershift && value !== undefined && value < minNodes) {
+                    return new Yup.ValidationError(
+                      `Max nodes must be at least ${minNodes} to satisfy the cluster-wide untainted-node minimum.`,
                       value,
                       'autoscaleMax',
                     );

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.test.tsx
@@ -214,6 +214,133 @@ describe('<EditNodeCountSection />', () => {
     });
   });
 
+  describe('HCP autoscaling min replicas', () => {
+    it('allows 0 min replicas for HCP cluster when other pools cover capacity', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        autoscaling: { min_replicas: 1, max_replicas: 1 },
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const otherPool = {
+        id: 'other-pool',
+        autoscaling: { min_replicas: 1, max_replicas: 1 },
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      const { user } = withState(initialState).render(
+        <Formik
+          initialValues={{
+            autoscaling: true,
+            autoscaleMin: 1,
+            autoscaleMax: 1,
+            instanceType: { id: 'm5.xlarge' },
+          }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[currentPool, otherPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const autoScaleMinFormGroup = screen.getByTestId('autoscale-min-group');
+      const minInput = within(autoScaleMinFormGroup).getByRole('spinbutton') as HTMLInputElement;
+      const minusButton = within(autoScaleMinFormGroup).getByRole('button', { name: 'Minus' });
+
+      expect(minInput.value).toBe('1');
+      expect(minusButton).not.toBeDisabled();
+
+      await user.click(minusButton);
+      expect(minInput.value).toBe('0');
+    });
+
+    it('does not allow negative min replicas for HCP cluster', async () => {
+      const currentPool = {
+        id: 'current-pool',
+        autoscaling: { min_replicas: 0, max_replicas: 2 },
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      };
+
+      withState(initialState).render(
+        <Formik
+          initialValues={{
+            autoscaling: true,
+            autoscaleMin: 0,
+            autoscaleMax: 2,
+            instanceType: { id: 'm5.xlarge' },
+          }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[currentPool]}
+            machineTypes={{}}
+            allow249NodesOSDCCSROSA={false}
+            cluster={hcpCluster}
+            machinePool={currentPool}
+          />
+        </Formik>,
+      );
+
+      const autoScaleMinFormGroup = screen.getByTestId('autoscale-min-group');
+      const minInput = within(autoScaleMinFormGroup).getByRole('spinbutton') as HTMLInputElement;
+      const minusButton = within(autoScaleMinFormGroup).getByRole('button', { name: 'Minus' });
+
+      expect(minInput.value).toBe('0');
+      expect(minusButton).toBeDisabled();
+    });
+
+    it('enforces minNodes on autoscale-min for non-HCP enforced default pool', () => {
+      const ccsCluster = {
+        ...nonHCPCluster,
+        ccs: { enabled: true },
+      } as ClusterFromSubscription;
+
+      const enforcedDefaultPool = {
+        id: 'worker',
+        replicas: 2,
+        availability_zones: ['us-east-1a'],
+        instance_type: 'm5.xlarge',
+      } as MachinePool;
+
+      withState(initialState).render(
+        <Formik
+          initialValues={{
+            autoscaling: true,
+            autoscaleMin: 2,
+            autoscaleMax: 5,
+            instanceType: { id: 'm5.xlarge' },
+          }}
+          onSubmit={() => {}}
+        >
+          <EditNodeCountSection
+            machinePools={[enforcedDefaultPool]}
+            machineTypes={{
+              types: { aws: [{ id: 'm5.xlarge', cpu: { value: 4 }, memory: { value: 16 } }] },
+            }}
+            allow249NodesOSDCCSROSA={false}
+            cluster={ccsCluster}
+            machinePool={enforcedDefaultPool}
+          />
+        </Formik>,
+      );
+
+      const autoScaleMinFormGroup = screen.getByTestId('autoscale-min-group');
+      const minInput = within(autoScaleMinFormGroup).getByRole('spinbutton') as HTMLInputElement;
+      const minusButton = within(autoScaleMinFormGroup).getByRole('button', { name: 'Minus' });
+
+      expect(minInput.value).toBe('2');
+      expect(minusButton).toBeDisabled();
+    });
+  });
+
   describe('HCP cluster minimum node requirements', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/components/EditMachinePoolModal/sections/EditNodeCountSection.tsx
@@ -90,7 +90,7 @@ const EditNodeCountSection = ({
             <Flex>
               <FlexItem>
                 <AutoscaleMinReplicasField
-                  minNodes={minNodesRequired}
+                  minNodes={isHcpCluster ? 0 : minNodesRequired}
                   cluster={cluster}
                   mpAvailZones={machinePool?.availability_zones?.length}
                   maxNodes={maxNodes}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.test.ts
@@ -1,6 +1,10 @@
 import { ClusterFromSubscription } from '~/types/types';
 
-import { countReplicasWithoutTaints, getClusterMinNodes } from './machinePoolsHelper';
+import {
+  countReplicasWithoutTaints,
+  getClusterMinNodes,
+  isMinimumCountWithoutTaints,
+} from './machinePoolsHelper';
 
 const hcpCluster = {
   product: { id: 'ROSA' },
@@ -45,21 +49,13 @@ describe('machinePoolsHelper', () => {
       expect(countReplicasWithoutTaints(pools, 'pool-1')).toBe(5);
     });
 
-    it('uses autoscaling min_replicas when available', () => {
+    it('uses autoscaling max_replicas when available', () => {
       const pools = [
         { id: 'pool-1', autoscaling: { min_replicas: 2, max_replicas: 10 } },
         { id: 'pool-2', replicas: 3 },
       ];
 
-      expect(countReplicasWithoutTaints(pools)).toBe(5);
-    });
-
-    it('prefers autoscaling min_replicas over replicas', () => {
-      const pools = [
-        { id: 'pool-1', replicas: 10, autoscaling: { min_replicas: 2, max_replicas: 10 } },
-      ];
-
-      expect(countReplicasWithoutTaints(pools)).toBe(2);
+      expect(countReplicasWithoutTaints(pools)).toBe(13);
     });
 
     it('handles mixed tainted and untainted pools with exclusion', () => {
@@ -74,7 +70,7 @@ describe('machinePoolsHelper', () => {
         { id: 'pool-4', autoscaling: { min_replicas: 1, max_replicas: 5 } },
       ];
 
-      expect(countReplicasWithoutTaints(pools, 'pool-1')).toBe(5); // pool-3 (4) + pool-4 (1)
+      expect(countReplicasWithoutTaints(pools, 'pool-1')).toBe(9); // pool-3 (4) + pool-4 (5)
     });
 
     it('ignores pools with empty taints array', () => {
@@ -84,6 +80,124 @@ describe('machinePoolsHelper', () => {
       ];
 
       expect(countReplicasWithoutTaints(pools)).toBe(8);
+    });
+
+    it('returns 0 when pool has no replicas and no autoscaling', () => {
+      const pools = [{ id: 'pool-1' }];
+
+      expect(countReplicasWithoutTaints(pools)).toBe(0);
+    });
+  });
+
+  describe('isMinimumCountWithoutTaints', () => {
+    const cluster = {
+      hypershift: { enabled: true },
+    } as ClusterFromSubscription;
+
+    it('returns true when other autoscaled pools have max_replicas >= 2', () => {
+      const machinePoolsScaled = [
+        {
+          id: 'mp-with-taints',
+          taints: [{ key: 'hello', value: 'world', effect: 'NoSchedule' }],
+          autoscaling: { min_replicas: 2, max_replicas: 3 },
+        },
+        {
+          id: 'mp1',
+          autoscaling: { min_replicas: 1, max_replicas: 3 },
+        },
+        {
+          id: 'mp-no-taints',
+          autoscaling: { min_replicas: 1, max_replicas: 3 },
+        },
+      ];
+
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools: machinePoolsScaled,
+          currentMachinePoolId: 'mp-no-taints',
+        }),
+      ).toBeTruthy();
+    });
+
+    it('returns false when other autoscaled pools have total max_replicas < 2', () => {
+      const poolsWithLowMax = [
+        {
+          id: 'mp-no-taints',
+          autoscaling: { min_replicas: 0, max_replicas: 1 },
+        },
+        {
+          id: 'mp-other',
+          autoscaling: { min_replicas: 0, max_replicas: 1 },
+        },
+      ];
+
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools: poolsWithLowMax,
+          currentMachinePoolId: 'mp-no-taints',
+        }),
+      ).toBeFalsy();
+    });
+
+    it('includes autoscaling max_replicas of current pool when includeCurrentMachinePool is true', () => {
+      const pools = [
+        {
+          id: 'autoscale-pool',
+          autoscaling: { min_replicas: 1, max_replicas: 3 },
+        },
+      ];
+
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools: pools,
+          currentMachinePoolId: 'autoscale-pool',
+          includeCurrentMachinePool: true,
+        }),
+      ).toBeTruthy();
+    });
+
+    it('does not add replicas for tainted current pool when includeCurrentMachinePool is true', () => {
+      const pools = [
+        {
+          id: 'tainted-current',
+          replicas: 5,
+          taints: [{ key: 'k', value: 'v', effect: 'NoSchedule' }],
+        },
+        {
+          id: 'other',
+          replicas: 1,
+        },
+      ];
+
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools: pools,
+          currentMachinePoolId: 'tainted-current',
+          includeCurrentMachinePool: true,
+        }),
+      ).toBeFalsy();
+    });
+
+    it('handles missing current pool gracefully when includeCurrentMachinePool is true', () => {
+      const pools = [
+        {
+          id: 'other',
+          replicas: 2,
+        },
+      ];
+
+      expect(
+        isMinimumCountWithoutTaints({
+          cluster,
+          machinePools: pools,
+          currentMachinePoolId: 'non-existent',
+          includeCurrentMachinePool: true,
+        }),
+      ).toBeTruthy();
     });
   });
 
@@ -191,7 +305,7 @@ describe('machinePoolsHelper', () => {
         expect(result).toBe(2);
       });
 
-      it('counts autoscaling min_replicas when calculating other pools', () => {
+      it('counts autoscaling max_replicas when calculating other pools capacity', () => {
         const currentPool = {
           id: 'current-pool',
           replicas: 1,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/machinePoolsHelper.ts
@@ -145,7 +145,7 @@ const isEnforcedDefaultMachinePool = (
 const countReplicasWithoutTaints = (machinePools: MachinePool[], excludePoolId?: string) =>
   machinePools?.reduce((count, pool) => {
     if (pool.id !== excludePoolId && !pool.taints?.length) {
-      return count + (pool.autoscaling?.min_replicas ?? pool.replicas ?? 0);
+      return count + (pool.autoscaling?.max_replicas ?? pool.replicas ?? 0);
     }
     return count;
   }, 0);
@@ -170,7 +170,7 @@ const isMinimumCountWithoutTaints = ({
   if (includeCurrentMachinePool && currentMachinePoolId) {
     const currentPool = machinePools.find((pool) => pool.id === currentMachinePoolId);
     if (!currentPool?.taints?.length) {
-      numberReplicas += currentPool?.autoscaling?.min_replicas ?? currentPool?.replicas ?? 0;
+      numberReplicas += currentPool?.autoscaling?.max_replicas ?? currentPool?.replicas ?? 0;
     }
   }
 


### PR DESCRIPTION
# Summary

  This PR fixes the untainted node capacity check when autoscaling is enabled for HCP machine pools. Previously, the 2-untainted-node requirement was validated against min_replicas, which prevented valid operations (e.g., deleting pools,  adding pools with 0 nodes) even when other autoscaled pools had sufficient max_replicas capacity. The fix uses `max_replicas` instead, since the autoscaler can scale up to that value to meet the requirement.    

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

[OCMUI-4932](https://redhat.atlassian.net/browse/OCMUI-4392), follow up for [OCMUI-4270](https://redhat.atlassian.net/browse/OCMUI-4270)

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->

# Additional information

  Example scenario (before fix):
  - 2 machine pools with autoscaling enabled: mp1 (min=0, max=1) and mp2 (min=0, max=1)
  - Total max capacity = 2 untainted nodes, which meets the backend requirement
  - But the UI counted min_replicas (0+0=0) and blocked delete/add operations

  After fix:
  - The UI counts max_replicas (1+1=2) and correctly allows these operations
  - This aligns with backend behavior — a cluster can be created with a single nodepool at min=0, max=2

  Changes:
  - `countReplicasWithoutTaints()`: uses max_replicas instead of min_replicas when autoscaling is enabled
  - `isMinimumCountWithoutTaints():` same change for the current pool inclusion path (used for delete validation)
  - 
# How to Test

  1. Prepare and access an HCP cluster with 3 machine pools
  2. Enable autoscaling on two pools, set both to min=0, max=1
  3. Verify you can delete other machine pools (total max capacity still >= 2)
  4. Verify you can add a new machine pool with node count = 0

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="1876" height="965" alt="image" src="https://github.com/user-attachments/assets/363e903c-997f-4372-a392-ea91ff2d67f4" />| <img width="1835" height="942" alt="image" src="https://github.com/user-attachments/assets/b8ed3f67-743f-40ec-ae3d-40ef9006a7b8" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4265]: https://redhat.atlassian.net/browse/OCMUI-4265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OCMUI-4270]: https://redhat.atlassian.net/browse/OCMUI-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ