### PR TITLE
OCMUI-4307: Make create cluster more prominent on OCM Overview page

### DIFF
--- a/playwright/e2e/overview/overview.spec.ts
+++ b/playwright/e2e/overview/overview.spec.ts
@@ -6,7 +6,7 @@ test.describe.serial('OCM Overview Page tests (OCP-65189)', { tag: ['@smoke', '@
     // Navigate to overview page and wait for it to load
     await navigateTo('overview');
   });
-  test('OCM Overview Page - header and central section', async ({ overviewPage }) => {
+  test('OCM Overview Page - header and central section', async ({ overviewPage, navigateTo, page }) => {
     // Verify we're on the overview page
     await overviewPage.isOverviewPage();
 
@@ -17,11 +17,12 @@ test.describe.serial('OCM Overview Page tests (OCP-65189)', { tag: ['@smoke', '@
     );
 
     // Check Create cluster header buttons redirect properly
-    await expect(overviewPage.headerCreateClusterButton()).toHaveAttribute('href', '/openshift/create');
-    await expect(overviewPage.headerCreateClusterWithAssistedInstallerButton()).toHaveAttribute(
-      'href',
-      '/openshift/assisted-installer/clusters/~new',
-    );
+    await overviewPage.headerCreateClusterButton().click();
+    await expect(page).toHaveURL(/\/openshift\/create/);
+    await navigateTo('overview');
+    await overviewPage.headerCreateClusterWithAssistedInstallerButton().click();
+    await expect(page).toHaveURL(/\/openshift\/assisted-installer\/clusters\/~new/);
+    await navigateTo('overview');
 
     // Verify central section has expected number of cards
     await overviewPage.centralSectionCardsExpected(7);

--- a/playwright/e2e/overview/overview.spec.ts
+++ b/playwright/e2e/overview/overview.spec.ts
@@ -16,6 +16,13 @@ test.describe.serial('OCM Overview Page tests (OCP-65189)', { tag: ['@smoke', '@
       docLinks.WHAT_IS_OPENSHIFT,
     );
 
+    // Check Create cluster header buttons redirect properly
+    await expect(overviewPage.headerCreateClusterButton()).toHaveAttribute('href', '/openshift/create');
+    await expect(overviewPage.headerCreateClusterWithAssistedInstallerButton()).toHaveAttribute(
+      'href',
+      '/openshift/assisted-installer/clusters/~new',
+    );
+
     // Verify central section has expected number of cards
     await overviewPage.centralSectionCardsExpected(7);
 

--- a/playwright/page-objects/overview-page.ts
+++ b/playwright/page-objects/overview-page.ts
@@ -40,7 +40,7 @@ export class OverviewPage extends BasePage {
   }
 
   headerCreateClusterWithAssistedInstallerButton(): Locator {
-    return this.page.locator('[data-testid="OverviewHeader"]').getByTestId('create-cluster-AI');
+    return this.page.locator('[data-testid="OverviewHeader"]').getByTestId('create-cluster-assisted-installer');
   }
 
   // Central section card methods

--- a/playwright/page-objects/overview-page.ts
+++ b/playwright/page-objects/overview-page.ts
@@ -1,6 +1,8 @@
-import { Page, Locator, expect } from '@playwright/test';
-import { BasePage } from './base-page';
+import { expect,Locator, Page } from '@playwright/test';
+
 import { CustomCommands } from '../support/custom-commands';
+
+import { BasePage } from './base-page';
 
 /**
  * Overview page object for Playwright tests
@@ -31,6 +33,14 @@ export class OverviewPage extends BasePage {
     return this.page
       .locator('[data-testid="OverviewHeader"]')
       .getByRole('link', { name: 'Learn more' });
+  }
+
+  headerCreateClusterButton(): Locator {
+    return this.page.locator('[data-testid="OverviewHeader"]').getByTestId('create-cluster');
+  }
+
+  headerCreateClusterWithAssistedInstallerButton(): Locator {
+    return this.page.locator('[data-testid="OverviewHeader"]').getByTestId('create-cluster-AI');
   }
 
   // Central section card methods

--- a/src/components/overview/components/OverviewProductBanner.test.tsx
+++ b/src/components/overview/components/OverviewProductBanner.test.tsx
@@ -26,7 +26,7 @@ describe('<OverviewProductBanner />', () => {
     expect(iconElement).toHaveAttribute('src', icon);
     expect(iconElement).toHaveAttribute('alt', altText);
 
-    const createClusterLinkElement = screen.getByRole('link', { name: 'Create Cluster' });
+    const createClusterLinkElement = screen.getByRole('link', { name: 'Create cluster' });
     const createClusterAILinkElement = screen.getByRole('link', {
       name: 'Create cluster with Assisted Installer',
     });

--- a/src/components/overview/components/OverviewProductBanner.test.tsx
+++ b/src/components/overview/components/OverviewProductBanner.test.tsx
@@ -56,7 +56,7 @@ describe('<OverviewProductBanner />', () => {
     const iconElement = screen.queryByRole('img');
     expect(iconElement).not.toBeInTheDocument();
 
-    const learnMoreLinkElement = screen.queryByText('Learn more');
+    const learnMoreLinkElement = screen.queryByRole('link', { name: /learn more/i });
     expect(learnMoreLinkElement).not.toBeInTheDocument();
   });
 

--- a/src/components/overview/components/OverviewProductBanner.test.tsx
+++ b/src/components/overview/components/OverviewProductBanner.test.tsx
@@ -37,8 +37,7 @@ describe('<OverviewProductBanner />', () => {
       '/openshift/assisted-installer/clusters/~new',
     );
 
-    // eslint-disable-next-line testing-library/no-node-access
-    const learnMoreLinkElement = screen.getByText('Learn more');
+    const learnMoreLinkElement = screen.getByRole('link', { name: /learn more/i });
 
     expect(learnMoreLinkElement).toBeInTheDocument();
     expect(learnMoreLinkElement).toHaveAttribute('href', learnMoreLink);

--- a/src/components/overview/components/OverviewProductBanner.test.tsx
+++ b/src/components/overview/components/OverviewProductBanner.test.tsx
@@ -26,8 +26,19 @@ describe('<OverviewProductBanner />', () => {
     expect(iconElement).toHaveAttribute('src', icon);
     expect(iconElement).toHaveAttribute('alt', altText);
 
+    const createClusterLinkElement = screen.getByRole('link', { name: 'Create Cluster' });
+    const createClusterAILinkElement = screen.getByRole('link', {
+      name: 'Create cluster with Assisted Installer',
+    });
+
+    expect(createClusterLinkElement).toHaveAttribute('href', '/openshift/create');
+    expect(createClusterAILinkElement).toHaveAttribute(
+      'href',
+      '/openshift/assisted-installer/clusters/~new',
+    );
+
     // eslint-disable-next-line testing-library/no-node-access
-    const learnMoreLinkElement = screen.getByText('Learn more').closest('a');
+    const learnMoreLinkElement = screen.getByText('Learn more');
 
     expect(learnMoreLinkElement).toBeInTheDocument();
     expect(learnMoreLinkElement).toHaveAttribute('href', learnMoreLink);

--- a/src/components/overview/components/OverviewProductBanner.tsx
+++ b/src/components/overview/components/OverviewProductBanner.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 import PageHeader from '@patternfly/react-component-groups/dist/dynamic/PageHeader';
-import { Grid } from '@patternfly/react-core';
+import { Flex, FlexItem, Grid, Stack, StackItem } from '@patternfly/react-core';
+
+import { Link } from '~/common/routing';
+import ExternalLink from '~/components/common/ExternalLink';
+import InternalTrackingLink from '~/components/common/InternalTrackingLink';
 
 import './OverviewProductBanner.scss';
 
@@ -21,23 +25,59 @@ export const OverviewProductBanner = ({
   title,
   description,
   dataTestId,
-}: OverviewProductBannerProps) => (
-  <Grid className="overview-product-banner-grid" data-testid={dataTestId}>
-    <PageHeader
-      title={title}
-      subtitle={description}
-      icon={icon ? <img src={icon} alt={altText} className="overview-product-banner-icon" /> : null}
-      linkProps={
-        learnMoreLink
-          ? {
-              label: 'Learn more',
-              isExternal: true,
-              href: learnMoreLink,
-              target: '_blank',
-            }
-          : undefined
-      }
-      data-testid={dataTestId}
-    />
-  </Grid>
-);
+}: OverviewProductBannerProps) => {
+  const createClusterURL = '/create';
+  const createClusterAIURL = '/assisted-installer/clusters/~new';
+
+  const headerActions = (
+    <Flex>
+      <FlexItem>
+        <InternalTrackingLink
+          isButton
+          variant="primary"
+          to={createClusterURL}
+          data-testid="create-cluster"
+          component={Link}
+        >
+          Create Cluster
+        </InternalTrackingLink>
+      </FlexItem>
+      <FlexItem>
+        <InternalTrackingLink
+          isButton
+          variant="secondary"
+          to={createClusterAIURL}
+          data-testid="create-cluster-AI"
+          component={Link}
+        >
+          Create cluster with Assisted Installer
+        </InternalTrackingLink>
+      </FlexItem>
+      {learnMoreLink ? (
+        <FlexItem>
+          <ExternalLink href={learnMoreLink}>Learn more</ExternalLink>
+        </FlexItem>
+      ) : null}
+    </Flex>
+  );
+
+  const subtitle = (
+    <Stack hasGutter>
+      <StackItem>{description}</StackItem>
+      <StackItem>{headerActions}</StackItem>
+    </Stack>
+  );
+
+  return (
+    <Grid className="overview-product-banner-grid" data-testid={dataTestId}>
+      <PageHeader
+        title={title}
+        subtitle={subtitle}
+        icon={
+          icon ? <img src={icon} alt={altText} className="overview-product-banner-icon" /> : null
+        }
+        data-testid={dataTestId}
+      />
+    </Grid>
+  );
+};

--- a/src/components/overview/components/OverviewProductBanner.tsx
+++ b/src/components/overview/components/OverviewProductBanner.tsx
@@ -39,7 +39,7 @@ export const OverviewProductBanner = ({
           data-testid="create-cluster"
           component={Link}
         >
-          Create Cluster
+          Create cluster
         </InternalTrackingLink>
       </FlexItem>
       <FlexItem>

--- a/src/components/overview/components/OverviewProductBanner.tsx
+++ b/src/components/overview/components/OverviewProductBanner.tsx
@@ -47,7 +47,7 @@ export const OverviewProductBanner = ({
           isButton
           variant="secondary"
           to={createClusterAIURL}
-          data-testid="create-cluster-AI"
+          data-testid="create-cluster-assisted-installer"
           component={Link}
         >
           Create cluster with Assisted Installer


### PR DESCRIPTION
# Summary

This PR makes creating cluster more prominent on OCM Overview page by adding 2 buttons to the page header:
1. Create Cluster - redirects to https://console.redhat.com/openshift/create
2. Create cluster with Assisted Installer - redirects to https://console.redhat.com/openshift/assisted-installer/clusters/~new

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4307](https://redhat.atlassian.net/browse/OCMUI-4307)

# Additional information

I placed the buttons within the subtitle prop because there is no built in area for buttons in this header component, only within the subtitle they can be correctly aligned (children and actionMenu do not work in terms of the layout).

# How to Test

1. Go to Overview page
2. Make sure the header looks like the [mock](https://www.figma.com/design/bSZL4vpVvGuD8xQoadj6EU/Assisted-installer-path?node-id=145-806&t=vzHVlOEEO41T7ENu-1)
3. Click on Create Cluster and Create cluster with Assisted Installer to verify the correct page is rendered
4. Try different browser widths and let me know if you notice any layout shifts.


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1121" height="289" alt="image" src="https://github.com/user-attachments/assets/494bd448-b150-4cc6-8c38-6a83d78d5afd" /> | <img width="1121" height="289" alt="image" src="https://github.com/user-attachments/assets/285b7796-a4a8-4bae-a039-1722c36d8670" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4307]: https://redhat.atlassian.net/browse/OCMUI-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ