### PR TITLE
OCMUI-4540 : Updated day2 spec to support min maximum node count >=1 for hcp cluster

### DIFF
--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
@@ -39,6 +39,16 @@ test.describe.serial(
       await machinePoolsPage.goToMachinePoolsTab();
     });
 
+    test('Verify delete is disabled for default machine pools due to minimum count restrictions', async ({
+      machinePoolsPage,
+    }) => {
+      const minCountTooltip =
+        'There needs to be at least 2 nodes without taints across all machine pools';
+
+      await machinePoolsPage.verifyDeleteDisabled('workers-0', minCountTooltip);
+      await machinePoolsPage.verifyDeleteDisabled('workers-1', minCountTooltip);
+    });
+
     test('Verify autoscaling min and max allow 0 for HCP in Add machine pool modal', async ({
       machinePoolsPage,
     }) => {
@@ -83,7 +93,7 @@ test.describe.serial(
       const firstZone = Object.keys(zones || {})[0];
       await machinePoolsPage.selectPrivateSubnet(zones[firstZone].PRIVATE_SUBNET_NAME);
 
-      await machinePoolsPage.setAutoscalingRange('0', '0');
+      await machinePoolsPage.setAutoscalingRange('0', '1');
 
       await machinePoolsPage.clickAddMachinePoolSubmitButton();
       await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
@@ -100,7 +110,7 @@ test.describe.serial(
       const firstZone = Object.keys(zones || {})[0];
       await machinePoolsPage.selectPrivateSubnet(zones[firstZone].PRIVATE_SUBNET_NAME);
 
-      await machinePoolsPage.setAutoscalingRange('0', '0');
+      await machinePoolsPage.setAutoscalingRange('0', '1');
 
       await machinePoolsPage.openTaintsSection();
       await machinePoolsPage.setTaint(0, 'e2e-test', 'tainted');
@@ -119,7 +129,7 @@ test.describe.serial(
 
       await expect(machinePoolsPage.autoscalingCheckbox()).toBeChecked();
       await expect(machinePoolsPage.autoscaleMinInput()).toHaveValue('0');
-      await expect(machinePoolsPage.autoscaleMaxInput()).toHaveValue('0');
+      await expect(machinePoolsPage.autoscaleMaxInput()).toHaveValue('1');
 
       // No validation error should be shown for min=0 on HCP
       await expect(machinePoolsPage.getByText(/Input cannot be less than/)).toBeHidden();
@@ -190,21 +200,17 @@ test.describe.serial(
       await machinePoolsPage.cancelMachinePoolModalButton().click();
     });
 
-    test('Verify delete is disabled for default machine pools due to minimum count restrictions', async ({
-      machinePoolsPage,
-    }) => {
-      const minCountTooltip =
-        'There needs to be at least 2 nodes without taints across all machine pools';
-
-      await machinePoolsPage.verifyDeleteDisabled('workers-0', minCountTooltip);
-      await machinePoolsPage.verifyDeleteDisabled('workers-1', minCountTooltip);
-    });
-
     test('Scale tainted pool mpAutoscale2 max > 2 and verify delete still disabled for default pools', async ({
       machinePoolsPage,
     }) => {
       await machinePoolsPage.editMachinePool(mpAutoscale2);
       await machinePoolsPage.autoscaleMaxInput().fill('3');
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
+
+      await machinePoolsPage.editMachinePool(mpAutoscale1);
+      await machinePoolsPage.openTaintsSection();
+      await machinePoolsPage.setTaint(0, 'e2e-test', 'tainted');
       await machinePoolsPage.clickAddMachinePoolSubmitButton();
       await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
 
@@ -215,37 +221,33 @@ test.describe.serial(
       await machinePoolsPage.verifyDeleteDisabled('workers-1', minCountTooltip);
     });
 
-    test('Edit workers-0 and verify autoscaleMax=0 and nodeCount=0 are rejected for untainted pool', async ({
+    test('Edit workers-0 and verify autoscaleMax=0 is rejected by capacity validation and nodeCount=0 is rejected', async ({
       machinePoolsPage,
     }) => {
+      // workers-0 max=2 should be accepted
       await machinePoolsPage.editMachinePool('workers-0');
+      await machinePoolsPage.autoscaleMaxInput().fill('2');
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
 
-      // Set autoscale max to 0 and verify rejection
-      await machinePoolsPage.autoscaleMaxInput().fill('0');
-      await machinePoolsPage.autoscaleMaxInput().blur();
-      await expect(
-        machinePoolsPage.getByText(
-          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
-        ),
-      ).toBeVisible();
-      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
 
-      // Disable autoscaling and set node count to 0
+
+      // workers-1 node count=0 without autoscaling should be accepted
+      await machinePoolsPage.editMachinePool('workers-1');
       await machinePoolsPage.autoscalingCheckbox().uncheck();
       await machinePoolsPage.nodeCountInput().fill('0');
-      await machinePoolsPage.nodeCountInput().blur();
-      await expect(machinePoolsPage.getByText(/Input cannot be less than \d+\./)).toBeVisible();
-      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+      await machinePoolsPage.clickAddMachinePoolSubmitButton();
+      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
 
-      await machinePoolsPage.cancelMachinePoolModalButton().click();
-    });
 
-    test('Adjust workers-0 and workers-1 max and verify capacity validation', async ({
-      machinePoolsPage,
-    }) => {
-      // workers-0 max=0 should be rejected (untainted minimum not met)
       await machinePoolsPage.editMachinePool('workers-0');
+      // For HCP, max=0 is rejected as min max requirement is now 1
       await machinePoolsPage.autoscaleMaxInput().fill('0');
+      await machinePoolsPage.autoscaleMaxInput().blur();
+      await expect(machinePoolsPage.getByText(/Max nodes must be greater than 0./)).toBeVisible();
+      await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
+      // For HCP, max=1 is rejected as minimum untainted node count is 2 per cluster
+      await machinePoolsPage.autoscaleMaxInput().fill('1');
       await machinePoolsPage.autoscaleMaxInput().blur();
       await expect(
         machinePoolsPage.getByText(
@@ -262,35 +264,16 @@ test.describe.serial(
           /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
         ),
       ).toBeHidden();
-      await machinePoolsPage.clickAddMachinePoolSubmitButton();
-      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
 
-      // workers-1 max=0 should now be accepted (workers-0 max=2 covers the minimum)
-      await machinePoolsPage.editMachinePool('workers-1');
-      await machinePoolsPage.autoscaleMaxInput().fill('0');
-      await machinePoolsPage.autoscaleMaxInput().blur();
-      await expect(
-        machinePoolsPage.getByText(
-          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
-        ),
-      ).toBeHidden();
-      await machinePoolsPage.clickAddMachinePoolSubmitButton();
-      await expect(machinePoolsPage.machinePoolModal()).toBeHidden({ timeout: 60000 });
-
-      // workers-0 max=1 should be rejected (workers-1 is now 0, so workers-0 alone must cover 2)
-      await machinePoolsPage.editMachinePool('workers-0');
-      await machinePoolsPage.autoscaleMaxInput().fill('1');
-      await machinePoolsPage.autoscaleMaxInput().blur();
-      await expect(
-        machinePoolsPage.getByText(
-          /Max nodes must be at least \d+ to satisfy the cluster-wide untainted-node minimum/,
-        ),
-      ).toBeVisible();
+      // Disable autoscaling and set node count to 0
+      await machinePoolsPage.autoscalingCheckbox().uncheck();
+      await machinePoolsPage.nodeCountInput().fill('0');
+      await machinePoolsPage.nodeCountInput().blur();
+      await expect(machinePoolsPage.getByText(/Input cannot be less than \d+\./)).toBeVisible();
       await expect(machinePoolsPage.addMachinePoolSubmitButton()).toBeDisabled();
 
       await machinePoolsPage.cancelMachinePoolModalButton().click();
-
-      // Verify delete state: workers-0 max=2, workers-1 max=0
+      // Verify delete state: workers-0 max=2, workers-1 node count=0
       // Removing workers-0 leaves 0 untainted capacity → delete disabled
       await machinePoolsPage.verifyDeleteDisabled(
         'workers-0',

--- a/playwright/page-objects/machine-pools-page.ts
+++ b/playwright/page-objects/machine-pools-page.ts
@@ -272,7 +272,7 @@ export class MachinePoolsPage extends BasePage {
 
   async resetMachinePoolAutoscaling(id: string, min: string, max: string): Promise<void> {
     await this.editMachinePool(id);
-
+    await this.autoscalingCheckbox().check();
     const currentMin = await this.autoscaleMinInput().inputValue();
     const currentMax = await this.autoscaleMaxInput().inputValue();
 


### PR DESCRIPTION
# Summary

Updated day2 spec to support min maximum node count >=1 for hcp cluster

# Jira

Fixes [OCMUI-4540](https://issues.redhat.com/browse/OCMUI-4540) 

# Additional information

Updated end to end test case spec `rosa-cluster-hosted-machine-pool-node-count.spec.ts ` based on the new requirement on min maximum node count >=1 for hcp cluster


# How to Test

1. Start the local server from feature PR https://github.com/RedHatInsights/uhc-portal/pull/462 
2. Download this PR.
3. Configure the playwright.env.json with below definition in app root folder.
```
{
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_AWS_ID": "your aws id",
  "QE_AWS_BILLING_ID" : "your aws billing id",
  "QE_AWS_REGION": "us-west-2",
  "QE_ACCOUNT_ROLE_PREFIX": "cypress-account-roles",
  "QE_OIDC_CONFIG_ID": "<oidc config id from your ocm org>",
  "QE_INFRA_REGIONS": {
    "us-west-2": [
      {
        "VPC-ID": "your vpc id",
        "VPC_NAME": "your vpc name",
        "SUBNETS": {
          "ZONES": {
            "us-west-2a": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2b": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            },
            "us-west-2c": {
              "PUBLIC_SUBNET_NAME": "public subnet name",
              "PUBLIC_SUBNET_ID": "public subnet id",
              "PRIVATE_SUBNET_NAME": "private subnet name",
              "PRIVATE_SUBNET_ID": "private subnet id"
            }
          }
        }
      }
    ]
  }
}
```
4. Replace with VPC details (need a vpc in us-west-2 region with three public and private subnets), your credentials and AWS definition
5. Create account role in your OCM org with prefix "cypress-account-roles"
6. Make sure you linked ocm-role, user-role in your OCM org ( Your test user must be in the same ocm org)
7. Run the below test case
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts        
```
8. Wait for the cluster installation to complete.
Run the below test case
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts 
```

# Screen Captures

```
% BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ yarn playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
yarn run v1.22.22
$ /Users/jmekkatt/Jaya-workspace/uhc-portal/node_modules/.bin/playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-machine-pool-node-count.spec.ts
🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 14 tests using 1 worker
  14 passed (1.6m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 96.82s.

```

[OCMUI-4540]: https://redhat.atlassian.net/browse/OCMUI-4540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ