### PR TITLE
OCMUI-4471: E2e test spec for machine pool minimum node count support for ROSA hosted clusters

### DIFF
--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
@@ -1,0 +1,324 @@
+import { test, expect } from '../../fixtures/pages';
+
+const clusterProfile = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.json');
+const day1Profile = clusterProfile['rosa-hosted-private-advanced']['day1-profile'];
+let infraRegions: any = {};
+try {
+  infraRegions = JSON.parse(process.env.QE_INFRA_REGIONS || '{}');
+} catch (error) {
+  console.warn('Failed to parse QE_INFRA_REGIONS environment variable:', error);
+}
+const region = Object.keys(infraRegions)[0] || day1Profile.Region.split(',')[0];
+const qeInfrastructure = infraRegions[region]?.[0] || {};
+const zones = qeInfrastructure.SUBNETS?.ZONES;
+
+test.describe.serial(
+  'ROSA HCP Machine Pool - Compute node count definition with autoscaling (OCMUI-4932)',
+  { tag: ['@day2', '@rosa-hosted', '@rosa', '@hcp', '@machine-pool', '@advanced', '@private'] },
+  () => {
+    const clusterName = process.env.CLUSTER_NAME || day1Profile.ClusterName;
+    const mpAutoscale1 = `mp-as1-${Math.random().toString(36).slice(2, 7)}`;
+    const mpAutoscale2 = `mp-as2-${Math.random().toString(36).slice(2, 7)}`;
+
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      if (!zones || Object.keys(zones).length === 0) {
+        throw new Error(`SUBNETS.ZONES is not defined in QE_INFRA_REGIONS for region "${region}"`);
+      }
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+    });
+
+    test('Navigate to HCP cluster Machine pools tab', async ({
+      clusterListPage,
+      machinePoolsPage,
+    }) => {
+      await clusterListPage.isClusterListScreen();
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await machinePoolsPage.goToMachinePoolsTab();
+    });
+
+    test('Verify autoscaling min and max allow 0 for HCP in Add machine pool modal', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.openAddMachinePoolModal();
+
+      await machinePoolsPage.autoscalingCheckbox().check();
+      await expect(machinePoolsPage.autoscalingCheckbox()).toBeChecked();
+
+      await expect(machinePoolsPage.autoscaleMinInput()).toBeVisible();
+      await machinePoolsPage.autoscaleMinInput().fill('0');
+      await machinePoolsPage.autoscaleMinInput().blur();
+      await expect(machinePoolsPage.autoscaleMinMinusButton()).toBeDisabled();
+
+      await expect(machinePoolsPage.autoscaleMaxInput()).toBeVisible();
+      await machinePoolsPage.autoscaleMaxInput().fill('0');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(machinePoolsPage.autoscaleMaxMinusButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Verify node count allows 0 for HCP without autoscaling', async ({ machinePoolsPage }) => {
+      await machinePoolsPage.openAddMachinePoolModal();
+      await expect(machinePoolsPage.autoscalingCheckbox()).not.toBeChecked();
+      await expect(machinePoolsPage.nodeCountInput()).toBeVisible();
+      await machinePoolsPage.nodeCountInput().fill('0');
+      await machinePoolsPage.nodeCountInput().blur();
+      // Minus button should be disabled at the 0 floor
+      await expect(machinePoolsPage.nodeCountMinusButton()).toBeDisabled();
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Create first machine pool with autoscaling min=0, max=0', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.openAddMachinePoolModal();
+      await machinePoolsPage.machinePoolIdInput().fill(mpAutoscale1);
+      const firstZone = Object.keys(zones || {})[0];
+      await machinePoolsPage.selectPrivateSubnet(zones[firstZone].PRIVATE_SUBNET_NAME);
+
+      await machinePoolsPage.setAutoscalingRange('0', '0');
+
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+      await expect(machinePoolsPage.getMachinePoolRow(mpAutoscale1)).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    test('Create second machine pool with autoscaling min=0, max=0 and a taint', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.openAddMachinePoolModal();
+      await machinePoolsPage.machinePoolIdInput().fill(mpAutoscale2);
+      const firstZone = Object.keys(zones || {})[0];
+      await machinePoolsPage.selectPrivateSubnet(zones[firstZone].PRIVATE_SUBNET_NAME);
+
+      await machinePoolsPage.setAutoscalingRange('0', '0');
+
+      await machinePoolsPage.openTaintsSection();
+      await machinePoolsPage.setTaint(0, 'e2e-test', 'tainted');
+
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+      await expect(machinePoolsPage.getMachinePoolRow(mpAutoscale2)).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    test('Edit machine pool and verify autoscaleMin=0 is valid for HCP', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+
+      await expect(machinePoolsPage.autoscalingCheckbox()).toBeChecked();
+      await expect(machinePoolsPage.autoscaleMinInput()).toHaveValue('0');
+      await expect(machinePoolsPage.autoscaleMaxInput()).toHaveValue('0');
+
+      // No validation error should be shown for min=0 on HCP
+      await expect(machinePoolsPage.getByText(/Input cannot be less than/)).toBeHidden();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Edit machine pool and verify autoscaleMin below 0 is rejected', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+
+      await machinePoolsPage.autoscaleMinInput().fill('-1');
+      await machinePoolsPage.autoscaleMinInput().blur();
+
+      await expect(machinePoolsPage.getByText('Input cannot be less than 0.')).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Edit machine pool and verify autoscaleMax and autoscaleMin below 0 are rejected', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+
+      await machinePoolsPage.autoscaleMinInput().fill('-1');
+      await machinePoolsPage.autoscaleMinInput().blur();
+      await expect(machinePoolsPage.getByText('Input cannot be less than 0.')).toBeVisible();
+
+      await machinePoolsPage.autoscaleMaxInput().fill('-1');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(machinePoolsPage.getByText('Max nodes cannot be negative.')).toBeVisible();
+
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Edit machine pool and verify min greater than max is rejected', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+
+      await machinePoolsPage.autoscaleMaxInput().fill('1');
+      await machinePoolsPage.autoscaleMinInput().fill('5');
+      await machinePoolsPage.autoscaleMinInput().blur();
+
+      await expect(
+        machinePoolsPage.getByText('Min nodes cannot be more than max nodes.'),
+      ).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Edit machine pool and verify autoscaleMax above quota limit is rejected', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+
+      await machinePoolsPage.autoscaleMaxInput().fill('500');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+
+      await expect(machinePoolsPage.getByText(/Input cannot be more than/)).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Verify delete is disabled for default machine pools due to minimum count restrictions', async ({
+      machinePoolsPage,
+    }) => {
+      const minCountTooltip =
+        'There needs to be at least 2 nodes without taints across all machine pools';
+
+      await machinePoolsPage.verifyDeleteDisabled('workers-0', minCountTooltip);
+      await machinePoolsPage.verifyDeleteDisabled('workers-1', minCountTooltip);
+    });
+
+    test('Scale tainted pool mpAutoscale2 max > 2 and verify delete still disabled for default pools', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool(mpAutoscale2);
+      await machinePoolsPage.autoscaleMaxInput().fill('3');
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+
+      const minCountTooltip =
+        'There needs to be at least 2 nodes without taints across all machine pools';
+
+      await machinePoolsPage.verifyDeleteDisabled('workers-0', minCountTooltip);
+      await machinePoolsPage.verifyDeleteDisabled('workers-1', minCountTooltip);
+    });
+
+    test('Edit workers-0 and verify autoscaleMax=0 and nodeCount=0 are rejected for untainted pool', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.editMachinePool('workers-0');
+
+      // Set autoscale max to 0 and verify rejection
+      await machinePoolsPage.autoscaleMaxInput().fill('0');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(
+        machinePoolsPage.getByText(
+          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
+        ),
+      ).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      // Disable autoscaling and set node count to 0
+      await machinePoolsPage.autoscalingCheckbox().uncheck();
+      await machinePoolsPage.nodeCountInput().fill('0');
+      await machinePoolsPage.nodeCountInput().blur();
+      await expect(machinePoolsPage.getByText(/Input cannot be less than \d+\./)).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+    });
+
+    test('Adjust workers-0 and workers-1 max and verify capacity validation', async ({
+      machinePoolsPage,
+    }) => {
+      // workers-0 max=0 should be rejected (untainted minimum not met)
+      await machinePoolsPage.editMachinePool('workers-0');
+      await machinePoolsPage.autoscaleMaxInput().fill('0');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(
+        machinePoolsPage.getByText(
+          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
+        ),
+      ).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      // workers-0 max=2 should be accepted
+      await machinePoolsPage.autoscaleMaxInput().fill('2');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(
+        machinePoolsPage.getByText(
+          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
+        ),
+      ).toBeHidden();
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+
+      // workers-1 max=0 should now be accepted (workers-0 max=2 covers the minimum)
+      await machinePoolsPage.editMachinePool('workers-1');
+      await machinePoolsPage.autoscaleMaxInput().fill('0');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(
+        machinePoolsPage.getByText(
+          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
+        ),
+      ).toBeHidden();
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+
+      // workers-0 max=1 should be rejected (workers-1 is now 0, so workers-0 alone must cover 2)
+      await machinePoolsPage.editMachinePool('workers-0');
+      await machinePoolsPage.autoscaleMaxInput().fill('1');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(
+        machinePoolsPage.getByText(
+          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
+        ),
+      ).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+
+      await machinePoolsPage.cancelMachinePoolModalButton().click();
+
+      // Verify delete state: workers-0 max=2, workers-1 max=0
+      // Removing workers-0 leaves 0 untainted capacity → delete disabled
+      await machinePoolsPage.verifyDeleteDisabled(
+        'workers-0',
+        'There needs to be at least 2 nodes without taints across all machine pools',
+      );
+      // Removing workers-1 leaves workers-0 max=2 which still meets the minimum → delete enabled
+      await machinePoolsPage.verifyDeleteEnabled('workers-1');
+
+      await machinePoolsPage.resetMachinePoolAutoscaling('workers-1', '0', '1');
+      await machinePoolsPage.resetMachinePoolAutoscaling('workers-0', '0', '1');
+    });
+
+    test('Delete untainted machine pools when max_replicas capacity is sufficient', async ({
+      machinePoolsPage,
+    }) => {
+      await machinePoolsPage.deleteMachinePool(mpAutoscale1);
+      await machinePoolsPage.deleteMachinePool(mpAutoscale2);
+    });
+
+    test.afterAll(async ({ machinePoolsPage }) => {
+      for (const mpName of [mpAutoscale1, mpAutoscale2]) {
+        const row = machinePoolsPage.getMachinePoolRow(mpName);
+        const isVisible = await row
+          .waitFor({ state: 'visible', timeout: 5000 })
+          .then(() => true)
+          .catch(() => false);
+        if (isVisible) {
+          await machinePoolsPage.deleteMachinePool(mpName);
+        }
+      }
+      await machinePoolsPage.resetMachinePoolAutoscaling('workers-1', '0', '1');
+      await machinePoolsPage.resetMachinePoolAutoscaling('workers-0', '0', '1');
+    });
+  },
+);

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
@@ -46,6 +46,8 @@ test.describe.serial(
 
       await machinePoolsPage.autoscalingCheckbox().check();
       await expect(machinePoolsPage.autoscalingCheckbox()).toBeChecked();
+      await expect(machinePoolsPage.autoscaleMinInput()).toHaveValue('2');
+      await expect(machinePoolsPage.autoscaleMaxInput()).toHaveValue('2');
 
       await expect(machinePoolsPage.autoscaleMinInput()).toBeVisible();
       await machinePoolsPage.autoscaleMinInput().fill('0');
@@ -64,6 +66,8 @@ test.describe.serial(
       await machinePoolsPage.openAddMachinePoolModal();
       await expect(machinePoolsPage.autoscalingCheckbox()).not.toBeChecked();
       await expect(machinePoolsPage.nodeCountInput()).toBeVisible();
+      await expect(machinePoolsPage.nodeCountInput()).toHaveValue('2');
+
       await machinePoolsPage.nodeCountInput().fill('0');
       await machinePoolsPage.nodeCountInput().blur();
       // Minus button should be disabled at the 0 floor

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
@@ -226,7 +226,7 @@ test.describe.serial(
         await createRosaWizardPage.isClusterPropertyMatchesValue(
           'Compute node count',
           (
-            parseInt(clusterProperties.MachinePools.NodeCount) *
+            parseInt(clusterProperties.MachinePools.NodeCount, 10) *
             Object.keys(qeInfrastructure.SUBNETS.ZONES).length
           ).toString(),
         );

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '../../fixtures/pages';
+
+// Import cluster properties JSON
+const clusterProfiles = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.json');
+const clusterProperties = clusterProfiles['rosa-hosted-private-advanced']['day1-profile'];
+
+test.describe.serial(
+  'Rosa hosted cluster (hypershift) - create private advanced cluster with minimum machinepools',
+  { tag: ['@day1', '@hcp', '@rosa-hosted', '@private', '@hosted', '@advanced'] },
+  () => {
+    let infraRegions: any = {};
+    try {
+      infraRegions = JSON.parse(process.env.QE_INFRA_REGIONS || '{}');
+    } catch (error) {
+      console.warn('Failed to parse QE_INFRA_REGIONS environment variable:', error);
+    }
+    const region = Object.keys(infraRegions)[0] || clusterProperties.Region.split(',')[0];
+    const awsAccountID = process.env.QE_AWS_ID || '';
+    const awsBillingAccountID = process.env.QE_AWS_BILLING_ID || '';
+    const qeInfrastructure: any = infraRegions[region]?.[0] || {};
+
+    const rolePrefix = process.env.QE_ACCOUNT_ROLE_PREFIX || '';
+    const installerARN = `arn:aws:iam::${awsAccountID}:role/${rolePrefix}-HCP-ROSA-Installer-Role`;
+    const clusterName = clusterProperties.ClusterName;
+    const oidcConfigId = process.env.QE_OIDC_CONFIG_ID ?? clusterProperties.OidcConfigId;
+
+    test.beforeAll(async ({ navigateTo }) => {
+      // Initial navigation using navigateTo
+      await navigateTo('create');
+    });
+
+    test(`Open Rosa wizard for private advanced cluster : ${clusterName}`, async ({
+      page,
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.waitAndClick(createRosaWizardPage.rosaCreateClusterButton());
+      await createRosaWizardPage.rosaClusterWithWeb().click();
+      await createRosaWizardPage.isCreateRosaPage();
+      await expect(page.locator('.spinner-loading-text')).not.toBeVisible();
+    });
+
+    test(`Step - Control plane - Select control plane type ${clusterName}`, async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.selectHostedControlPlaneType();
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test(`Step - Accounts and roles - Select Accounts and roles for ${clusterName}`, async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isAccountsAndRolesScreen();
+      await createRosaWizardPage.selectAWSInfrastructureAccount(awsAccountID);
+      await createRosaWizardPage.waitForARNList();
+      await createRosaWizardPage.refreshInfrastructureAWSAccountButton().click();
+      await createRosaWizardPage.waitForARNList();
+      await createRosaWizardPage.selectAWSBillingAccount(awsBillingAccountID);
+      await createRosaWizardPage.selectInstallerRole(installerARN);
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test(`Step - Cluster Settings - Set cluster details for ${clusterName}`, async ({
+      createRosaWizardPage,
+      page,
+    }) => {
+      await createRosaWizardPage.isClusterDetailsScreen();
+      await createRosaWizardPage.selectRegion(region);
+      await createRosaWizardPage.setClusterName(clusterName);
+      await createRosaWizardPage.createCustomDomainPrefixCheckbox().check();
+      await createRosaWizardPage.setDomainPrefix(clusterProperties.DomainPrefix);
+      await createRosaWizardPage.selectVersion(
+        clusterProperties.Version || process.env.VERSION || '',
+      );
+      await createRosaWizardPage.closePopoverAndNavigateNext();
+    });
+
+    test(`Step - Cluster Settings - Set machine pools for ${clusterName}`, async ({
+      page,
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isClusterMachinepoolsScreen(true);
+      await createRosaWizardPage.waitForVPCList();
+      await createRosaWizardPage.selectVPC(qeInfrastructure.VPC_NAME);
+
+      const availabilityZones = Object.keys(qeInfrastructure.SUBNETS.ZONES);
+      for (let i = 1; i <= availabilityZones.length - 1; i++) {
+        await createRosaWizardPage.selectMachinePoolPrivateSubnet(
+          qeInfrastructure.SUBNETS.ZONES[availabilityZones[i - 1]].PRIVATE_SUBNET_NAME,
+          i,
+        );
+        if (i < availabilityZones.length - 1) {
+          await createRosaWizardPage.addMachinePoolLink().click();
+        }
+      }
+      await createRosaWizardPage.selectComputeNodeType(clusterProperties.MachinePools.InstanceType);
+      if (clusterProperties.ClusterAutoscaling.includes('Enabled')) {
+        await createRosaWizardPage.enableAutoScaling();
+        await createRosaWizardPage.setMinimumNodeCount(
+          clusterProperties.MachinePools.MiniNodeCount,
+        );
+        await createRosaWizardPage.setMaximumNodeCount(clusterProperties.MachinePools.MaxNodeCount);
+      } else {
+        await createRosaWizardPage.disabledAutoScaling();
+        await createRosaWizardPage.selectComputeNodeCount(clusterProperties.MachinePools.NodeCount);
+      }
+
+      if (clusterProperties.InstanceMetadataService.includes('IMDSv1')) {
+        await createRosaWizardPage.useBothIMDSv1AndIMDSv2Radio().check();
+      } else {
+        await createRosaWizardPage.useIMDSv2Radio().check();
+      }
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test(`Step - Cluster Settings - configuration - cluster privacy for ${clusterName}`, async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test(`Step - Cluster Settings - CIDR Ranges - CIDR default values for ${clusterName}`, async ({
+      createRosaWizardPage,
+    }) => {
+      await expect(createRosaWizardPage.cidrDefaultValuesCheckBox()).toBeChecked();
+      await createRosaWizardPage.useCIDRDefaultValues(false);
+      await createRosaWizardPage.useCIDRDefaultValues(true);
+      await expect(createRosaWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createRosaWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createRosaWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createRosaWizardPage.hostPrefixInput()).toHaveValue(
+        clusterProperties.HostPrefix,
+      );
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Cluster roles and policies - role provider mode and its definitions', async ({
+      createRosaWizardPage,
+      customCommands,
+    }) => {
+      await createRosaWizardPage.selectOidcConfigId(oidcConfigId);
+      const operatorRoleCmd = await createRosaWizardPage.operatorRoleCommandInput().inputValue();
+      await customCommands.executeRosaCmd(`${operatorRoleCmd} --mode auto`);
+      await customCommands.executeRosaCmd(
+        `rosa create oidc-provider --oidc-config-id "${oidcConfigId}" --mode auto -y`,
+      );
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Cluster update - update strategies and its definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isUpdatesScreen();
+      if (clusterProperties.UpdateStrategy.includes('Recurring')) {
+        await createRosaWizardPage.recurringUpdateRadio().check({ force: true });
+      } else {
+        await createRosaWizardPage.individualUpdateRadio().check({ force: true });
+      }
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Review and create : Accounts and roles definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Control plane',
+        clusterProperties.ControlPlaneType,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'AWS infrastructure account ID',
+        awsAccountID,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'AWS billing account ID',
+        awsBillingAccountID,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue('Installer role', installerARN);
+    });
+
+    test('Step - Review and create : Cluster Settings definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isClusterPropertyMatchesValue('Cluster name', clusterName);
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Domain prefix',
+        clusterProperties.DomainPrefix,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue('Region', region);
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Availability',
+        clusterProperties.Availability,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Encrypt volumes with customer keys',
+        clusterProperties.EncryptVolumesWithCustomerKeys,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Additional etcd encryption',
+        clusterProperties.AdditionalEncryption,
+      );
+    });
+
+    test('Step - Review and create : Machine pool definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Node instance type',
+        clusterProperties.MachinePools.InstanceType,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Autoscaling',
+        clusterProperties.MachinePools.Autoscaling,
+      );
+      if (clusterProperties.ClusterAutoscaling.includes('Enabled')) {
+        await expect(createRosaWizardPage.computeNodeRangeLabelValue()).toContainText(
+          `Minimum nodes per machine pool: ${clusterProperties.MachinePools.MiniNodeCount}`,
+        );
+        await expect(createRosaWizardPage.computeNodeRangeLabelValue()).toContainText(
+          `Maximum nodes per machine pool: ${clusterProperties.MachinePools.MaxNodeCount}`,
+        );
+      } else {
+        await createRosaWizardPage.isClusterPropertyMatchesValue(
+          'Compute node count',
+          (
+            parseInt(clusterProperties.MachinePools.NodeCount) *
+            Object.keys(qeInfrastructure.SUBNETS.ZONES).length
+          ).toString(),
+        );
+      }
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Install to selected VPC',
+        qeInfrastructure.VPC_NAME,
+      );
+
+      const availabilityZones = Object.keys(qeInfrastructure.SUBNETS.ZONES);
+      for (let i = 1; i <= availabilityZones.length - 1; i++) {
+        const zone = availabilityZones[i - 1];
+        const subnetName = qeInfrastructure.SUBNETS.ZONES[zone].PRIVATE_SUBNET_NAME;
+        await expect(createRosaWizardPage.machinePoolLabelValue()).toContainText(zone);
+        await expect(createRosaWizardPage.machinePoolLabelValue()).toContainText(subnetName);
+      }
+
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Instance Metadata Service (IMDS)',
+        clusterProperties.InstanceMetadataService,
+      );
+    });
+
+    test('Step - Review and create : Networking definitions', async ({ createRosaWizardPage }) => {
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Cluster privacy',
+        clusterProperties.ClusterPrivacy,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue('PrivateLink', 'Enabled');
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Machine CIDR',
+        clusterProperties.MachineCIDR,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Service CIDR',
+        clusterProperties.ServiceCIDR,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Pod CIDR',
+        clusterProperties.PodCIDR,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'Host prefix',
+        clusterProperties.HostPrefix,
+      );
+    });
+
+    test('Step - Review and create : cluster roles and update definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'OIDC Configuration Type',
+        clusterProperties.OidcConfigType,
+      );
+      await createRosaWizardPage.isClusterPropertyMatchesValue(
+        'OIDC Configuration ID',
+        oidcConfigId,
+      );
+    });
+
+    test('Create cluster and check the installation progress', async ({
+      createRosaWizardPage,
+      clusterDetailsPage,
+      page,
+    }) => {
+      // Wait for the review screen to be fully loaded (role API calls to complete)
+      await createRosaWizardPage.waitForReviewScreenReady();
+      await createRosaWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(page.locator('h2:has-text("Installing cluster")')).toBeVisible();
+      await expect(page.locator('a:has-text("Download OC CLI")')).toBeVisible();
+      await expect(
+        page.locator('text=Cluster creation usually takes 10 minutes to complete'),
+      ).toBeVisible();
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('OIDC and operator roles');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+    });
+  },
+);

--- a/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.json
+++ b/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.json
@@ -1,0 +1,44 @@
+{
+  "rosa-hosted-private-advanced": {
+    "day1-profile": {
+      "Description": "rosa hosted private cluster with autoscaling",
+      "ControlPlaneType": "Hosted architecture",
+      "Type": "ROSA",
+      "DomainPrefix": "rosahcpvt",
+      "ClusterName": "ply-rosa-hosted-private-advanced",
+      "Region": "us-west-2, US West, Oregon",
+      "Availability": "Multi-zone",
+      "AdditionalEncryption": "Disabled",
+      "EncryptVolumesWithCustomerKeys": "Disabled",
+      "Nodes": {
+        "Control plane": "3/3",
+        "Infra": "2/2",
+        "Compute": "3/3"
+      },
+      "InstanceMetadataService": "IMDSv2",
+      "ClusterAutoscaling": "Enabled",
+      "ClusterPrivacy": "Private",
+      "ClusterWideProxy": "Disabled",
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "HostPrefix": "/23",
+      "OidcConfigType": "Red Hat managed",
+      "UpdateStrategy": "Individual updates",
+      "MachinePools": {
+        "InstanceType": "m6id.xlarge",
+        "Autoscaling": "Enabled",
+        "MiniNodeCount": "0",
+        "MaxNodeCount": "1"
+      },
+      "networking": {
+        "CIDRRanges": {
+          "MachineCIDR": "10.0.0.0/16",
+          "ServiceCIDR": "172.30.0.0/16",
+          "PodCIDR": "10.128.0.0/14",
+          "Hostprefix": "/23"
+        }
+      }
+    }
+  }
+}

--- a/playwright/page-objects/machine-pools-page.ts
+++ b/playwright/page-objects/machine-pools-page.ts
@@ -112,6 +112,68 @@ export class MachinePoolsPage extends BasePage {
     );
   }
 
+  autoscalingCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: /autoscaling/i });
+  }
+
+  autoscaleMinGroup(): Locator {
+    return this.page.getByTestId('autoscale-min-group');
+  }
+
+  autoscaleMaxGroup(): Locator {
+    return this.page.getByTestId('autoscale-max-group');
+  }
+
+  autoscaleMinInput(): Locator {
+    return this.autoscaleMinGroup().getByRole('spinbutton');
+  }
+
+  autoscaleMaxInput(): Locator {
+    return this.autoscaleMaxGroup().getByRole('spinbutton');
+  }
+
+  autoscaleMinMinusButton(): Locator {
+    return this.autoscaleMinGroup().getByRole('button', { name: 'Minus' });
+  }
+
+  autoscaleMaxMinusButton(): Locator {
+    return this.autoscaleMaxGroup().getByRole('button', { name: 'Minus' });
+  }
+
+  nodeCountInput(): Locator {
+    return this.page.getByRole('spinbutton', { name: 'Compute nodes' });
+  }
+
+  nodeCountMinusButton(): Locator {
+    return this.page.getByRole('button', { name: 'Decrement compute nodes' });
+  }
+
+  editNodeLabelsAndTaintsButton(): Locator {
+    return this.page.getByRole('button', { name: 'Edit node labels and taints' });
+  }
+
+  labelsAndTaintsTab(): Locator {
+    return this.page.getByRole('tab', { name: /Labels.*Taints/i });
+  }
+
+  // Taint fields lack accessible labels in the source (TextField/TaintEffectField);
+  // Formik-stable name/id attributes are the only reliable selectors available.
+  taintKeyInput(index: number): Locator {
+    return this.page.locator(`input[name="taints[${index}].key"]`);
+  }
+
+  taintValueInput(index: number): Locator {
+    return this.page.locator(`input[name="taints[${index}].value"]`);
+  }
+
+  taintEffectToggle(index: number): Locator {
+    return this.page.locator(`[id="taints[${index}].effect"]`).getByRole('button');
+  }
+
+  taintEffectOption(effect: string): Locator {
+    return this.page.getByRole('option', { name: effect });
+  }
+
   async clickAddMachinePoolSubmitButton(): Promise<void> {
     await expect(this.addMachinePoolSubmitButton()).toBeEnabled();
     await this.addMachinePoolSubmitButton().click();
@@ -151,6 +213,34 @@ export class MachinePoolsPage extends BasePage {
     await this.pressKey('Escape');
   }
 
+  async setAutoscalingRange(min: string, max: string): Promise<void> {
+    await this.autoscalingCheckbox().check();
+    await this.autoscaleMinInput().fill(min);
+    await this.autoscaleMaxInput().fill(max);
+  }
+
+  async openTaintsSection(): Promise<void> {
+    const taintsTab = this.labelsAndTaintsTab();
+    if (await taintsTab.isVisible().catch(() => false)) {
+      await taintsTab.click();
+    } else {
+      const toggle = this.editNodeLabelsAndTaintsButton();
+      const expanded = await toggle.getAttribute('aria-expanded');
+      if (expanded !== 'true') {
+        await toggle.click();
+      }
+    }
+  }
+
+  async setTaint(index: number, key: string, value: string, effect?: string): Promise<void> {
+    await this.taintKeyInput(index).fill(key);
+    await this.taintValueInput(index).fill(value);
+    if (effect) {
+      await this.taintEffectToggle(index).click();
+      await this.taintEffectOption(effect).click();
+    }
+  }
+
   async selectInstanceType(instanceType: string): Promise<void> {
     await this.instanceTypeSelectButton().click();
     await this.instanceTypeSearchInput().clear();
@@ -180,6 +270,49 @@ export class MachinePoolsPage extends BasePage {
     await expect(this.machinePoolModal()).toBeVisible({ timeout: 30000 });
   }
 
+  async resetMachinePoolAutoscaling(id: string, min: string, max: string): Promise<void> {
+    await this.editMachinePool(id);
+
+    const currentMin = await this.autoscaleMinInput().inputValue();
+    const currentMax = await this.autoscaleMaxInput().inputValue();
+
+    if (currentMin === min && currentMax === max) {
+      await this.cancelMachinePoolModalButton().click();
+      return;
+    }
+
+    if (currentMin !== min) {
+      await this.autoscaleMinInput().fill(min);
+    }
+    if (currentMax !== max) {
+      await this.autoscaleMaxInput().fill(max);
+    }
+
+    await this.clickAddMachinePoolSubmitButton();
+    await expect(this.machinePoolModal()).toBeHidden({ timeout: 60000 });
+  }
+
+  async verifyDeleteEnabled(id: string): Promise<void> {
+    const row = this.page.getByRole('row').filter({ hasText: id });
+    await row.getByRole('button', { name: 'Kebab toggle' }).click();
+    const deleteItem = this.page.getByRole('menuitem', { name: 'Delete' });
+    await expect(deleteItem).not.toHaveAttribute('aria-disabled', 'true');
+    await this.page.keyboard.press('Escape');
+  }
+
+  async verifyDeleteDisabled(id: string, tooltipText?: string): Promise<void> {
+    const row = this.page.getByRole('row').filter({ hasText: id });
+    await row.getByRole('button', { name: 'Kebab toggle' }).click();
+    const deleteItem = this.page.getByRole('menuitem', { name: 'Delete' });
+    await expect(deleteItem).toHaveAttribute('aria-disabled', 'true');
+    if (tooltipText) {
+      await deleteItem.hover();
+      await expect(this.page.getByText(tooltipText)).toBeVisible();
+    }
+    // Close the kebab menu by pressing Escape
+    await this.page.keyboard.press('Escape');
+  }
+
   async deleteMachinePool(id: string): Promise<void> {
     const row = this.page.getByRole('row').filter({ hasText: id });
     await row.locator('button[aria-label="Kebab toggle"]').click();
@@ -193,8 +326,7 @@ export class MachinePoolsPage extends BasePage {
     await Promise.all([
       this.page.waitForResponse(
         (response) =>
-          response.request().method() === 'DELETE' &&
-          response.url().includes(`/node_pools/${id}`),
+          response.request().method() === 'DELETE' && response.url().includes(`/node_pools/${id}`),
         { timeout: 30000 },
       ),
       dialog.getByRole('button', { name: 'Delete' }).click(),


### PR DESCRIPTION

# Summary
E2e test spec for machine pool minimum node count support for ROSA hosted clusters

# Jira

Fixes [OCMUI-4471](https://issues.redhat.com/browse/OCMUI-4471) 

# Additional information

- rosa-cluster-hosted-private-advanced-creation.spec.ts New test spec for ROSA hosted cluster creation (Note: a private cluster with minimum node pools i.e two machine pool with autoscaling enabled , min =0 and max=1 node count per machine pool)
- rosa-cluster-hosted-machine-pool-node-count.spec.ts : New test spec to evaluate various circumstances of minimum machine pool count support as part of day2 actions. 
- Updated related fixture and page object definitions.

# How to Test

- Start the local server from feature PR https://github.com/RedHatInsights/uhc-portal/pull/462 
- Download this PR.
- Configure the playwright.env.json with below definition in app root folder.

```
{
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_AWS_ID": "your aws id",
  "QE_AWS_BILLING_ID" : "your aws billing id",
  "QE_AWS_REGION": "us-west-2",
  "QE_ACCOUNT_ROLE_PREFIX": "cypress-account-roles",
  "QE_OIDC_CONFIG_ID": "<oidc config id from your ocm org>",
  "QE_INFRA_REGIONS": {
    "us-west-2": [
      {
        "VPC-ID": "your vpc id",
        "VPC_NAME": "your vpc name",
        "SUBNETS": {
          "ZONES": {
            "us-west-2a": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2b": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2c": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            }
          }
        }
      }
    ]
  }
}
```

- Replace with VPC details (need a vpc in us-west-2 region with three public and private subnets), your credentials and AWS definition
- Create account role in your OCM org with prefix "cypress-account-roles"
- Make sure you linked ocm-role, user-role in your OCM org ( Your test user must be in the same ocm org)
- Run the below test case
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts        
```

- Wait for the cluster installation to complete.
- Run the below test case

```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts 
```

# Screen Captures
rosa-cluster-hosted-private-advanced-creation.spec.ts >>
```
% BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts        
yarn run v1.22.22
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: ***
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 15 tests using 1 worker
  15 passed (2.3m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 138.55s.

```

rosa-cluster-hosted-machine-pool-node-count.spec.ts >>
```
% BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts 
yarn run v1.22.22
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 15 tests using 1 worker
  15 passed (2.2m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 131.77s.

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-4471]: https://redhat.atlassian.net/browse/OCMUI-4471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ