### PR TITLE
[OCMUI-4409] Import patternfly-charts.css for dark mode chart theming

### DIFF
--- a/src/chrome-main.tsx
+++ b/src/chrome-main.tsx
@@ -37,6 +37,7 @@ import { authInterceptor } from './services/apiRequest';
 import { Chrome } from './types/types';
 import config, { APP_API_ENV } from './config';
 
+import '@patternfly/patternfly/patternfly-charts.css';
 import './styles/main.scss';
 
 import './i18n';

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -75,11 +75,6 @@ limitations under the License.
   text-align: center;
 }
 
-// fix donut chart tooltip css
-.metrics-chart .VictoryContainer > div > svg > g > text > tspan {
-  stroke: none !important;
-  fill: #ffffff !important;
-}
 
 // Enable word wrapping in the cluster list
 // TODO -- fix, .table-grid-pf-row was the PF3 one


### PR DESCRIPTION
# Summary

Import `@patternfly/patternfly/patternfly-charts.css` in the app entry point so that all PF chart CSS custom properties — including dark-mode overrides under `:where(.pf-v6-theme-dark)` — are available globally.

Without this import, Victory chart components fall back to hardcoded light-mode defaults, causing black center-title text and incorrectly themed tooltips on dark backgrounds.

Also removes the legacy tooltip workaround in `app.scss` (`fill: #ffffff !important`) which is no longer needed and would conflict with PF's native tooltip theming (white background + dark text).

Assisted by: Cursor/claude-sonnet

# Jira

Fixes [OCMUI-4409](https://issues.redhat.com/browse/OCMUI-4409)

# Additional information

- `patternfly-charts.css` is imported from `.tsx` (not SCSS) because Dart Sass won't inline `.css` files — webpack's css-loader handles it correctly.
- Removed the `app.scss` tooltip workaround (`fill: #ffffff !important`) since PF's native chart theming now handles tooltip styling.

# How to Test

1. Run locally and navigate to `https://prod.foo.redhat.com:1337/openshift/`
2. Toggle dark mode on `https://prod.foo.redhat.com:1337/openshift/` via setting Preview mode, and then selecting the masthead Settings gear → Color scheme → Dark (native switcher)
3. Verify chart center-title text is readable (light color on dark background) at:
   - `/dashboard` — CPU & Memory utilization donuts
   - `/details/<cluster-id>` → **Overview** tab — Resource usage donuts, Cost breakdown pie, Insights Advisor chart
4. Hover over chart segments — verify tooltip text is readable (dark text on white background)
5. Toggle back to light mode and verify charts still render correctly

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1166" height="775" alt="image" src="https://github.com/user-attachments/assets/a120a100-baab-4303-9447-b3fe6580dac8" /> | <img width="1081" height="782" alt="image" src="https://github.com/user-attachments/assets/a216fea5-748d-4670-b66b-12c8c1ba8eb2" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4409]: https://redhat.atlassian.net/browse/OCMUI-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ