### PR TITLE
OCMUI-4470 - [ROSA hosted]Machine pools status incorrectly shows "Pending" on HCP cluster overview when autoscaling min node count is zero

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.test.tsx
@@ -55,6 +55,13 @@ const machinePoolsAutoScaleReady = [
   },
 ];
 
+const machinePoolsAutoScaleZeroMin = [
+  {
+    autoscaling: { min_replicas: 0, max_replicas: 3 },
+    status: { current_replicas: 0 },
+  },
+];
+
 describe('<ClusterStatus />', () => {
   describe('Hypershift is not enabled', () => {
     it('is accessible', async () => {
@@ -159,6 +166,55 @@ describe('<ClusterStatus />', () => {
       );
 
       // Assert
+      expect(screen.getByText('Ready 2 / 2')).toBeInTheDocument();
+    });
+
+    it('shows autoscaling pool with min_replicas 0 and current_replicas 0 as ready', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true } }}
+          limitedSupport={false}
+          machinePools={machinePoolsAutoScaleZeroMin}
+        />,
+      );
+
+      expect(screen.getByText('Ready 1 / 1')).toBeInTheDocument();
+    });
+
+    it('shows autoscaling pool with min_replicas 0 and a status message as not ready', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true } }}
+          limitedSupport={false}
+          machinePools={[
+            {
+              autoscaling: { min_replicas: 0, max_replicas: 3 },
+              status: { current_replicas: 0, message: 'waitingOnMachine' },
+            },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText('Pending 0 / 1')).toBeInTheDocument();
+    });
+
+    it('counts zero-min autoscaling pools alongside normal pools correctly', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true } }}
+          limitedSupport={false}
+          machinePools={[
+            {
+              autoscaling: { min_replicas: 0, max_replicas: 3 },
+              status: { current_replicas: 0 },
+            },
+            {
+              autoscaling: { min_replicas: 2, max_replicas: 4 },
+              status: { current_replicas: 3 },
+            },
+          ]}
+        />,
+      );
       expect(screen.getByText('Ready 2 / 2')).toBeInTheDocument();
     });
   });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.test.tsx
@@ -215,7 +215,55 @@ describe('<ClusterStatus />', () => {
           ]}
         />,
       );
+
       expect(screen.getByText('Ready 2 / 2')).toBeInTheDocument();
+    });
+
+    it('does not count pool without current_replicas as ready', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true } }}
+          limitedSupport={false}
+          machinePools={[{ replicas: 2, status: {} }]}
+        />,
+      );
+
+      expect(screen.getByText('Pending 0 / 1')).toBeInTheDocument();
+    });
+
+    it('shows uninstalling state when cluster is uninstalling', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true }, state: ClusterState.uninstalling }}
+          limitedSupport={false}
+          machinePools={machinePools}
+        />,
+      );
+
+      expect(screen.getByTestId('machine-pools-status')).toHaveTextContent('Uninstalling');
+    });
+
+    it('shows deleted when there are no machine pools and cluster is ready', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true } }}
+          limitedSupport={false}
+          machinePools={[]}
+        />,
+      );
+
+      expect(screen.getByTestId('machine-pools-status')).toHaveTextContent('Deleted 0 / 0');
+    });
+
+    it('shows pending when there are no machine pools and cluster is installing', () => {
+      render(
+        <ClusterStatus
+          cluster={{ ...cluster, hypershift: { enabled: true }, state: ClusterState.installing }}
+          limitedSupport={false}
+          machinePools={[]}
+        />,
+      );
+      expect(screen.getByTestId('machine-pools-status')).toHaveTextContent('Pending 0 / 0');
     });
   });
 });

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.tsx
@@ -23,31 +23,34 @@ type NormalizedNodePool = Omit<NodePool, 'autoscaling'> & {
 
 // Despite being designed to handle HCP node pools, numberReadyNodePools function cannot accept type NodePool since we normalize the data to match the structure of NodePoolAutoscaling type to MachinePoolAutoscaling type.
 // See normalizeNodePool function in machinePoolsHelper.ts
-export const numberReadyNodePools = (nodePools: NormalizedNodePool[]) =>
-  nodePools?.filter((pool) => {
-    const hasMin = (min: number | undefined) => min !== undefined && min !== null;
-    const current = pool.status?.current_replicas;
+export const numberReadyNodePools = (nodePools: NormalizedNodePool[]) => {
+  const hasMin = (min: number | undefined) => min !== undefined && min !== null;
+  return (
+    nodePools?.filter((pool) => {
+      const current = pool.status?.current_replicas;
 
-    if (current === undefined) {
-      return false;
-    }
-
-    if (pool.status?.message && pool.autoscaling?.min_replicas === 0) {
-      return false;
-    }
-
-    if (pool.autoscaling) {
-      if (!hasMin(pool.autoscaling.min_replicas) || !hasMin(pool.autoscaling.max_replicas)) {
+      if (current === undefined) {
         return false;
       }
-      return current >= pool.autoscaling.min_replicas && current <= pool.autoscaling.max_replicas;
-    }
 
-    if (pool.replicas === undefined) {
-      return false;
-    }
-    return pool.replicas === current;
-  }).length || 0;
+      if (pool.status?.message && pool.autoscaling?.min_replicas === 0) {
+        return false;
+      }
+
+      if (pool.autoscaling) {
+        if (!hasMin(pool.autoscaling.min_replicas) || !hasMin(pool.autoscaling.max_replicas)) {
+          return false;
+        }
+        return current >= pool.autoscaling.min_replicas && current <= pool.autoscaling.max_replicas;
+      }
+
+      if (pool.replicas === undefined) {
+        return false;
+      }
+      return pool.replicas === current;
+    }).length || 0
+  );
+};
 
 interface ClusterStatusProps {
   cluster: ClusterFromSubscription;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/ClusterStatus.tsx
@@ -25,13 +25,19 @@ type NormalizedNodePool = Omit<NodePool, 'autoscaling'> & {
 // See normalizeNodePool function in machinePoolsHelper.ts
 export const numberReadyNodePools = (nodePools: NormalizedNodePool[]) =>
   nodePools?.filter((pool) => {
+    const hasMin = (min: number | undefined) => min !== undefined && min !== null;
     const current = pool.status?.current_replicas;
 
     if (current === undefined) {
       return false;
     }
+
+    if (pool.status?.message && pool.autoscaling?.min_replicas === 0) {
+      return false;
+    }
+
     if (pool.autoscaling) {
-      if (!pool.autoscaling.min_replicas || !pool.autoscaling.max_replicas) {
+      if (!hasMin(pool.autoscaling.min_replicas) || !hasMin(pool.autoscaling.max_replicas)) {
         return false;
       }
       return current >= pool.autoscaling.min_replicas && current <= pool.autoscaling.max_replicas;


### PR DESCRIPTION
# Summary

This PR fixes a mismatch in the number of ready machine pools being shown now that clusters can be created with 0 min_replicas when autoscaling. 

# Jira

Fixes [OCMUI-4470](https://issues.redhat.com/browse/OCMUI-4470) 

# Additional information
Since 0 is a falsy value, doing the check 
`if (!pool.autoscaling.min_replicas || !pool.autoscaling.max_replicas)`
will always result in false if the min is 0 leading to a machine pool not being counted as ready

I replaced the check with the block below to account for this. 
`if (!hasMin(pool.autoscaling.min_replicas) || !hasMin(pool.autoscaling.max_replicas))`

We can't rely only on this check because when a cluster is initially installing, pool.status.replicas is always 0, so when the min_replicas is 0 this results in the machine pool being counted as ready right away when that is not actually the case.

I've added the below check to account for this. 
```
 if (pool.status?.message && pool.autoscaling?.min_replicas === 0) {
      return false;
    }
```

In the existing code, the message property is not being used for anything. The property displays warning message related to the status of the machine pool, such as "waitingOnMachine" or "requires minimum availability of 1..". Digging into the type definition of the property it is defined as 

```
/** @description Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas. */
      message?: string;
```

Assisted by: Cursor/claude-4.6-opus
# How to Test

1. Begin creating a Rosa HCP cluster
2. When you get to the machine pools step, add 2 or 3 machine pools, enable autoscaling and set the min_replicas to 0
3. Finish creating the cluster and go to its cluster details page
4. While the cluster initially loads the Status section in the right side of the details page for machine pools should show Pending 0 / 2 or Pending 0 / 3
5. When the cluster fully builds this status sections should show Ready 2 / 2 or Ready 3 / 3. 
6. If it still shows Pending, console.log the pool value `console.log('pool', pool)` in the function `numberReadyNodePools` to check if one of the pools has the pool.status.message property with more information on why it isn't created yet

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1060" height="504" alt="ocmui4470_before" src="https://github.com/user-attachments/assets/03061197-6bb6-4ff6-84f3-17020238d2c1" /> | <img width="1060" height="501" alt="ocmui4470 _after" src="https://github.com/user-attachments/assets/19b2b069-1abb-4de0-8514-3e99e14acbf1" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4470]: https://redhat.atlassian.net/browse/OCMUI-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ