### PR TITLE
OCMUI-3979: Remove Red hat marketplace

### DIFF
--- a/src/common/__tests__/helpers.test.js
+++ b/src/common/__tests__/helpers.test.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 
 import helpers, {
-  goZeroTime2Null,
   isSupportedMinorVersion,
   parseCIDRSubnetLength,
   parseReduxFormKeyValueList,
@@ -100,27 +99,6 @@ describe('parseReduxFormTaints', () => {
     const reduxFormInput = [{}, {}, {}];
     const expected = [];
     expect(parseReduxFormTaints(reduxFormInput)).toEqual(expected);
-  });
-});
-
-describe('goZeroTime2Null', () => {
-  it('returns null for golang zero time', () => {
-    expect(goZeroTime2Null('0001-01-01T00:00:00Z')).toEqual(null);
-    expect(goZeroTime2Null('0001-01-01T00:00:00Z')).toEqual(null);
-    expect(goZeroTime2Null('0001-01-01T00:00:00.000000+00:00')).toEqual(null);
-  });
-
-  it('returns "empty" values as is', () => {
-    expect(goZeroTime2Null(null)).toEqual(null);
-    expect(goZeroTime2Null(false)).toEqual(false);
-    expect(goZeroTime2Null('')).toEqual('');
-  });
-
-  it('returns valid time str as is', () => {
-    const tm = new Date();
-    expect(goZeroTime2Null(tm.toDateString())).toEqual(tm.toDateString());
-    expect(goZeroTime2Null(tm.toLocaleDateString())).toEqual(tm.toLocaleDateString());
-    expect(goZeroTime2Null(tm.toUTCString())).toEqual(tm.toUTCString());
   });
 });
 

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -236,27 +236,6 @@ const parseReduxFormTaints = (
 const goZeroTime = '0001-01-01T00:00:00Z';
 
 /**
- * try to parse the go zero time, and return null for it.
- * it does not exhaust all time formats.
- * the fix is for AMS returning null timestamp in the form of go zerotime.
- * @param {string} timeStr the timestamp string. Example:
- * '2021-10-08T17:11:02Z' returns '2021-10-08T17:11:02Z'
- * '0001-01-01T00:00:00Z' returns null
- */
-const goZeroTime2Null = (timeStr: string): string | null => {
-  if (timeStr === goZeroTime) {
-    return null;
-  }
-
-  const tm = Date.parse(timeStr);
-  if (!Number.isNaN(tm) && tm === Date.parse(goZeroTime)) {
-    return null;
-  }
-
-  return timeStr;
-};
-
-/**
  * determine if a version's major.minor level is <= maxMinorVerison's major.minor level.
  * we exclude the patch version of maxMinorVersion here even though ocpVersion can have a patch version.
  * this works because a <=major.minor semver range ignores patch versions, e.g. 4.11.13 satisfies the range <=4.11.
@@ -426,7 +405,6 @@ export {
   parseReduxFormKeyValueList,
   parseReduxFormTaints,
   goZeroTime,
-  goZeroTime2Null,
   stringToArray,
   arrayToString,
   truncateTextWithEllipsis,

--- a/src/components/clusters/ClusterDetailsMultiRegion/__tests__/ClusterDetails.fixtures.js
+++ b/src/components/clusters/ClusterDetailsMultiRegion/__tests__/ClusterDetails.fixtures.js
@@ -443,16 +443,6 @@ const OSDTrialClusterDetails = produce(CCSClusterDetails, (draft) => {
   };
 });
 
-const OSDRHMClusterDetails = produce(CCSClusterDetails, (draft) => {
-  draft.cluster.product = { id: normalizedProducts.OSD };
-  draft.cluster.subscription.plan = {
-    id: normalizedProducts.OSD,
-    type: normalizedProducts.OSD,
-  };
-  draft.cluster.subscription.cluster_billing_model =
-    SubscriptionCommonFieldsClusterBillingModel.marketplace;
-});
-
 const OSDGCPClusterDetails = produce(CCSClusterDetails, (draft) => {
   draft.cluster.product = { id: normalizedProducts.OSD };
   draft.cluster.subscription.plan = {
@@ -1132,7 +1122,6 @@ const fixtures = {
   clusterDetails,
   CCSClusterDetails,
   OSDTrialClusterDetails,
-  OSDRHMClusterDetails,
   OSDGCPClusterDetails,
   ROSAClusterDetails,
   ROSAManualClusterDetails,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.test.tsx
@@ -35,7 +35,6 @@ describe('AddOnsSubscription', () => {
         allowed: 100,
         cloudAccounts: {
           aws: [],
-          rhm: [],
           azure: [],
         },
       },
@@ -90,7 +89,6 @@ describe('AddOnsSubscription', () => {
           allowed: 100,
           cloudAccounts: {
             aws: [],
-            rhm: [],
             azure: [],
           },
         },
@@ -126,7 +124,6 @@ describe('AddOnsSubscription', () => {
           cost: 0,
           cloudAccounts: {
             aws: [],
-            rhm: [],
             azure: [],
           },
         },

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.tsx
@@ -12,8 +12,6 @@ import {
 } from '@patternfly/react-core';
 
 import { BillingQuota } from '~/components/clusters/common/quotaModel';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
-import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
 import { setAddonsDrawer } from '../AddOnsActions';
@@ -44,8 +42,6 @@ const AddOnsSubscription = ({
     );
   };
   const activeSubscription = subscriptionModels[activeCardId];
-
-  const hideRHMarketplace = useFeatureGate(HIDE_RH_MARKETPLACE);
 
   // TODO: We are hiding RHM and Azure options for now until backend is ready
   const hideRhmAzureForNow = true;
@@ -132,20 +128,6 @@ const AddOnsSubscription = ({
   const cloudAccounts = billingQuota.marketplace?.cloudAccounts;
   const marketplaceOptions = (
     <>
-      {!hideRhmAzureForNow && !hideRHMarketplace ? (
-        <AddOnsSubscriptionCard
-          subscriptionModels={subscriptionModels}
-          setSubscriptionModel={setSubscriptionModel}
-          activeCardId={activeCardId}
-          hasQuota={hasQuotaMarketplace}
-          isReady={isReady}
-          cloudAccounts={cloudAccounts}
-          installedAddOn={installedAddOn}
-          billingModel={SubscriptionCommonFieldsClusterBillingModel.marketplace_rhm}
-          name="Red Hat Marketplace"
-          cloudProvider="rhm"
-        />
-      ) : null}
       <AddOnsSubscriptionCard
         subscriptionModels={subscriptionModels}
         setSubscriptionModel={setSubscriptionModel}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscription.tsx
@@ -43,8 +43,8 @@ const AddOnsSubscription = ({
   };
   const activeSubscription = subscriptionModels[activeCardId];
 
-  // TODO: We are hiding RHM and Azure options for now until backend is ready
-  const hideRhmAzureForNow = true;
+  // TODO: We are hiding Azure options for now until backend is ready
+  const hideAzureForNow = true;
   // TODO: PATCH operation to change billing model after install not yet supported
   const cannotModifyBillingAfterInstall = Boolean(installedAddOn);
 
@@ -140,7 +140,7 @@ const AddOnsSubscription = ({
         name="AWS Marketplace"
         cloudProvider="aws"
       />
-      {!hideRhmAzureForNow && (
+      {!hideAzureForNow && (
         <AddOnsSubscriptionCard
           subscriptionModels={subscriptionModels}
           setSubscriptionModel={setSubscriptionModel}

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscriptionCard.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsSubscriptionCard.tsx
@@ -23,7 +23,6 @@ import './AddOnsSubscriptionCard.scss';
 const SELECT_ACCOUNT_PLACEHOLDER = 'Select an account';
 const marketplaceLinks: {
   [addOn: string]: {
-    rhm?: string;
     aws?: string;
     azure?: string;
   };

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsTypes.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/AddOnsTypes.ts
@@ -1,6 +1,6 @@
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
-export type CloudProviders = 'rhm' | 'aws' | 'azure';
+export type CloudProviders = 'aws' | 'azure';
 
 export type CloudAccount = {
   // eslint-disable-next-line camelcase

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/__tests__/AddOns.fixtures.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AddOns/AddOnsDrawer/__tests__/AddOns.fixtures.jsx
@@ -222,12 +222,6 @@ export const billingQuota = {
   },
   marketplace: {
     cloudAccounts: {
-      rhm: [
-        {
-          cloud_account_id: 'fakeRHMarketplaceAccount',
-          cloud_provider_id: 'rhm',
-        },
-      ],
       aws: [
         {
           cloud_account_id: '000000000004',

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.jsx
@@ -21,7 +21,6 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import { getOCMResourceType, trackEvents } from '~/common/analytics';
 import { BREADCRUMB_PATHS, buildBreadcrumbs } from '~/common/breadcrumbPaths';
 import getClusterName from '~/common/getClusterName';
-import { goZeroTime2Null } from '~/common/helpers';
 import isAssistedInstallSubscription, {
   isAvailableAssistedInstallCluster,
   isUninstalledAICluster,
@@ -39,7 +38,6 @@ import useAnalytics from '~/hooks/useAnalytics';
 import { usePreviousProps } from '~/hooks/usePreviousProps';
 import { refreshClusterDetails } from '~/queries/refreshEntireCache';
 import {
-  SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel,
   SubscriptionCommonFieldsStatus,
   SubscriptionCommonFieldsSupport_level as SubscriptionCommonFieldsSupportLevel,
 } from '~/types/accounts_mgmt.v1';
@@ -169,10 +167,6 @@ function ClusterDetailsTop(props) {
   const addNotification = useAddNotification();
   const isProductOSDTrial =
     get(cluster, 'subscription.plan.type', '') === normalizedProducts.OSDTrial;
-  const isProductOSDRHM =
-    get(cluster, 'subscription.plan.type', '') === normalizedProducts.OSD &&
-    get(cluster, 'subscription.cluster_billing_model', '') ===
-      SubscriptionCommonFieldsClusterBillingModel.marketplace;
   const isOSD = get(cluster, 'subscription.plan.type') === normalizedProducts.OSD;
   const isROSA = get(cluster, 'subscription.plan.type') === normalizedProducts.ROSA;
   const isOCP = get(cluster, 'subscription.plan.type') === normalizedProducts.OCP;
@@ -269,8 +263,6 @@ function ClusterDetailsTop(props) {
     pending || organization.pending || isClusterIdentityProvidersLoading || isRefetching;
 
   const trialEndDate = isProductOSDTrial && get(cluster, 'subscription.trial_end_date');
-  const OSDRHMEndDate =
-    isProductOSDRHM && goZeroTime2Null(get(cluster, 'subscription.billing_expiration_date'));
 
   const canNotEditReason =
     !cluster.canEdit && 'You do not have permissions to unarchive this cluster';
@@ -345,7 +337,6 @@ function ClusterDetailsTop(props) {
   const hasIDPAlert = showIDPMessage;
   const hasExpirationAlert = !!cluster.expiration_timestamp;
   const hasTrialExpirationAlert = !!trialEndDate && !isDeprovisioned;
-  const hasOsdRHMEEndDateAlert = OSDRHMEndDate && !isDeprovisioned;
   const hasGCPOrgPolicyAlert = !!showGcpOrgPolicyWarning;
   const hasSubscriptionCompliancyAlert =
     isOCP &&
@@ -365,7 +356,6 @@ function ClusterDetailsTop(props) {
     hasIDPAlert,
     hasExpirationAlert,
     hasTrialExpirationAlert,
-    hasOsdRHMEEndDateAlert,
     hasGCPOrgPolicyAlert,
     hasSubscriptionCompliancyAlert,
     hasClusterNonEditableAlert,
@@ -491,9 +481,7 @@ function ClusterDetailsTop(props) {
                 {...trialExpirationUpgradeProps}
               />
             )}
-            {OSDRHMEndDate && !isDeprovisioned && (
-              <ExpirationAlert expirationTimestamp={OSDRHMEndDate} OSDRHMExpiration />
-            )}
+
             {showGcpOrgPolicyWarning && <GcpOrgPolicyAlert summary={gcpOrgPolicyWarning} />}
 
             <SubscriptionCompliancy

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/ClusterDetailsTop.test.jsx
@@ -5,16 +5,8 @@ import * as notifications from '@redhat-cloud-services/frontend-components-notif
 
 import { CLUSTER_LIST_PATH, ocmBaseName } from '~/common/routing';
 import { normalizedProducts } from '~/common/subscriptionTypes';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
 import * as clusterService from '~/services/clusterService';
-import {
-  checkAccessibility,
-  mockUseChrome,
-  mockUseFeatureGate,
-  render,
-  screen,
-  within,
-} from '~/testUtils';
+import { checkAccessibility, mockUseChrome, render, screen, within } from '~/testUtils';
 import { SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 
 import clusterStates from '../../../common/clusterStates';
@@ -274,37 +266,6 @@ describe('<ClusterDetailsTop />', () => {
       await user.click(expandBtn);
 
       expect(await screen.findByRole('alert')).toBeInTheDocument();
-      expect(
-        within(screen.getByRole('alert')).getByText('Danger alert', {
-          exact: false,
-        }),
-      ).toBeInTheDocument();
-      expect(
-        within(screen.getByRole('alert')).getByText('This cluster will be deleted in a day', {
-          exact: false,
-        }),
-      ).toBeInTheDocument();
-    });
-
-    it('should show expiration alert for OSD RHM', async () => {
-      mockUseFeatureGate([[HIDE_RH_MARKETPLACE, false]]);
-
-      const { cluster } = fixtures.OSDRHMClusterDetails;
-
-      const expDate = new Date();
-      expDate.setDate(expDate.getDate() + 1); // now + 1 day
-      cluster.subscription.trial_end_date = '';
-      cluster.subscription.billing_expiration_date = expDate.toISOString();
-      cluster.expiration_timestamp = '';
-
-      const newProps = { ...props, cluster };
-
-      const { user } = render(<ClusterDetailsTop {...newProps} />);
-
-      const expandBtn = screen.getByText('Alerts and recommendations');
-
-      await user.click(expandBtn);
-
       expect(
         within(screen.getByRole('alert')).getByText('Danger alert', {
           exact: false,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
@@ -8,8 +8,6 @@ import supportLinks from '~/common/supportLinks.mjs';
 import ExternalLink from '~/components/common/ExternalLink';
 import { modalActions } from '~/components/common/Modal/ModalActions';
 import modals from '~/components/common/Modal/modals';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
-import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { Cluster } from '~/types/clusters_mgmt.v1';
 
 type ExpirationAlertProps = {
@@ -25,8 +23,6 @@ const ExpirationAlert = ({
   cluster,
   OSDRHMExpiration,
 }: ExpirationAlertProps) => {
-  const hideRHMarketplace = useFeatureGate(HIDE_RH_MARKETPLACE);
-
   const dispatch = useDispatch();
   const now = dayjs.utc();
   const expirationTime = dayjs.utc(expirationTimestamp);
@@ -86,19 +82,7 @@ const ExpirationAlert = ({
     <>This cluster is scheduled for deletion on {expirationTimedate}</>
   );
   if (OSDRHMExpiration) {
-    contents = hideRHMarketplace ? (
-      <>Once expired, the cluster will be deleted permanently.</>
-    ) : (
-      <>
-        Your cluster subscription was purchased from Red Hat Marketplace and will expire on{' '}
-        {expirationTimedate}. Once expired, the cluster will be deleted permanently. To avoid
-        deletion, please purchase a new subscription from the{' '}
-        <ExternalLink href="https://marketplace.redhat.com/en-us/products/red-hat-openshift-dedicated">
-          Red Hat Marketplace
-        </ExternalLink>{' '}
-        before the expiration date.
-      </>
-    );
+    contents = <>Once expired, the cluster will be deleted permanently.</>;
   } else if (trialExpiration) {
     contents = (
       <>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/ClusterDetailsTop/components/ExpirationAlert.tsx
@@ -14,14 +14,12 @@ type ExpirationAlertProps = {
   expirationTimestamp: string;
   trialExpiration?: boolean;
   cluster?: Cluster;
-  OSDRHMExpiration?: boolean;
 };
 
 const ExpirationAlert = ({
   expirationTimestamp,
   trialExpiration,
   cluster,
-  OSDRHMExpiration,
 }: ExpirationAlertProps) => {
   const dispatch = useDispatch();
   const now = dayjs.utc();
@@ -81,9 +79,7 @@ const ExpirationAlert = ({
   let contents: string | React.ReactElement = (
     <>This cluster is scheduled for deletion on {expirationTimedate}</>
   );
-  if (OSDRHMExpiration) {
-    contents = <>Once expired, the cluster will be deleted permanently.</>;
-  } else if (trialExpiration) {
+  if (trialExpiration) {
     contents = (
       <>
         Your free trial cluster will automatically be deleted on {expirationTimedate}. Upgrade your

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/__tests__/ExpirationAlert.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/__tests__/ExpirationAlert.test.tsx
@@ -108,29 +108,5 @@ describe('<ExpirationAlert />', () => {
         });
       });
     });
-
-    describe('OSDRHMExpiration true', () => {
-      it('properly renders the button', () => {
-        // Arrange
-        const expirationTimestamp = dayjs
-          .utc()
-          .add(12, 'hour')
-          .local()
-          .format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-        const timeDifference = dayjs.utc().to(dayjs.utc(expirationTimestamp));
-        const expirationTimeString = dayjs
-          .utc(expirationTimestamp)
-          .local()
-          .format('dddd, MMMM D, YYYY [at] h:mm A');
-
-        // Act
-        render(<ExpirationAlert expirationTimestamp={expirationTimestamp} OSDRHMExpiration />);
-
-        // Assert
-        expect(screen.getByTestId('expiration-alert-will-delete')).toHaveTextContent(
-          `This cluster will be deleted ${timeDifference}.Your cluster subscription was purchased from Red Hat Marketplace and will expire on ${expirationTimeString}`,
-        );
-      });
-    });
   });
 });

--- a/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.jsx
+++ b/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.jsx
@@ -8,8 +8,6 @@ import { Alert, Button, Form } from '@patternfly/react-core';
 import { Link } from '~/common/routing';
 import Modal from '~/components/common/Modal/Modal';
 import { useFetchMachineTypes } from '~/queries/ClusterDetailsQueries/MachinePoolTab/MachineTypes/useFetchMachineTypes';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
-import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { refreshClusterDetails } from '~/queries/refreshEntireCache';
 import { useGlobalState } from '~/redux/hooks/useGlobalState';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
@@ -33,7 +31,6 @@ import './UpgradeTrialClusterDialog.scss';
 
 const UpgradeTrialClusterDialog = ({ onClose }) => {
   const dispatch = useDispatch();
-  const hideRHMarketplace = useFeatureGate(HIDE_RH_MARKETPLACE);
   const modalData = useGlobalState((state) => state.modal.data);
   const organization = useGlobalState((state) => state.userProfile.organization);
   const clusterID = modalData.clusterID ? modalData.clusterID : '';
@@ -116,7 +113,7 @@ const UpgradeTrialClusterDialog = ({ onClose }) => {
       return acc;
     }, {});
 
-    const quota = { MARKETPLACE: !hideRHMarketplace, STANDARD: true };
+    let standardQuota = true;
     Object.keys(machinePoolTypes || {}).forEach((key) => {
       const quotaParams = {
         product: OSD,
@@ -137,75 +134,24 @@ const UpgradeTrialClusterDialog = ({ onClose }) => {
         resourceType: QuotaTypes.NODE,
       });
 
-      quota.STANDARD =
-        quota.STANDARD && standardNodes >= machinePoolTypes[key] && standardClusters > 0;
-
-      const marketClusters = availableQuota(quotaList, {
-        ...quotaParams,
-        billingModel: SubscriptionCommonFieldsClusterBillingModel.marketplace,
-        resourceType: QuotaTypes.CLUSTER,
-      });
-      const marketNodes = availableQuota(quotaList, {
-        ...quotaParams,
-        billingModel: SubscriptionCommonFieldsClusterBillingModel.marketplace,
-        resourceType: QuotaTypes.NODE,
-      });
-
-      quota.MARKETPLACE =
-        !hideRHMarketplace &&
-        quota.MARKETPLACE &&
-        marketNodes >= machinePoolTypes[key] &&
-        marketClusters > 0;
+      standardQuota =
+        standardQuota && standardNodes >= machinePoolTypes[key] && standardClusters > 0;
     });
-    return quota;
+    return standardQuota;
   };
 
   const getPrimaryButtonProps = (availableQuotaValue) => {
-    const marketplaceQuotaEnabled = availableQuotaValue.MARKETPLACE && !hideRHMarketplace;
     const button = {
       primaryText: 'Contact sales',
       onPrimaryClick: () => buttonLinkClick('https://cloud.redhat.com/products/dedicated/contact/'),
     };
 
-    if (availableQuotaValue.STANDARD && !marketplaceQuotaEnabled) {
+    if (availableQuotaValue) {
       button.primaryText = 'Upgrade using quota';
       button.primaryLink = null;
       button.onPrimaryClick = () =>
         submitUpgrade(clusterID, SubscriptionCommonFieldsClusterBillingModel.standard);
       return button;
-    }
-
-    if (marketplaceQuotaEnabled) {
-      button.primaryText = 'Upgrade using Marketplace billing';
-      button.primaryLink = null;
-      button.onPrimaryClick = () =>
-        submitUpgrade(clusterID, SubscriptionCommonFieldsClusterBillingModel.marketplace);
-      return button;
-    }
-
-    return button;
-  };
-
-  const getSecondaryButtonProps = (availableQuotaValue) => {
-    const marketplaceQuotaEnabled = availableQuotaValue.MARKETPLACE && !hideRHMarketplace;
-    const button = {
-      showSecondary: false,
-    };
-
-    button.secondaryText = 'Enable Marketplace billing';
-    button.showSecondary = !hideRHMarketplace;
-    button.onSecondaryClick = () =>
-      buttonLinkClick('https://marketplace.redhat.com/en-us/products/red-hat-openshift-dedicated');
-
-    if (marketplaceQuotaEnabled && availableQuotaValue.STANDARD) {
-      button.secondaryText = 'Upgrade using quota';
-      button.onSecondaryClick = () =>
-        submitUpgrade(clusterID, SubscriptionCommonFieldsClusterBillingModel.standard);
-    }
-
-    if (marketplaceQuotaEnabled && !availableQuotaValue.STANDARD) {
-      button.showSecondary = false;
-      button.secondaryLink = null;
     }
 
     return button;
@@ -230,10 +176,8 @@ const UpgradeTrialClusterDialog = ({ onClose }) => {
 
   const availableQuotaValue = upgradeModalQuota();
   const primaryButton = getPrimaryButtonProps(availableQuotaValue);
-  const secondaryButton = getSecondaryButtonProps(availableQuotaValue);
   const tertiaryButton = getTertiaryButtonProps();
-  const noQuota =
-    !availableQuotaValue.STANDARD && (!availableQuotaValue.MARKETPLACE || hideRHMarketplace);
+  const noQuota = !availableQuotaValue;
   const modalSize = noQuota ? 'small' : 'medium';
 
   return (
@@ -245,7 +189,7 @@ const UpgradeTrialClusterDialog = ({ onClose }) => {
       isSmall={false}
       {...primaryButton}
       className="upgrade-trial-cluster-dialog"
-      {...secondaryButton}
+      showSecondary={false}
       {...tertiaryButton}
       isPending={isUpgradeFromTrialPending}
     >

--- a/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.test.jsx
+++ b/src/components/clusters/common/UpgradeTrialClusterDialog/UpgradeTrialClusterDialog.test.jsx
@@ -4,9 +4,8 @@ import * as reactRedux from 'react-redux';
 import * as useUpgradeClusterFromTrial from '~/queries/ClusterActionsQueries/useUpgradeClusterFromTrial';
 import * as useFetchMachineTypes from '~/queries/ClusterDetailsQueries/MachinePoolTab/MachineTypes/useFetchMachineTypes';
 import * as useFetchMachineOrNodePools from '~/queries/ClusterDetailsQueries/MachinePoolTab/useFetchMachineOrNodePools';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
 
-import { mockUseFeatureGate, screen, withState } from '../../../../testUtils';
+import { screen, withState } from '../../../../testUtils';
 import fixtures from '../../ClusterDetailsMultiRegion/__tests__/ClusterDetails.fixtures';
 import { emptyQuotaList, mockQuotaList } from '../__tests__/quota.fixtures';
 
@@ -99,82 +98,7 @@ describe('<UpgradeTrialClusterDialog />', () => {
     expect(screen.getByRole('dialog')).toHaveClass('pf-m-sm');
   });
 
-  it('allows upgrade via marketplace billing', () => {
-    // Has marketplace quota but no standard quota
-    mockedUseFetchMachineOrNodePools.mockReturnValue({
-      isLoading: false,
-      isError: false,
-      error: null,
-      data: [
-        {
-          instance_type: 'm5.xlarge',
-          replicas: 140,
-        },
-      ],
-    });
-
-    const orgState = {
-      userProfile: {
-        organization: {
-          fulfilled: true,
-          pending: false,
-          quotaList: mockQuotaList,
-        },
-      },
-    };
-    const updatedState = {
-      ...defaultState,
-      ...orgState,
-    };
-    withState(updatedState).render(<UpgradeTrialClusterDialog isOpen onClose={onClose} />);
-
-    expect(screen.queryByTestId('no-quota-alert')).not.toBeInTheDocument();
-    expect(screen.getByText('Upgrade using Marketplace billing')).toBeInTheDocument();
-    expect(screen.queryByText('Upgrade using quota')).not.toBeInTheDocument();
-    // when it's possible to upgrade, we have to make room for all the action buttons and use a bigger PF modal
-    expect(screen.getByRole('dialog')).toHaveClass('pf-m-md');
-  });
-
-  it('renders no-quota when user has marketplace quota but feature gate is enabled', () => {
-    // Has marketplace quota but no standard quota
-
-    mockUseFeatureGate([[HIDE_RH_MARKETPLACE, true]]);
-
-    mockedUseFetchMachineOrNodePools.mockReturnValue({
-      isLoading: false,
-      isError: false,
-      error: null,
-      data: [
-        {
-          instance_type: 'm5.xlarge',
-          replicas: 140,
-        },
-      ],
-    });
-
-    const orgState = {
-      userProfile: {
-        organization: {
-          fulfilled: true,
-          pending: false,
-          quotaList: mockQuotaList,
-        },
-      },
-    };
-    const updatedState = {
-      ...defaultState,
-      ...orgState,
-    };
-    withState(updatedState).render(<UpgradeTrialClusterDialog isOpen onClose={onClose} />);
-
-    expect(screen.getByTestId('no-quota-alert')).toBeInTheDocument();
-    expect(screen.getByText('Contact sales')).toBeInTheDocument();
-  });
-
-  it('allows upgrade via standard or marketplace billing', () => {
-    // Has both marketplace and standard quota
-
-    mockUseFeatureGate([[HIDE_RH_MARKETPLACE, false]]);
+  it('allows upgrade via standard billing', () => {
     mockedUseFetchMachineOrNodePools.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -203,43 +127,6 @@ describe('<UpgradeTrialClusterDialog />', () => {
 
     withState(updatedState).render(<UpgradeTrialClusterDialog isOpen onClose={onClose} />);
     expect(screen.queryByTestId('no-quota-alert')).not.toBeInTheDocument();
-    expect(screen.getByText('Upgrade using Marketplace billing')).toBeInTheDocument();
-    expect(screen.getByText('Upgrade using quota')).toBeInTheDocument();
-  });
-
-  it('allows only upgrade via standard when hide marketplace feature flag is enabled', () => {
-    // Has both marketplace and standard quota
-    mockUseFeatureGate([[HIDE_RH_MARKETPLACE, true]]);
-
-    mockedUseFetchMachineOrNodePools.mockReturnValue({
-      isLoading: false,
-      isError: false,
-      error: null,
-      data: [
-        {
-          instance_type: 'm5.xlarge',
-          replicas: 130,
-        },
-      ],
-    });
-
-    const orgState = {
-      userProfile: {
-        organization: {
-          fulfilled: true,
-          pending: false,
-          quotaList: mockQuotaList,
-        },
-      },
-    };
-    const updatedState = {
-      ...defaultState,
-      ...orgState,
-    };
-
-    withState(updatedState).render(<UpgradeTrialClusterDialog isOpen onClose={onClose} />);
-    expect(screen.queryByTestId('no-quota-alert')).not.toBeInTheDocument();
-    expect(screen.queryByText('Upgrade using Marketplace billing')).not.toBeInTheDocument();
     expect(screen.getByText('Upgrade using quota')).toBeInTheDocument();
   });
 

--- a/src/components/clusters/common/__tests__/quota.fixtures.js
+++ b/src/components/clusters/common/__tests__/quota.fixtures.js
@@ -109,10 +109,6 @@ export const quotaWithAccounts = {
           cloud_provider_id: 'aws',
         },
         {
-          cloud_account_id: 'fakeRHMarketplaceAccount',
-          cloud_provider_id: 'rhm',
-        },
-        {
           cloud_account_id: 'fakeAzureAccount',
           cloud_provider_id: 'azure',
         },
@@ -137,10 +133,6 @@ export const quotaWithoutAccounts = {
     {
       allowed: 1080,
       cloud_accounts: [
-        {
-          cloud_account_id: 'fakeRHMarketplaceAccount',
-          cloud_provider_id: 'rhm',
-        },
         {
           cloud_account_id: 'fakeAzureAccount',
           cloud_provider_id: 'azure',

--- a/src/components/clusters/common/__tests__/quotaSelectors.fixtures.ts
+++ b/src/components/clusters/common/__tests__/quotaSelectors.fixtures.ts
@@ -112,10 +112,6 @@ export const quotaWithAccounts: QuotaCostList = {
           cloud_provider_id: 'aws',
         },
         {
-          cloud_account_id: 'fakeRHMarketplaceAccount',
-          cloud_provider_id: 'rhm',
-        },
-        {
           cloud_account_id: 'fakeAzureAccount',
           cloud_provider_id: 'azure',
         },
@@ -142,10 +138,6 @@ export const quotaWithoutAccounts: QuotaCostList = {
     {
       allowed: 1080,
       cloud_accounts: [
-        {
-          cloud_account_id: 'fakeRHMarketplaceAccount',
-          cloud_provider_id: 'rhm',
-        },
         {
           cloud_account_id: 'fakeAzureAccount',
           cloud_provider_id: 'azure',
@@ -224,7 +216,6 @@ export const expectedAddons = {
     consumed: 0,
     cost: 1,
     cloudAccounts: {
-      rhm: [],
       aws: [],
       azure: [],
     },

--- a/src/components/clusters/common/billingModelMapper.test.ts
+++ b/src/components/clusters/common/billingModelMapper.test.ts
@@ -27,10 +27,6 @@ describe('billingModelMapper', () => {
         SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp,
         RelatedResourceBillingModel.marketplace,
       ],
-      [
-        SubscriptionCommonFieldsClusterBillingModel.marketplace_rhm,
-        RelatedResourceBillingModel.marketplace,
-      ],
       [SubscriptionCommonFieldsClusterBillingModel.standard, RelatedResourceBillingModel.standard],
       ['any', RelatedResourceBillingModel.any],
       ['whatever', undefined],

--- a/src/components/clusters/common/quotaModel.ts
+++ b/src/components/clusters/common/quotaModel.ts
@@ -29,7 +29,6 @@ export type QuotaParams = {
 export type QuotaQuery = Omit<RelatedResource, 'cost'>;
 
 export type BillingQuotaCloudAccounts = {
-  rhm: CloudAccount[];
   aws: CloudAccount[];
   azure: CloudAccount[];
 };

--- a/src/components/clusters/common/quotaSelectors.test.ts
+++ b/src/components/clusters/common/quotaSelectors.test.ts
@@ -74,7 +74,6 @@ describe('quotaSelectors', () => {
       [BillingModel.marketplace, BillingModel.marketplace],
       [BillingModel.marketplace_azure, BillingModel.marketplace_azure],
       [BillingModel.marketplace_gcp, BillingModel.marketplace_gcp],
-      [BillingModel.marketplace_rhm, BillingModel.marketplace_rhm],
     ])('model %p is %p', (model: BillingModel, expected: string) => {
       expect(getBillingQuotaModel(model)).toBe(expected);
     });

--- a/src/components/clusters/common/quotaSelectors.ts
+++ b/src/components/clusters/common/quotaSelectors.ts
@@ -150,7 +150,6 @@ const addOnBillingQuota = (quotaList: QuotaCostList, quotaParams: QuotaParams): 
           models.marketplace = {
             cost: resource.cost,
             cloudAccounts: {
-              rhm: quotaCostItem.cloud_accounts?.filter((m) => m.cloud_provider_id === 'rhm') ?? [],
               aws: quotaCostItem.cloud_accounts?.filter((m) => m.cloud_provider_id === 'aws') ?? [],
               azure:
                 quotaCostItem.cloud_accounts?.filter((m) => m.cloud_provider_id === 'azure') ?? [],

--- a/src/components/clusters/wizards/common/ReviewCluster/reviewValues.jsx
+++ b/src/components/clusters/wizards/common/ReviewCluster/reviewValues.jsx
@@ -44,8 +44,6 @@ const reviewValues = {
     values: {
       [SubscriptionCommonFieldsClusterBillingModel.standard]:
         'Annual: Fixed capacity subscription from Red Hat',
-      [SubscriptionCommonFieldsClusterBillingModel.marketplace]:
-        'On-Demand: Flexible usage billed through Red Hat Marketplace',
       [SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp]:
         'On-Demand: Flexible usage billed through Google Cloud Marketplace',
       [STANDARD_TRIAL_BILLING_MODEL_TYPE]: 'Free trial (upgradeable)',

--- a/src/components/clusters/wizards/common/ReviewCluster/reviewValues.stories.tsx
+++ b/src/components/clusters/wizards/common/ReviewCluster/reviewValues.stories.tsx
@@ -228,7 +228,6 @@ export const BillingModelShowcase: Story = {
     const base = buildFullReviewFormValues();
     const models: Array<{ label: string; billingModel: string }> = [
       { label: 'Standard', billingModel: ClusterBillingModel.standard },
-      { label: 'Marketplace (RHM)', billingModel: ClusterBillingModel.marketplace },
       { label: 'Marketplace AWS', billingModel: ClusterBillingModel.marketplace_aws },
       { label: 'Marketplace GCP', billingModel: ClusterBillingModel.marketplace_gcp },
       { label: 'Free trial', billingModel: STANDARD_TRIAL_BILLING_MODEL_TYPE },

--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Formik } from 'formik';
 
 import { useIsOSDFromGoogleCloud } from '~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud';
-import { HIDE_RH_MARKETPLACE } from '~/queries/featureGates/featureConstants';
 import { checkAccessibility, mockUseFeatureGate, render, screen, waitFor } from '~/testUtils';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
@@ -47,7 +46,6 @@ const buildTestComponent = (isOSDFromGoogleCloud = false) => (
 describe('<BillingModel />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseFeatureGate([[HIDE_RH_MARKETPLACE, true]]);
     mockUseGetBillingQuotas.mockReturnValue(defaultQuotas);
   });
   describe('Default path for osd creation', () => {

--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Formik } from 'formik';
 
 import { useIsOSDFromGoogleCloud } from '~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud';
-import { checkAccessibility, mockUseFeatureGate, render, screen, waitFor } from '~/testUtils';
+import { checkAccessibility, render, screen, waitFor } from '~/testUtils';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
 import { FieldId, initialValues } from '../constants';

--- a/src/hooks/__tests__/useCanClusterAutoscale.test.ts
+++ b/src/hooks/__tests__/useCanClusterAutoscale.test.ts
@@ -12,32 +12,18 @@ describe('canAutoScale', () => {
     useGlobalStateMock.mockReturnValue(false);
     const result = useCanClusterAutoscale(
       normalizedProducts.ROSA,
-      SubscriptionCommonFieldsClusterBillingModel.marketplace,
+      SubscriptionCommonFieldsClusterBillingModel.marketplace_aws,
     );
     expect(result).toBe(true);
   });
 
-  it('should allow autoscaling for OSD clusters with Red Hat marketplace billing accouunt', () => {
+  it('should allow autoscaling for OSD clusters with standard billing account', () => {
     useGlobalStateMock.mockReturnValue(true);
-    const resultMarketPlaceRH = useCanClusterAutoscale(
-      normalizedProducts.OSD,
-      SubscriptionCommonFieldsClusterBillingModel.marketplace,
-    );
-    const resultMarketPlaceRHM = useCanClusterAutoscale(
-      normalizedProducts.OSD,
-      SubscriptionCommonFieldsClusterBillingModel.marketplace_rhm,
-    );
-    expect(resultMarketPlaceRH).toBe(true);
-    expect(resultMarketPlaceRHM).toBe(true);
-  });
-
-  it('should allow autoscaling for OSD clusters with standard billing accouunt', () => {
-    useGlobalStateMock.mockReturnValue(true);
-    const resultMarketPlaceRH = useCanClusterAutoscale(
+    const result = useCanClusterAutoscale(
       normalizedProducts.OSD,
       SubscriptionCommonFieldsClusterBillingModel.standard,
     );
-    expect(resultMarketPlaceRH).toBe(true);
+    expect(result).toBe(true);
   });
 
   it('should not allow autoscaling for OCP cluster', () => {

--- a/src/hooks/useCanClusterAutoscale.ts
+++ b/src/hooks/useCanClusterAutoscale.ts
@@ -26,8 +26,7 @@ const useCanClusterAutoscale = (
   return (
     product === normalizedProducts.ROSA ||
     (product === normalizedProducts.OSD &&
-      (billingModel === SubscriptionCommonFieldsClusterBillingModel.marketplace ||
-        billingModel === SubscriptionCommonFieldsClusterBillingModel.marketplace_aws ||
+      (billingModel === SubscriptionCommonFieldsClusterBillingModel.marketplace_aws ||
         billingModel === SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp ||
         hasAutoScaleCapability))
   );

--- a/src/queries/featureGates/featureConstants.ts
+++ b/src/queries/featureGates/featureConstants.ts
@@ -30,7 +30,6 @@ export const BYPASS_COMPUTE_NODE_COUNT_LIMIT_CLASSIC_OSD_GCP =
 export const MAX_NODES_TOTAL_249 = 'ocmui-max-nodes-total-249';
 export const ENHANCED_HTPASSWRD = 'ocmui-enhanced-htpasswrd';
 export const GCP_SECURE_BOOT = 'ocmui-gcp-secure-boot';
-export const HIDE_RH_MARKETPLACE = 'OCMUI-hide-rh-marketplace';
 export const IMDS_SELECTION = 'ocmui-imds-selection';
 export const AWS_TAGS_NEW_MP = 'ocmui-aws-tags-new-mp';
 export const TABBED_MACHINE_POOL_MODAL = 'ocmui-tabbed-machine-pool-modal';
@@ -67,7 +66,6 @@ export default {
   MAX_NODES_TOTAL_249,
   ENHANCED_HTPASSWRD,
   GCP_SECURE_BOOT,
-  HIDE_RH_MARKETPLACE,
   IMDS_SELECTION,
   AWS_TAGS_NEW_MP,
   TABBED_MACHINE_POOL_MODAL,


### PR DESCRIPTION
# Summary

Red Hat Marketplace has been decommissioned and was previously hidden behind the OCMUI-hide-rh-marketplace feature flag. This PR removes the flag and all related UI/logic in the affected areas.

Changes fall into two groups:

1. Feature flag removal - Remove HIDE_RH_MARKETPLACE from featureConstants.ts and all useFeatureGate usage in touched components/tests.

2. RHM code removal - Remove remaining Red Hat Marketplace code that was not hidden behind the feature flag probably:

- Upgrade trial dialog - Remove the marketplace upgrade path.
- OSD RHM expiration alert - Remove the alert entirely from ClusterDetailsTop / ExpirationAlert (not just the FF-gated copy). There are no remaining RHM clusters in production.
- Add-ons drawer - Remove the Red Hat Marketplace subscription card, drop rhm from cloud provider types, and fixtures.
- Autoscale - remove RHM from autoscale in useCanClusterAutoscale.
- Remove the RHM marketplace billing label from reviewValues and Storybook showcase.

# Jira

Fixes [OCMUI-3979](https://redhat.atlassian.net/browse/OCMUI-3979)

# Additional information

- Red hat marketplace was already removed from the billing model subscription in a previous PR.
- Generated types under src/types/ were intentionally left unchanged.

# How to Test

Most of this PR is removal of dead RHM code and cleanup of fixtures and tests. Apart from the areas that previously used the feature flag, there isn't a practical way to manually test the other changes other than running unit tests and checking touched OSD clsuter flows behave the same.

FF removal test:
In staging - switch off the FF OCMUI-hide-rh-marketplace.

1. Create OSD cluster with free trial subscription
2. Make sure RHM option does not exist in (should be the same as in staging):
    - Cluster details -> actions -> upgrade (from free trial)

# Screen Captures

Upgrade modal - before and flag off:
<img width="959" height="401" alt="image" src="https://github.com/user-attachments/assets/65808de9-427b-4361-a23c-b1ffcadd8add" />

Upgrade modal - after
<img width="993" height="443" alt="Screenshot From 2026-05-03 17-37-28" src="https://github.com/user-attachments/assets/6071e54b-c0fd-4685-92f1-c66cf3e5922b" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3979]: https://redhat.atlassian.net/browse/OCMUI-3979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ