### PR TITLE
OCMUI-4541: fix failing playwright e2e spec on rosa getstarted page feature

### DIFF
--- a/playwright/page-objects/rosa-getstarted-page.ts
+++ b/playwright/page-objects/rosa-getstarted-page.ts
@@ -1,5 +1,6 @@
 import { Page, Locator, expect } from '@playwright/test';
 import { BasePage } from './base-page';
+import { DEFAULT_NAVIGATION_TIMEOUT } from '../support/playwright-constants';
 
 /**
  * ROSA Get Started page object for Playwright tests
@@ -145,8 +146,18 @@ export class RosaGetStartedPage extends BasePage {
   }
 
   async isLinkAccessSuccess(link: string): Promise<void> {
-    const response = await this.page.request.get(link);
-    expect(response.status()).toBe(200);
+    // page.request.get() has a different TLS stack and cannot run JS challenges, so
+    // CDNs (docs.redhat.com, access.redhat.com) return 403 even with browser headers.
+    // Opening a new tab in the same browser context uses the real Chromium engine with-
+    // proper TLS fingerprinting and JS challenge execution, while preserving cookies.
+    const newPage = await this.page.context().newPage();
+    try {
+      const response = await newPage.goto(link, { waitUntil: 'commit', timeout: DEFAULT_NAVIGATION_TIMEOUT });
+      const status = response?.status();
+      expect(status, `Expected link to be reachable but got ${status}: ${link}`).toBe(200);
+    } finally {
+      await newPage.close();
+    }
   }
 
   // Additional helper methods for input field validation


### PR DESCRIPTION
# Summary

Fix failing playwright e2e spec on rosa getstarted page feature

# Jira
 Fixes [OCMUI-4541](https://issues.redhat.com/browse/OCMUI-4541)

# Additional information


# How to Test
Run the below test case spec.
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa/rosa-cluster-getstarted-page.spec.ts
```

# Screen Captures

```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/rosa/rosa-cluster-getstarted-page.spec.ts
yarn run v1.22.22
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 8 tests using 1 worker
  8 passed (1.2m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 70.41s.

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-4541]: https://redhat.atlassian.net/browse/OCMUI-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ