### PR TITLE
OCMUI-4393: Updates on rosa hcp day1 e2e test specs for node zero support validations

### DIFF
--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
@@ -218,11 +218,11 @@ test.describe.serial(
       await expect(createRosaWizardPage.computeNodeCountDecrementButton()).not.toBeEnabled();
       await createRosaWizardPage.selectComputeNodeCount((parseInt(minNodes) - 1).toString());
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.LowerLimitError,
       );
       await createRosaWizardPage.computeNodeCountIncrementButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.LowerLimitError,
         false,
       );
       await createRosaWizardPage.selectComputeNodeCount(maxNodes);
@@ -230,11 +230,11 @@ test.describe.serial(
       await expect(createRosaWizardPage.computeNodeCountDecrementButton()).toBeEnabled();
       await createRosaWizardPage.selectComputeNodeCount((parseInt(maxNodes) + 1).toString());
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.UpperLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.UpperLimitError,
       );
       await createRosaWizardPage.computeNodeCountDecrementButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.UpperLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.UpperLimitError,
         false,
       );
 
@@ -273,12 +273,12 @@ test.describe.serial(
       var maxNodes = '250';
       await createRosaWizardPage.selectComputeNodeCount((parseInt(minNodes) - 1).toString());
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount
           .LowerLimitErrorWithMultipleMachinePools,
       );
       await createRosaWizardPage.computeNodeCountIncrementButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount
           .LowerLimitErrorWithMultipleMachinePools,
         false,
       );
@@ -287,12 +287,12 @@ test.describe.serial(
       await expect(createRosaWizardPage.computeNodeCountDecrementButton()).toBeEnabled();
       await createRosaWizardPage.selectComputeNodeCount((parseInt(maxNodes) + 1).toString());
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount
           .UpperLimitErrorWithMultipleMachinePools,
       );
       await createRosaWizardPage.computeNodeCountDecrementButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount
           .UpperLimitErrorWithMultipleMachinePools,
         false,
       );
@@ -307,61 +307,69 @@ test.describe.serial(
       // Test node count validations
       await expect(createRosaWizardPage.minimumNodeCountInput()).toHaveValue('2');
       await expect(createRosaWizardPage.maximumNodeCountInput()).toHaveValue('2');
-      await expect(createRosaWizardPage.minimumNodeCountMinusButton()).not.toBeEnabled();
+      await expect(createRosaWizardPage.minimumNodeCountMinusButton()).toBeEnabled();
       await expect(createRosaWizardPage.maximumNodeCountMinusButton()).not.toBeEnabled();
 
-      await createRosaWizardPage.setMinimumNodeCount('0');
+      await createRosaWizardPage.setMinimumNodeCount('-1');
+      await expect(createRosaWizardPage.minimumNodeCountMinusButton()).not.toBeEnabled();
+      await expect(createRosaWizardPage.minimumNodeCountPlusButton()).toBeEnabled();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.Autoscaling.LowerLimitError,
       );
-
       await createRosaWizardPage.setMinimumNodeCount('600');
+      await expect(createRosaWizardPage.minimumNodeCountMinusButton()).toBeEnabled();
+      await expect(createRosaWizardPage.minimumNodeCountPlusButton()).not.toBeEnabled();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.UpperLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.UpperLimitError,
       );
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
 
-      await createRosaWizardPage.setMinimumNodeCount('2');
+      await createRosaWizardPage.setMinimumNodeCount('0');
+      await expect(createRosaWizardPage.minimumNodeCountMinusButton()).not.toBeEnabled();
+      await expect(createRosaWizardPage.minimumNodeCountPlusButton()).toBeEnabled();
+
       await createRosaWizardPage.setMaximumNodeCount('600');
+      await expect(createRosaWizardPage.maximumNodeCountMinusButton()).toBeEnabled();
+      await expect(createRosaWizardPage.maximumNodeCountPlusButton()).not.toBeEnabled();
+
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.UpperLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.UpperLimitError,
       );
 
       await createRosaWizardPage.setMaximumNodeCount('0');
+      await expect(createRosaWizardPage.maximumNodeCountMinusButton()).not.toBeEnabled();
+      await expect(createRosaWizardPage.maximumNodeCountPlusButton()).toBeEnabled();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.Autoscaling
+          .LowerLimitErrorInMaximumNodeCount,
       );
 
       await createRosaWizardPage.setMaximumNodeCount('2');
       await createRosaWizardPage.minimumNodeCountPlusButton().click();
+      await createRosaWizardPage.minimumNodeCountPlusButton().click();
+      await createRosaWizardPage.minimumNodeCountPlusButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
 
       await createRosaWizardPage.maximumNodeCountPlusButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
         false,
       );
 
       await createRosaWizardPage.maximumNodeCountMinusButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
 
       await createRosaWizardPage.minimumNodeCountMinusButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
         false,
       );
-
       // Check for validation errors in machine pool node counts fields after subnet changes
       await createRosaWizardPage.addMachinePoolLink().click();
       await createRosaWizardPage.selectMachinePoolPrivateSubnet(
@@ -374,29 +382,26 @@ test.describe.serial(
         2,
       );
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
 
       await createRosaWizardPage.minimumNodeCountMinusButton().click();
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.LowerLimitError,
         false,
       );
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
         false,
       );
 
       // Check for minimum and maximum node counts when both fields set to minimum value
       await createRosaWizardPage.removeMachinePool(2);
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
         false,
       );
-      await expect(createRosaWizardPage.minimumNodeInput()).toHaveValue('2');
+      await expect(createRosaWizardPage.minimumNodeInput()).toHaveValue('1');
       await expect(createRosaWizardPage.maximumNodeInput()).toHaveValue('2');
 
       // Check for minimum and maximum node count when both fields set to > minimum value
@@ -410,8 +415,7 @@ test.describe.serial(
       await expect(createRosaWizardPage.minimumNodeInput()).toHaveValue('3');
       await expect(createRosaWizardPage.maximumNodeInput()).toHaveValue('2');
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
 
       // Check for validation errors when minimum node count > maximum node count
@@ -425,21 +429,26 @@ test.describe.serial(
         qeInfrastructure.SUBNETS.ZONES[getAvailabilityZone(2)].PRIVATE_SUBNET_NAME,
         3,
       );
-      await createRosaWizardPage.setMinimumNodeCount('3');
+      await createRosaWizardPage.setMinimumNodeCount('0');
       await createRosaWizardPage.setMaximumNodeCount('1');
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.Autoscaling
+          .LowerLimitErrorInMaximumNodeCount,
+        false,
+      );
+      await createRosaWizardPage.setMinimumNodeCount('3');
       await createRosaWizardPage.removeMachinePool(2);
       await createRosaWizardPage.removeMachinePool(2);
       await expect(createRosaWizardPage.minimumNodeInput()).toHaveValue('3');
       await expect(createRosaWizardPage.maximumNodeInput()).toHaveValue('2');
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone.LowerLimitError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.LowerLimitError,
         false,
       );
       await createRosaWizardPage.isTextContainsInPage(
-        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MultiZone
-          .MinAndMaxLimitDependencyError,
+        clusterFieldValidations.ClusterSettings.Machinepool.NodeCount.MinAndMaxLimitDependencyError,
       );
-      await createRosaWizardPage.setMinimumNodeCount('2');
+      await createRosaWizardPage.setMinimumNodeCount('0');
       await createRosaWizardPage.setMinimumNodeCount('2');
     });
 

--- a/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.json
+++ b/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.json
@@ -49,12 +49,14 @@
       "DuplicateSubnetsError": "Every machine pool must be associated to a different subnet",
       "SubnetRequiredError": "Subnet is required",
       "NodeCount": {
-        "MultiZone": {
-          "LowerLimitError": "Input cannot be less than 2",
-          "UpperLimitError": "Input cannot be more than 500",
-          "LowerLimitErrorWithMultipleMachinePools": "Input cannot be less than 1",
-          "UpperLimitErrorWithMultipleMachinePools": "Input cannot be more than 250",
-          "MinAndMaxLimitDependencyError": "Max nodes cannot be less than min nodes"
+        "LowerLimitError": "Input cannot be less than 2",
+        "UpperLimitError": "Input cannot be more than 500",
+        "LowerLimitErrorWithMultipleMachinePools": "Input cannot be less than 1",
+        "UpperLimitErrorWithMultipleMachinePools": "Input cannot be more than 250",
+        "MinAndMaxLimitDependencyError": "Max nodes cannot be less than min nodes",
+        "Autoscaling": {
+          "LowerLimitError": "Input cannot be less than 0",
+          "LowerLimitErrorInMaximumNodeCount": "Maximum nodes cannot be less than 2"
         }
       },
       "RootDiskSize": {


### PR DESCRIPTION
# Summary

Updates on rosa hcp e2e day1 validation test specs for node zero support

# Jira

Fixes [OCMUI-4393](https://issues.redhat.com/browse/OCMUI-4393)

# Additional information

Added additional /updated existing checkpoints for zero minimum node count validation for ROSA HCP machine pools step.

# How to Test

- Start the local server from feature PR https://github.com/RedHatInsights/uhc-portal/pull/448 
- Download this PR.
- Configure the playwright.env.json with below definition in app root folder.

```
{
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_AWS_ID": "your aws id",
  "QE_AWS_BILLING_ID" : "your aws billing id",
  "QE_AWS_REGION": "us-west-2",
  "QE_ACCOUNT_ROLE_PREFIX": "cypress-account-roles",
  "QE_OIDC_CONFIG_ID": "<oidc config id from your ocm org>",
  "QE_INFRA_REGIONS": {
    "us-west-2": [
      {
        "VPC-ID": "your vpc id",
        "VPC_NAME": "your vpc name",
        "SUBNETS": {
          "ZONES": {
            "us-west-2a": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2b": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2c": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            }
          }
        }
      }
    ]
  }
}
```

- Replace with VPC details (need a vpc in us-west-2 region with three public and private subnets), your credentials and AWS definition 
- Create account role in your OCM org with prefix "cypress-account-roles"
- Make sure you linked ocm-role, user-role in your OCM org ( Your test user must be in the same ocm org)
- Run the below test case

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
```

# Screen Captures
```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts --headed
yarn run v1.22.22
🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user:******
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 10 tests using 1 worker
  10 passed (1.1m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 67.66s.
```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).


[OCMUI-4393]: https://redhat.atlassian.net/browse/OCMUI-4393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ