### PR TITLE
OCMUI-2963:E2e playwright tests for htpasswd IDP definitions

### DIFF
--- a/playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts
+++ b/playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts
@@ -1,0 +1,224 @@
+import { expect, test } from '../../fixtures/pages';
+
+const {
+  'rosa-hosted-public-advanced': clusterProfile,
+} = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const htpasswdProfile = require('../../fixtures/access-control/identity-provider-htpasswd.json');
+
+const clusterName = process.env.CLUSTER_NAME || clusterProfile['day1-profile'].ClusterName;
+const commonIdpName = htpasswdProfile.Htpasswd.Common.IDPName;
+const manualProfile = htpasswdProfile.Htpasswd.Manual;
+
+// Short suffix makes each run's IDP names unique, preventing collisions on retries or shared clusters.
+const runId = Math.random().toString(36).slice(2, 5);
+const htpasswdIdpNames = [`HtpasswdSingleUser-${runId}`, `HtpasswdMultipleUsers-${runId}`];
+// >10 users required to exercise per-page-10 pagination; +1 extra reserved for the add-user edit modal test
+const BULK_USER_COUNT = 15;
+const bulkUsers = Array.from({ length: BULK_USER_COUNT + 1 }, (_, i) => `ocmplaywright${i + 1}`);
+
+test.describe.serial(
+  'ROSA Hosted Public Cluster - Htpasswd IDP validation (OCP-42373, OCP-42372, OCP-28661)',
+  { tag: ['@day2', '@access-control', '@rosa-hosted', '@hcp', '@idp', '@htpasswd'] },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test.afterAll(async ({ clusterIdentityProviderPage }) => {
+      for (const idpName of [htpasswdIdpNames[0], htpasswdIdpNames[1]]) {
+        await clusterIdentityProviderPage.deleteHtpasswdIDP(idpName).catch(() => {});
+      }
+    });
+
+    test(`Navigate to the ROSA Hosted Access Control tab for ${clusterName} cluster`, async ({
+      clusterListPage,
+      clusterRolesAndAccessPage,
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterRolesAndAccessPage.goToAccessControlTab();
+      await clusterIdentityProviderPage.goToIdentityProvidersTab();
+    });
+
+    test(`Validate Htpasswd IDP form field errors for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await expect(
+        clusterIdentityProviderPage.getByText(commonIdpName.DefaultNameInformation),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(' ');
+      await clusterIdentityProviderPage.htpasswdNameInput().blur();
+      await expect(
+        clusterIdentityProviderPage.getByText(commonIdpName.EmptyNameError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage
+        .htpasswdNameInput()
+        .fill(commonIdpName.InvalidHtPasswdName[0]);
+      await clusterIdentityProviderPage.htpasswdNameInput().blur();
+      await expect(
+        clusterIdentityProviderPage.getByText(commonIdpName.InvalidHtPasswdNameError),
+      ).toBeVisible();
+
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Usernames.DefaultUsernameInformation),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(' ');
+      await clusterIdentityProviderPage.htpasswdUsernameInput().clear();
+      await clusterIdentityProviderPage.htpasswdUsernameInput().blur();
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Usernames.EmptyUserNameError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage
+        .htpasswdUsernameInput()
+        .fill(manualProfile.Usernames.InvalidUserNameInput[0]);
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Usernames.InValidUserNameError),
+      ).toBeVisible();
+
+      for (const info of manualProfile.Password.DefaultPasswordInformation) {
+        await expect(clusterIdentityProviderPage.getByText(info)).toBeVisible();
+      }
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Password.ConfirmPassword),
+      ).toBeVisible();
+
+      await expect(clusterIdentityProviderPage.addUserButton()).toBeDisabled();
+      await clusterIdentityProviderPage.cancelIdpForm();
+    });
+
+    test(`Create Htpasswd IDP with a single user for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(htpasswdIdpNames[0]);
+      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(bulkUsers[1]);
+      await clusterIdentityProviderPage.fillSuggestedPassword();
+      await clusterIdentityProviderPage.fillSuggestedConfirmPassword();
+
+      await clusterIdentityProviderPage.idpFormSubmitButton().click();
+      await clusterIdentityProviderPage.waitForIdpToAppearInTable(htpasswdIdpNames[0]);
+    });
+
+    test(`Create Htpasswd IDP  with multiple users for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      for (let i = 0; i < BULK_USER_COUNT; i++) {
+        const isLast = i === BULK_USER_COUNT - 1;
+
+        await clusterIdentityProviderPage.htpasswdUsernameInput().fill(bulkUsers[i]);
+        await clusterIdentityProviderPage.fillSuggestedPassword();
+        await clusterIdentityProviderPage.fillSuggestedConfirmPassword();
+
+        if (!isLast) {
+          await clusterIdentityProviderPage.addUserButton().click();
+        }
+      }
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(htpasswdIdpNames[1]);
+      await clusterIdentityProviderPage.idpFormSubmitButton().click();
+      await clusterIdentityProviderPage.waitForIdpToAppearInTable(htpasswdIdpNames[1]);
+    });
+
+    test(`Verify IDP table shows Name, Type and Auth callback URL columns for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      for (const column of ['Name', 'Type', 'Auth callback URL']) {
+        await expect(
+          clusterIdentityProviderPage
+            .identityProvidersTable()
+            .getByRole('columnheader')
+            .filter({ hasText: column }),
+        ).toBeVisible({ timeout: 20000 });
+      }
+    });
+
+    test(`Expand  IDP collapsible and verify users are listed`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.identityProviderExpandToggle(htpasswdIdpNames[1]).click();
+      await expect(clusterIdentityProviderPage.getByText(bulkUsers[3])).toBeVisible();
+    });
+
+    test(`Open Edit modal for an IDP and verify user filter behaviour`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.editHtpasswdIDP(htpasswdIdpNames[1]);
+
+      await expect(clusterIdentityProviderPage.editIdpPageTitle()).toBeVisible();
+      await expect(clusterIdentityProviderPage.getByText(bulkUsers[1])).toBeVisible();
+
+      await clusterIdentityProviderPage
+        .filterByUsernameInput()
+        .fill(manualProfile.Usernames.InvalidUserNameInput[0]);
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Usernames.NoMatchingUserName),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.clearAllFiltersButton().click();
+      await clusterIdentityProviderPage.scrollToBottom();
+    });
+
+    test(`Verify edit modal user table pagination for an IDP`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.scrollToBottom();
+      await expect(clusterIdentityProviderPage.editModalUsersTableRows()).toHaveCount(
+        BULK_USER_COUNT,
+      );
+
+      await clusterIdentityProviderPage.itemPerPage().click();
+      await clusterIdentityProviderPage.clickPerPageItem('10');
+      await expect(clusterIdentityProviderPage.editModalUsersTableRows()).toHaveCount(
+        Math.min(BULK_USER_COUNT, 10),
+      );
+
+      await clusterIdentityProviderPage.itemPerPage().click();
+      await clusterIdentityProviderPage.clickPerPageItem('20');
+      await expect(clusterIdentityProviderPage.editModalUsersTableRows()).toHaveCount(
+        BULK_USER_COUNT,
+      );
+
+      await clusterIdentityProviderPage.itemPerPage().click();
+      await clusterIdentityProviderPage.clickPerPageItem('50');
+
+      await clusterIdentityProviderPage.itemPerPage().click();
+      await clusterIdentityProviderPage.clickPerPageItem('100');
+    });
+
+    test(`Add a new user to an IDP via the edit modal`, async ({ clusterIdentityProviderPage }) => {
+      await clusterIdentityProviderPage.addUserButton().click();
+
+      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(bulkUsers[BULK_USER_COUNT]);
+      await clusterIdentityProviderPage.fillSuggestedPassword();
+      await clusterIdentityProviderPage.fillSuggestedConfirmPassword();
+
+      await clusterIdentityProviderPage.addUserModalSubmitButton().click();
+      await clusterIdentityProviderPage.waitForAddUserDialogToClose();
+    });
+
+    test(`Delete both htpasswd IDPs created during the test for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.goToAccessControlTab();
+
+      await clusterIdentityProviderPage.deleteHtpasswdIDP(htpasswdIdpNames[0]);
+      await clusterIdentityProviderPage.waitForDeleteIdpDialogToClose();
+
+      await clusterIdentityProviderPage.deleteHtpasswdIDP(htpasswdIdpNames[1]);
+      await clusterIdentityProviderPage.waitForDeleteIdpDialogToClose();
+    });
+  },
+);

--- a/playwright/e2e/access-control/identity-provider-htpasswd-upload.spec.ts
+++ b/playwright/e2e/access-control/identity-provider-htpasswd-upload.spec.ts
@@ -1,0 +1,514 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { expect, test } from '../../fixtures/pages';
+
+const {
+  'rosa-hosted-public-advanced': clusterProfile,
+} = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const htpasswdProfile = require('../../fixtures/access-control/identity-provider-htpasswd.json');
+const clusterName = process.env.CLUSTER_NAME || clusterProfile['day1-profile'].ClusterName;
+const invalidFixtures = htpasswdProfile.Htpasswd.Upload.InvalidFixtures;
+
+// Per-run suffix prevents IDP name collisions across retries or shared clusters.
+const runId = Math.random().toString(36).slice(2, 5);
+const validIdpNames = [
+  `HtpasswdUpload1-${runId}`,
+  `HtpasswdUpload2-${runId}`,
+  `HtpasswdUploadTxt-${runId}`,
+];
+
+// Bcrypt-hashed htpasswd file contents are kept here (not in JSON) to avoid
+// false-positive sensitive-content scanner failures on fixture files.
+// Single shared hash used across all entries — tests validate file format, not password uniqueness.
+const H = '$2y$05$uDMntF9GB8MScvn2oo3NQO8j56WIGY4G2R5/qKfyVZZP1ljbI.aLa'; // notsecret
+
+const htpasswdFileContents = {
+  MainHtpasswd: {
+    extension: 'htpasswd',
+    content: [`example-user1:${H}`, `example-user2:${H}`].join('\n'),
+  },
+  TxtExtension: {
+    extension: 'txt',
+    content: [`example-user3:${H}`, `example-user4:${H}`, `example-user5:${H}`].join('\n'),
+  },
+  ModalValid: {
+    extension: 'htpasswd',
+    content: [`example-user6:${H}`, `example-user7:${H}`, `example-user8:${H}`].join('\n'),
+  },
+  ModalValidTxt: {
+    extension: 'txt',
+    content: [`example-user9:${H}`, `example-user10:${H}`, `example-user11:${H}`].join('\n'),
+  },
+  InvalidEmptyUsernames: {
+    extension: 'htpasswd',
+    content: `:${H}`,
+  },
+  InvalidEmptyPassword: {
+    extension: 'htpasswd',
+    content: 'example-user12:',
+  },
+  InvalidPlainPassword: {
+    extension: 'htpasswd',
+    content: 'example-user13:plaintext',
+  },
+  InvalidDuplicateUsernames: {
+    extension: 'htpasswd',
+    content: [`example-user14:${H}`, `example-user15:${H}`, `example-user14:${H}`].join('\n'),
+  },
+  InvalidEmptyFile: {
+    extension: 'htpasswd',
+    content: '',
+  },
+} as const;
+
+/**
+ * Writes the given content to a single shared temp file with the specified extension,
+ * overwriting any previous content. Returns the file path for use with setInputFiles.
+ */
+function writeFixtureFile(content: string, extension = 'htpasswd'): string {
+  const filePath = path.join(os.tmpdir(), `htpasswd-test-fixture.${extension}`);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+test.describe.serial(
+  'ROSA Hosted Public Cluster - Htpasswd IDP upload file validation(OCP-42373)',
+  { tag: ['@day2', '@access-control', '@rosa-hosted', '@hcp', '@idp', '@htpasswd'] },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test.afterAll(
+      async ({
+        navigateTo,
+        clusterListPage,
+        clusterRolesAndAccessPage,
+        clusterIdentityProviderPage,
+      }) => {
+        await navigateTo('cluster-list');
+        await clusterListPage.waitForDataReady();
+        await clusterListPage.filterTxtField().fill(clusterName);
+        await clusterListPage.waitForDataReady();
+        await clusterListPage.openClusterDefinition(clusterName);
+        await clusterRolesAndAccessPage.goToAccessControlTab();
+        await clusterIdentityProviderPage.goToIdentityProvidersTab();
+
+        for (const idpName of validIdpNames) {
+          await clusterIdentityProviderPage.deleteHtpasswdIDP(idpName).catch(() => {});
+          await clusterIdentityProviderPage.waitForDeleteIdpDialogToClose().catch(() => {});
+        }
+      },
+    );
+
+    test(`Navigate to the ROSA Hosted Access Control tab for ${clusterName} cluster`, async ({
+      clusterListPage,
+      clusterRolesAndAccessPage,
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterRolesAndAccessPage.goToAccessControlTab();
+      await clusterIdentityProviderPage.goToIdentityProvidersTab();
+    });
+
+    test(`Validate htpasswd IDP upload form displays correct radio option and file input for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await expect(clusterIdentityProviderPage.uploadHtpasswdRadio()).toBeVisible();
+
+      await clusterIdentityProviderPage.selectUploadMode();
+
+      await expect(clusterIdentityProviderPage.browseButton()).toBeVisible();
+      await expect(clusterIdentityProviderPage.htpasswdFileInput()).toBeAttached();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Validate htpasswd IDP upload form field errors for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await expect(
+        clusterIdentityProviderPage.getByText(
+          htpasswdProfile.Htpasswd.Common.IDPName.DefaultNameInformation,
+        ),
+      ).toBeVisible();
+      await clusterIdentityProviderPage.selectUploadMode();
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Reject htpasswd file with empty usernames for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyUsernames.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyUsernames.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Reject htpasswd file with empty passwords for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyPassword.content),
+      );
+
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyPassword.ExpectedError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Reject htpasswd file with non-hashed plaintext passwords for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(htpasswdFileContents.InvalidPlainPassword.content),
+      );
+
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.PlainPassword.ExpectedError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Reject htpasswd file with duplicate usernames for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(htpasswdFileContents.InvalidDuplicateUsernames.content),
+      );
+
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.DuplicateUsernames.ExpectedError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Reject empty htpasswd file with no users or passwords for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyFile.content),
+      );
+
+      await expect(clusterIdentityProviderPage.idpFormSubmitButton()).toBeDisabled();
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyFile.ExpectedError),
+      ).toBeVisible();
+
+      await clusterIdentityProviderPage.cancelLink().click();
+    });
+
+    test(`Create htpasswd IDP using a .txt file upload for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[2]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(
+          htpasswdFileContents.TxtExtension.content,
+          htpasswdFileContents.TxtExtension.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.clearFileButton()).toBeVisible();
+
+      await clusterIdentityProviderPage.idpFormSubmitButton().click();
+      await clusterIdentityProviderPage.waitForIdpToAppearInTable(validIdpNames[2]);
+    });
+
+    test(`Create htpasswd IDP using upload mode for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[0]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.clearFileButton()).toBeVisible();
+
+      await clusterIdentityProviderPage.idpFormSubmitButton().click();
+      await clusterIdentityProviderPage.waitForIdpToAppearInTable(validIdpNames[0]);
+    });
+
+    test(`Verify uploaded htpasswd IDP appears in the identity providers table`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await expect(clusterIdentityProviderPage.identityProviderRow(validIdpNames[0])).toBeVisible();
+    });
+
+    test(`Clear uploaded file and re-upload for htpasswd IDP for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openHtpasswdForm();
+
+      await clusterIdentityProviderPage.htpasswdNameInput().fill(validIdpNames[1]);
+      await clusterIdentityProviderPage.selectUploadMode();
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.clearFileButton()).toBeVisible();
+      await clusterIdentityProviderPage.clearFileButton().click();
+
+      await expect(clusterIdentityProviderPage.browseButton()).toBeVisible();
+      await expect(clusterIdentityProviderPage.clearFileButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadHtpasswdFile(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+
+      await clusterIdentityProviderPage.idpFormSubmitButton().click();
+      await clusterIdentityProviderPage.waitForIdpToAppearInTable(validIdpNames[1]);
+    });
+
+    // ==================== Edit IDP - Upload htpasswd file modal ====================
+
+    test(`Open edit page for an IDP and verify upload htpasswd file button is visible`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.editHtpasswdIDP(validIdpNames[0]);
+
+      await expect(clusterIdentityProviderPage.editIdpPageTitle()).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadHtpasswdFileToolbarButton()).toBeVisible();
+    });
+
+    test(`Verify upload modal opens and submit is disabled when no file is selected for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+
+      await expect(clusterIdentityProviderPage.uploadFileModalBrowseButton()).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Reject upload modal file with empty usernames for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyUsernames.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyUsernames.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Reject upload modal file with empty passwords for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyPassword.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyPassword.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Reject upload modal file with non-hashed plaintext passwords for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(htpasswdFileContents.InvalidPlainPassword.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.PlainPassword.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Reject upload modal file with duplicate usernames for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(htpasswdFileContents.InvalidDuplicateUsernames.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.DuplicateUsernames.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Reject empty htpasswd file in upload modal for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(htpasswdFileContents.InvalidEmptyFile.content),
+      );
+
+      await expect(
+        clusterIdentityProviderPage.getByText(invalidFixtures.EmptyFile.ExpectedError),
+      ).toBeVisible();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Clear and re-upload file in the upload modal for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.uploadFileModalClearButton()).toBeVisible();
+      await clusterIdentityProviderPage.uploadFileModalClearButton().click();
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeDisabled();
+
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeEnabled();
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Verify backend error when uploading a file with usernames that already exist in the IDP for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(
+          htpasswdFileContents.MainHtpasswd.content,
+          htpasswdFileContents.MainHtpasswd.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeEnabled();
+      await clusterIdentityProviderPage.uploadFileModalSubmitButton().click();
+
+      await expect(clusterIdentityProviderPage.uploadModalErrorAlert()).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(clusterIdentityProviderPage.uploadModalErrorAlert()).toContainText(
+        htpasswdProfile.Htpasswd.Upload.DuplicateUsernameErrorPattern,
+      );
+
+      await clusterIdentityProviderPage.uploadFileModalCancelButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Successfully upload a valid htpasswd file with new users via the upload modal for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(
+          htpasswdFileContents.ModalValid.content,
+          htpasswdFileContents.ModalValid.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeEnabled();
+      await clusterIdentityProviderPage.uploadFileModalSubmitButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+
+    test(`Successfully upload a .txt htpasswd file with new users via the upload modal for ${clusterName}`, async ({
+      clusterIdentityProviderPage,
+    }) => {
+      await clusterIdentityProviderPage.openUploadFileModal();
+      await clusterIdentityProviderPage.uploadFileInModal(
+        writeFixtureFile(
+          htpasswdFileContents.ModalValidTxt.content,
+          htpasswdFileContents.ModalValidTxt.extension,
+        ),
+      );
+
+      await expect(clusterIdentityProviderPage.uploadFileModalSubmitButton()).toBeEnabled();
+      await clusterIdentityProviderPage.uploadFileModalSubmitButton().click();
+      await clusterIdentityProviderPage.waitForUploadFileModalToClose();
+    });
+  },
+);

--- a/playwright/fixtures/access-control/identity-provider-htpasswd.json
+++ b/playwright/fixtures/access-control/identity-provider-htpasswd.json
@@ -1,0 +1,51 @@
+{
+  "Htpasswd": {
+    "Common": {
+      "IDPName": {
+        "DefaultNameInformation": "Unique name for the identity provider. This cannot be changed later.",
+        "EmptyNameError": "Name must not contain whitespaces",
+        "InvalidHtPasswdName": ["OsdR%%"],
+        "InvalidHtPasswdNameError": "Name should contain only alphanumeric and dashes"
+      }
+    },
+    "Manual": {
+      "Usernames": {
+        "EmptyUserNameError": "Username is required",
+        "InvalidUserNameInput": ["Osd%Rosa:asd", "1234567890"],
+        "InValidUserNameError": "Username must not contain /, :, %, or empty spaces.",
+        "DefaultUsernameInformation": "Unique name of the user within the cluster.",
+        "NoMatchingUserName": "No results found"
+      },
+      "Password": {
+        "DefaultPasswordInformation": [
+          "At least 14 characters (ASCII-standard) without whitespaces",
+          "Include lowercase letters",
+          "Include uppercase letters",
+          "Include numbers or symbols (ASCII-standard characters only)"
+        ],
+        "ConfirmPassword": "Retype the password to confirm."
+      }
+    },
+    "Upload": {
+      "DuplicateUsernameErrorPattern": "already exists",
+      "InvalidFixtures": {
+        "InvalidFileTypeError": "File must be an htpasswd file",
+        "EmptyUsernames": {
+          "ExpectedError": "username cannot be empty"
+        },
+        "EmptyPassword": {
+          "ExpectedError": "Password cannot be empty"
+        },
+        "PlainPassword": {
+          "ExpectedError": "Password for \"example-user13\" does not appear to be hashed"
+        },
+        "DuplicateUsernames": {
+          "ExpectedError": "Duplicate username \"example-user14\""
+        },
+        "EmptyFile": {
+          "ExpectedError": "File is empty or contains no valid entries"
+        }
+      }
+    }
+  }
+}

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -23,6 +23,7 @@ import { ReleasesPage } from '../page-objects/releases-page';
 import { RosaGetStartedPage } from '../page-objects/rosa-getstarted-page';
 import { SubscriptionsPage } from '../page-objects/subscriptions-page';
 import { TokensPage } from '../page-objects/tokens-page';
+import { ClusterIdentityProviderPage } from '../page-objects/cluster-identity-provider-page';
 import { CustomCommands } from '../support/custom-commands';
 import { STORAGE_STATE_PATH } from '../support/playwright-constants';
 
@@ -55,6 +56,7 @@ type WorkerFixtures = {
   subscriptionsPage: SubscriptionsPage;
   tokensPage: TokensPage;
   customCommands: CustomCommands;
+  clusterIdentityProviderPage: ClusterIdentityProviderPage;
 };
 
 /**
@@ -295,6 +297,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     async ({ authenticatedPage }, use) => {
       const customCommands = new CustomCommands(authenticatedPage);
       await use(customCommands);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Worker-scoped: ClusterIdentityProviderPage instance - created once, reused across all tests in suite
+  clusterIdentityProviderPage: [
+    async ({ authenticatedPage }, use) => {
+      const pageObject = new ClusterIdentityProviderPage(authenticatedPage);
+      await use(pageObject);
     },
     { scope: 'worker' },
   ],

--- a/playwright/page-objects/cluster-identity-provider-page.ts
+++ b/playwright/page-objects/cluster-identity-provider-page.ts
@@ -1,0 +1,277 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class ClusterIdentityProviderPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isIdentityProvidersPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/#accessControl/);
+    await expect(this.addIdentityProviderDropdown()).toBeVisible({ timeout: 30000 });
+  }
+
+  // ==================== Navigation ====================
+
+  accessControlTab(): Locator {
+    return this.page.getByRole('link', { name: 'Access control' });
+  }
+
+  identityProvidersTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Identity providers' });
+  }
+
+  async goToAccessControlTab(): Promise<void> {
+    await this.accessControlTab().click();
+    await expect(this.addIdentityProviderDropdown()).toBeVisible({ timeout: 30000 });
+  }
+
+  async goToIdentityProvidersTab(): Promise<void> {
+    await this.identityProvidersTab().click();
+    await expect(this.addIdentityProviderDropdown()).toBeVisible({ timeout: 30000 });
+  }
+
+  // ==================== Add IDP Form ====================
+
+  addIdentityProviderDropdown(): Locator {
+    return this.page.getByRole('button', { name: 'Add identity provider' });
+  }
+
+  htpasswdOption(): Locator {
+    return this.page.getByRole('menuitem', { name: 'htpasswd' });
+  }
+
+  uploadHtpasswdRadio(): Locator {
+    return this.page.getByRole('radio', { name: 'Upload an htpasswd file' });
+  }
+
+  htpasswdFileInput(): Locator {
+    return this.page.locator('input[type="file"]');
+  }
+
+  browseButton(): Locator {
+    return this.page.getByRole('button', { name: 'Browse' });
+  }
+
+  clearFileButton(): Locator {
+    return this.page.getByRole('button', { name: 'Clear' });
+  }
+
+  htpasswdNameInput(): Locator {
+    return this.page.locator('input[id="name"]');
+  }
+
+  htpasswdUsernameInput(): Locator {
+    return this.page.locator('input[id="users.0.username"]');
+  }
+
+  passwordInput(): Locator {
+    return this.page.locator('input[id="users.0.password"]');
+  }
+
+  confirmPasswordInput(): Locator {
+    return this.page.locator('input[id="users.0.password-confirm"]');
+  }
+
+  suggestedPasswordOption(): Locator {
+    return this.page.getByText('Use suggested password:');
+  }
+
+  addUserButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add user' });
+  }
+
+  removeFirstUserButton(): Locator {
+    return this.page.getByTestId('remove-users').first();
+  }
+
+  cancelLink(): Locator {
+    return this.page.getByRole('link', { name: 'Cancel' });
+  }
+
+  idpFormSubmitButton(): Locator {
+    return this.page.locator('button[type="submit"]');
+  }
+
+  // ==================== Identity Providers Table ====================
+
+  identityProvidersTable(): Locator {
+    return this.page.getByRole('grid', { name: /identity providers/i });
+  }
+
+  identityProviderRow(name: string): Locator {
+    return this.identityProvidersTable().getByRole('row').filter({ hasText: name });
+  }
+
+  identityProviderExpandToggle(idpName: string): Locator {
+    return this.identityProviderRow(idpName).getByRole('button', { name: 'Details' });
+  }
+
+  kebabToggleInRow(idpName: string): Locator {
+    return this.identityProviderRow(idpName).getByRole('button', { name: 'Kebab toggle' });
+  }
+
+  editMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Edit' });
+  }
+
+  deleteMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Delete' });
+  }
+
+  confirmDeleteButton(): Locator {
+    return this.page.getByTestId('btn-primary');
+  }
+
+  // ==================== Edit IDP - Upload htpasswd File Modal ====================
+
+  uploadHtpasswdFileToolbarButton(): Locator {
+    return this.page.getByRole('button', { name: 'Upload htpasswd file' });
+  }
+
+  uploadFileModal(): Locator {
+    return this.page.getByRole('dialog', { name: /upload/i });
+  }
+
+  uploadFileModalInput(): Locator {
+    return this.uploadFileModal().locator('input[type="file"]');
+  }
+
+  uploadFileModalBrowseButton(): Locator {
+    return this.uploadFileModal().getByRole('button', { name: 'Browse' });
+  }
+
+  uploadFileModalClearButton(): Locator {
+    return this.uploadFileModal().getByRole('button', { name: 'Clear' });
+  }
+
+  uploadFileModalSubmitButton(): Locator {
+    return this.uploadFileModal().getByRole('button', { name: 'Upload' });
+  }
+
+  uploadFileModalCancelButton(): Locator {
+    return this.uploadFileModal().getByRole('button', { name: 'Cancel' });
+  }
+
+  uploadModalErrorAlert(): Locator {
+    return this.uploadFileModal().getByTestId('alert-error');
+  }
+
+  async openUploadFileModal(): Promise<void> {
+    await this.uploadHtpasswdFileToolbarButton().click();
+    await expect(this.uploadFileModal()).toBeVisible();
+  }
+
+  async uploadFileInModal(filePath: string): Promise<void> {
+    await this.uploadFileModalInput().setInputFiles(filePath);
+  }
+
+  async waitForUploadFileModalToClose(): Promise<void> {
+    await expect(this.uploadFileModal()).toBeHidden({ timeout: 30000 });
+  }
+
+  // ==================== Edit IDP Modal ====================
+
+  editIdpPageTitle(): Locator {
+    return this.page.getByRole('heading', { name: /Edit identity provider:/ });
+  }
+
+  addUserModalSubmitButton(): Locator {
+    return this.page
+      .getByRole('dialog', { name: 'Add user' })
+      .getByRole('button', { name: 'Add user' });
+  }
+
+  editModalUsersTableRows(): Locator {
+    return this.page
+      .getByRole('grid')
+      .getByRole('rowgroup')
+      .getByRole('row')
+      .filter({ has: this.page.getByRole('gridcell') });
+  }
+
+  filterByUsernameInput(): Locator {
+    return this.page.locator('input[aria-label="Filter by username"]');
+  }
+
+  clearAllFiltersButton(): Locator {
+    return this.page.getByRole('button', { name: 'Clear all filters' });
+  }
+
+  // ==================== Pagination ====================
+
+  itemPerPage(): Locator {
+    return this.page.locator('#options-menu-bottom-toggle').last();
+  }
+
+  async clickPerPageItem(count: string): Promise<void> {
+    await this.page.locator(`li[data-action="per-page-${count}"]`).click();
+  }
+
+  // ==================== Actions ====================
+
+  async openHtpasswdForm(): Promise<void> {
+    await this.addIdentityProviderDropdown().click();
+    await this.htpasswdOption().click();
+  }
+
+  async selectUploadMode(): Promise<void> {
+    await this.uploadHtpasswdRadio().click();
+    await expect(this.htpasswdFileInput()).toBeAttached();
+  }
+
+  async uploadHtpasswdFile(filePath: string): Promise<void> {
+    await this.htpasswdFileInput().setInputFiles(filePath);
+  }
+
+  async fillSuggestedPassword(): Promise<void> {
+    await this.passwordInput().click();
+    await this.suggestedPasswordOption().click();
+  }
+
+  async fillSuggestedConfirmPassword(): Promise<void> {
+    await this.confirmPasswordInput().click();
+  }
+
+  async cancelIdpForm(): Promise<void> {
+    const cancelHref = await this.cancelLink().getAttribute('href');
+    await this.page.goto(cancelHref!);
+    await this.goToIdentityProvidersTab();
+  }
+
+  async editHtpasswdIDP(idpName: string): Promise<void> {
+    await this.kebabToggleInRow(idpName).click();
+    await this.editMenuItem().click();
+  }
+
+  async deleteHtpasswdIDP(idpName: string): Promise<void> {
+    await this.kebabToggleInRow(idpName).click();
+    await this.deleteMenuItem().click();
+    await this.confirmDeleteButton().click();
+  }
+
+  async scrollToBottom(): Promise<void> {
+    await this.page.getByTestId('appDrawerContent').evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+  }
+
+  // ==================== Wait helpers ====================
+
+  async waitForIdpToAppearInTable(idpName: string): Promise<void> {
+    await expect(this.identityProviderRow(idpName)).toBeVisible({ timeout: 90000 });
+  }
+
+  async waitForAddUserDialogToClose(): Promise<void> {
+    await expect(this.page.getByRole('dialog', { name: 'Add user' })).toBeHidden({
+      timeout: 30000,
+    });
+  }
+
+  async waitForDeleteIdpDialogToClose(): Promise<void> {
+    await expect(this.page.getByRole('dialog', { name: 'Remove identity provider' })).toBeHidden({
+      timeout: 15000,
+    });
+  }
+}


### PR DESCRIPTION
# Summary

E2e playwright tests for htpasswd IDP (including manual and upload) definitions

# Jira

Fixes [OCMUI-2963](https://issues.redhat.com/browse/OCMUI-2963) 

# Additional information

- New e2e test case specs to cover htpasswd idp features for cluster day2 side.
- The coverage include creation of htpasswd idps via two options : adding users manually and upload from file options.
- The additional fixture and page object definitions are added or updated.

# How to Test
- Download the PR code
- Create a ROSA HCP cluster or use existing ROSA HCP cluster.
- Export the cluster name from your terminal
```
export CLUSTER_NAME=<your clustername>
```
- Run the following command
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts 
```
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/access-control/identity-provider-htpasswd-upload.spec.ts
```


# Screen Captures
identity-provider-htpasswd-upload.spec.ts >> 
```
 BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/access-control/identity-provider-htpasswd-upload.spec.ts 
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 23 tests using 1 worker
  23 passed (2.0m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 118.78s.
```
identity-provider-htpasswd-manual.spec.ts >>
```
 BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ yarn playwright test playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts 
🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 10 tests using 1 worker
  10 passed (2.3m)

To open last HTML report run:

  yarn playwright show-report playwright-artifacts/reports

✨  Done in 141.44s.

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-2963]: https://redhat.atlassian.net/browse/OCMUI-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ