### PR TITLE
OCMUI-3677: confine dependency-updates to 'main'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,7 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "reviewersFromCodeOwners": true,
+  "baseBranchPatterns": ["main"],
   "tekton": {
     "schedule": ["at any time"]
   }


### PR DESCRIPTION

# Summary

update renovate config to only include 'main' branch, to stop auto' dependency-update PRs on any other branch.


# Jira

addresses [OCMUI-3677][1]


# Additional information

the new addition of [konflux setup for fedramp][2] started triggering dependency updates against the 'security-compliance' branch (see #473 for example).

this change aims to eliminate those updates as redundant; the content of 'security-compliance' is already synced from 'main' periodically (upon fedramp releases).


# How to Test

can only be tested once merged.

mintmaker triggers updates whenever they're available – usually every few days.

after the merge, the repo pull-requests page should be monitored to check no [PRs labeled <kbd>dependency update</kbd> are being opened against 'security-compliance' branch][4].  once such a PR is opened against 'main' without a 'security-compliance' counterpart, the test will be concluded.



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

no feature testing.




[1]: https://redhat.atlassian.net/browse/OCMUI-3677
[2]: https://github.com/RedHatInsights/uhc-portal/pull/465
[4]: https://github.com/RedHatInsights/uhc-portal/pulls?q=is%3Apr+label%3A%22dependency+update%22+base%3Asecurity-compliance+is%3Aopen


[OCMUI-3677]: https://redhat.atlassian.net/browse/OCMUI-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ