### PR TITLE
OCMUI-3263: feat(playwright): Add GitHub Identity Provider e2e tests (OCP-23708, OCP-32006)

### DIFF
--- a/playwright/e2e/access-control/identity-providers-github.spec.ts
+++ b/playwright/e2e/access-control/identity-providers-github.spec.ts
@@ -1,12 +1,15 @@
 import { expect, test } from '../../fixtures/pages';
 
+const {
+  'rosa-hosted-public-advanced': clusterProfile,
+} = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
 const testData = require('../../fixtures/access-control/identity-providers-github.spec.json');
 
 test.describe.serial(
   'GitHub Identity Provider - Access Control (OCP-23708, OCP-32006)',
-  { tag: ['@day2', '@smoke', '@access-control', '@idp', '@rosa-hosted'] },
+  { tag: ['@day2', '@access-control', '@rosa-hosted', '@hcp', '@idp'] },
   () => {
-    const clusterName = process.env.CLUSTER_NAME || testData.ClusterName;
+    const clusterName = process.env.CLUSTER_NAME || clusterProfile['day1-profile'].ClusterName;
     const clientId = process.env.GITHUB_CLIENT_ID || testData.ClientId;
     const clientSecret = process.env.GITHUB_CLIENT_SECRET || testData.ClientSecret;
     const testOrg = process.env.GITHUB_TEST_ORG || testData.Organization;
@@ -93,7 +96,6 @@ test.describe.serial(
       await expect(identityProvidersPage.nameInput()).toHaveValue(/^GitHub/);
 
       await identityProvidersPage.nameInput().fill(idpName);
-      await expect(identityProvidersPage.nameInput()).toHaveValue(idpName);
       await identityProvidersPage.nameInput().blur();
       await expect(identityProvidersPage.duplicateNameError()).toBeVisible();
       await expect(identityProvidersPage.createButton()).toBeDisabled();

--- a/playwright/e2e/access-control/identity-providers-github.spec.ts
+++ b/playwright/e2e/access-control/identity-providers-github.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test } from '../../fixtures/pages';
+
+const testData = require('../../fixtures/access-control/identity-providers-github.spec.json');
+
+test.describe.serial(
+  'GitHub Identity Provider - Access Control (OCP-23708, OCP-32006)',
+  { tag: ['@day2', '@smoke', '@access-control', '@idp', '@rosa-hosted'] },
+  () => {
+    const clusterName = process.env.CLUSTER_NAME || testData.ClusterName;
+    const clientId = process.env.GITHUB_CLIENT_ID || testData.ClientId;
+    const clientSecret = process.env.GITHUB_CLIENT_SECRET || testData.ClientSecret;
+    const testOrg = process.env.GITHUB_TEST_ORG || testData.Organization;
+
+    const idpNameSuffix = Math.random().toString(36).slice(2, 7);
+    const idpName = `GitHub-${idpNameSuffix}`;
+    const idpNameTeams = `GitHub-Teams-${idpNameSuffix}`;
+
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+    });
+
+    test('Navigate to cluster and Access Control > Identity Providers tab', async ({
+      clusterListPage,
+      identityProvidersPage,
+    }) => {
+      await clusterListPage.isClusterListScreen();
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+      await identityProvidersPage.isIdentityProvidersPage();
+    });
+
+    test('Verify Identity Providers section layout', async ({ identityProvidersPage }) => {
+      await expect(identityProvidersPage.identityProvidersHeading()).toBeVisible();
+      await expect(identityProvidersPage.learnMoreLink()).toBeVisible();
+      await expect(identityProvidersPage.addIdentityProviderDropdown()).toBeVisible();
+    });
+
+    test('Verify Add identity provider dropdown contains GitHub option', async ({
+      identityProvidersPage,
+    }) => {
+      await identityProvidersPage.openAddIdpDropdown();
+      await expect(identityProvidersPage.addIdpDropdownItem('GitHub')).toBeVisible();
+      await identityProvidersPage.pressKey('Escape');
+    });
+
+    test('Create GitHub IDP with Organizations - verify form and submit (OCP-23708)', async ({
+      identityProvidersPage,
+    }) => {
+      await identityProvidersPage.selectIdpType('GitHub');
+
+      await expect(identityProvidersPage.nameInput()).toBeVisible();
+      await expect(identityProvidersPage.clientIdInput()).toBeVisible();
+      await expect(identityProvidersPage.clientSecretInput()).toBeVisible();
+      await expect(identityProvidersPage.hostnameInput()).toBeVisible();
+      await expect(identityProvidersPage.useOrganizationsRadio()).toBeVisible();
+      await expect(identityProvidersPage.useTeamsRadio()).toBeVisible();
+
+      const nameValue = await identityProvidersPage.nameInput().inputValue();
+      expect(nameValue).toMatch(/^GitHub/);
+
+      await expect(identityProvidersPage.createButton()).toBeDisabled();
+
+      await identityProvidersPage.nameInput().clear();
+      await identityProvidersPage.nameInput().fill(idpName);
+      await identityProvidersPage.clientIdInput().fill(clientId);
+      await identityProvidersPage.clientSecretInput().fill(clientSecret);
+      await identityProvidersPage.useOrganizationsRadio().click();
+      await identityProvidersPage.organizationsInput().fill(testOrg);
+
+      await identityProvidersPage.submitCreateAndVerify();
+    });
+
+    test('Verify created GitHub IDP appears in table', async ({ identityProvidersPage }) => {
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+
+      await identityProvidersPage.verifyIdpExists(idpName, 'GitHub');
+      await expect(identityProvidersPage.copyCallbackUrlButton(idpName)).toBeVisible();
+    });
+
+    test('Create GitHub IDP with Teams, Hostname, and CA (OCP-23708)', async ({
+      identityProvidersPage,
+      page,
+    }) => {
+      await page.reload();
+      await identityProvidersPage.goToIdentityProvidersTab();
+      await identityProvidersPage.selectIdpType('GitHub');
+      await expect(identityProvidersPage.nameInput()).toHaveValue(/^GitHub/);
+
+      await identityProvidersPage.nameInput().fill(idpName);
+      await expect(identityProvidersPage.nameInput()).toHaveValue(idpName);
+      await identityProvidersPage.nameInput().blur();
+      await expect(identityProvidersPage.duplicateNameError()).toBeVisible();
+      await expect(identityProvidersPage.createButton()).toBeDisabled();
+
+      await identityProvidersPage.nameInput().clear();
+      await identityProvidersPage.nameInput().fill(idpNameTeams);
+
+      await identityProvidersPage.clientIdInput().fill(clientId);
+      await identityProvidersPage.clientSecretInput().fill(clientSecret);
+
+      await identityProvidersPage.hostnameInput().fill(testData.Hostname);
+      await identityProvidersPage.uploadCaFile(testData.CaContent);
+
+      await identityProvidersPage.useTeamsRadio().click();
+      await identityProvidersPage.teamsInput().fill(testData.Team);
+
+      await identityProvidersPage.submitCreateAndVerify();
+    });
+
+    test('Verify Teams-based GitHub IDP appears in table', async ({ identityProvidersPage }) => {
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+
+      await identityProvidersPage.verifyIdpExists(idpNameTeams, 'GitHub');
+    });
+
+    test('Edit Teams IDP - verify Hostname and CA, validate Hostname required (OCP-32006)', async ({
+      identityProvidersPage,
+      page,
+    }) => {
+      await page.reload();
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+      await identityProvidersPage.clickEditIdp(idpNameTeams);
+      await expect(identityProvidersPage.editIdpHeading()).toBeVisible();
+
+      const hostnameValue = await identityProvidersPage.hostnameInput().inputValue();
+      expect(hostnameValue).toBe(testData.Hostname);
+
+      await expect(identityProvidersPage.caFileTextarea()).toBeVisible();
+
+      await identityProvidersPage.uploadCaFile(testData.CaContent);
+      await identityProvidersPage.hostnameInput().clear();
+      await identityProvidersPage.hostnameInput().blur();
+      await expect(identityProvidersPage.confirmButton()).toBeDisabled();
+
+      await identityProvidersPage.cancelFormAndReturnToIdpTab();
+    });
+
+    test('Edit GitHub IDP - verify pre-filled values including Mapping Method (OCP-32006)', async ({
+      identityProvidersPage,
+    }) => {
+      await identityProvidersPage.clickEditIdp(idpName);
+      await expect(identityProvidersPage.editIdpHeading()).toBeVisible();
+
+      await expect(identityProvidersPage.mappingMethodValue()).toContainText(testData.MappingMethod);
+
+      const clientIdValue = await identityProvidersPage.clientIdInput().inputValue();
+      expect(clientIdValue).toBe(clientId);
+
+      const clientSecretValue = await identityProvidersPage.clientSecretInput().inputValue();
+      expect(clientSecretValue).toBeTruthy();
+
+      await expect(identityProvidersPage.useOrganizationsRadio()).toBeChecked();
+      const orgValue = await identityProvidersPage.organizationsInput().inputValue();
+      expect(orgValue).toBe(testOrg);
+
+      await identityProvidersPage.cancelFormAndReturnToIdpTab();
+    });
+
+    test('Edit GitHub IDP - update Client ID and verify change (OCP-32006)', async ({
+      identityProvidersPage,
+    }) => {
+      await identityProvidersPage.clickEditIdp(idpName);
+      await expect(identityProvidersPage.editIdpHeading()).toBeVisible();
+
+      await identityProvidersPage.clientIdInput().clear();
+      await identityProvidersPage.clientIdInput().blur();
+      await expect(identityProvidersPage.requiredFieldError()).toBeVisible();
+      await expect(identityProvidersPage.confirmButton()).toBeDisabled();
+
+      await identityProvidersPage.clientIdInput().fill(testData.UpdatedClientId);
+
+      await identityProvidersPage.submitEditAndVerify();
+    });
+
+    test('Edit GitHub IDP - switch from Organizations to Teams (OCP-32006)', async ({
+      identityProvidersPage,
+      page,
+    }) => {
+      await page.reload();
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+
+      await identityProvidersPage.clickEditIdp(idpName);
+      await expect(identityProvidersPage.editIdpHeading()).toBeVisible();
+
+      await identityProvidersPage.useTeamsRadio().click();
+      await expect(identityProvidersPage.teamsInput()).toBeVisible();
+      await identityProvidersPage.teamsInput().fill(testData.UpdatedTeam);
+
+      await identityProvidersPage.submitEditAndVerify();
+    });
+
+    test('Delete GitHub IDP (Organizations) and verify removal', async ({ identityProvidersPage }) => {
+      await identityProvidersPage.goToAccessControlTab();
+      await identityProvidersPage.goToIdentityProvidersTab();
+
+      await identityProvidersPage.deleteIdp(idpName);
+      await expect(identityProvidersPage.idpRow(idpName)).toBeHidden({ timeout: 30000 });
+    });
+
+    test('Delete GitHub IDP (Teams) and verify removal', async ({ identityProvidersPage }) => {
+      await identityProvidersPage.deleteIdp(idpNameTeams);
+      await expect(identityProvidersPage.idpRow(idpNameTeams)).toBeHidden({ timeout: 30000 });
+    });
+
+    test.afterAll(async ({ identityProvidersPage }) => {
+      try {
+        await identityProvidersPage.goToAccessControlTab();
+        await identityProvidersPage.goToIdentityProvidersTab();
+
+        for (const name of [idpName, idpNameTeams]) {
+          const idpRowVisible = await identityProvidersPage.idpRow(name).isVisible();
+          if (idpRowVisible) {
+            await identityProvidersPage.deleteIdp(name);
+          }
+        }
+      } catch {
+        console.log('IDP cleanup: some IDPs already deleted or not found');
+      }
+    });
+  },
+);

--- a/playwright/fixtures/access-control/identity-providers-github.spec.json
+++ b/playwright/fixtures/access-control/identity-providers-github.spec.json
@@ -1,0 +1,14 @@
+{
+  "ClusterName": "ply-rosa-hosted-public-advanced",
+  "ClientId": "test-client-id-12345",
+  "ClientSecret": "test-client-secret-67890",
+  "Organization": "ocm-qe-test-org",
+  "Team": "ocm-qe-test-org/test-team",
+  "UpdatedClientId": "updated-client-id-99999",
+  "UpdatedOrganization": "ocm-qe-updated-org",
+  "UpdatedTeam": "ocm-qe-test-org/updated-team",
+  "InvalidTeamFormat": "invalid-team-no-slash",
+  "MappingMethod": "claim",
+  "Hostname": "github.example.com",
+  "CaContent": "-----BEGIN CERTIFICATE-----\nMIICpDCCAYwCCQDU+pQ4P3MQ8jANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\nb2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjAUMRIwEAYD\nVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7\no5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H\n9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZwIDAQABMA0GCSqGSIb3DQEBCwUA\nA4IBAQBvE3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e\n7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ\n-----END CERTIFICATE-----"
+}

--- a/playwright/fixtures/access-control/identity-providers-github.spec.json
+++ b/playwright/fixtures/access-control/identity-providers-github.spec.json
@@ -1,13 +1,10 @@
 {
-  "ClusterName": "ply-rosa-hosted-public-advanced",
   "ClientId": "test-client-id-12345",
   "ClientSecret": "test-client-secret-67890",
   "Organization": "ocm-qe-test-org",
   "Team": "ocm-qe-test-org/test-team",
   "UpdatedClientId": "updated-client-id-99999",
-  "UpdatedOrganization": "ocm-qe-updated-org",
   "UpdatedTeam": "ocm-qe-test-org/updated-team",
-  "InvalidTeamFormat": "invalid-team-no-slash",
   "MappingMethod": "claim",
   "Hostname": "github.example.com",
   "CaContent": "-----BEGIN CERTIFICATE-----\nMIICpDCCAYwCCQDU+pQ4P3MQ8jANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\nb2NhbGhvc3QwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjAUMRIwEAYD\nVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7\no5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H\n9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZwIDAQABMA0GCSqGSIb3DQEBCwUA\nA4IBAQBvE3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e\n7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ3o5e7VvX3p6Z3H9aZ\n-----END CERTIFICATE-----"

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -16,6 +16,7 @@ import { CreateRosaWizardPage } from '../page-objects/create-rosa-wizard-page';
 import { DownloadsPage } from '../page-objects/downloads-page';
 import { ClusterRolesAndAccessPage } from '../page-objects/cluster-roles-access-page';
 import { ClusterSupportPage } from '../page-objects/cluster-support-page';
+import { IdentityProvidersPage } from '../page-objects/identity-providers-page';
 import { OCMRolesAndAccessPage } from '../page-objects/ocm-roles-access-page';
 import { OsdProductPage } from '../page-objects/osd-product-page';
 import { OverviewPage } from '../page-objects/overview-page';
@@ -49,6 +50,7 @@ type WorkerFixtures = {
   downloadsPage: DownloadsPage;
   clusterRolesAndAccessPage: ClusterRolesAndAccessPage;
   clusterSupportPage: ClusterSupportPage;
+  identityProvidersPage: IdentityProvidersPage;
   ocmRolesAndAccessPage: OCMRolesAndAccessPage;
   osdProductPage: OsdProductPage;
   overviewPage: OverviewPage;
@@ -228,6 +230,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   clusterSupportPage: [
     async ({ authenticatedPage }, use) => {
       const pageObject = new ClusterSupportPage(authenticatedPage);
+      await use(pageObject);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Worker-scoped: IdentityProvidersPage instance - created once, reused across all tests in suite
+  identityProvidersPage: [
+    async ({ authenticatedPage }, use) => {
+      const pageObject = new IdentityProvidersPage(authenticatedPage);
       await use(pageObject);
     },
     { scope: 'worker' },

--- a/playwright/page-objects/identity-providers-page.ts
+++ b/playwright/page-objects/identity-providers-page.ts
@@ -1,0 +1,233 @@
+import { expect, Locator } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class IdentityProvidersPage extends BasePage {
+  async isIdentityProvidersPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/#accessControl/);
+    await expect(this.identityProvidersHeading()).toBeVisible();
+  }
+
+  accessControlTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Access control' });
+  }
+
+  identityProvidersTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Identity providers' });
+  }
+
+  async goToAccessControlTab(): Promise<void> {
+    await this.accessControlTab().click();
+    await expect(this.accessControlTab()).toHaveAttribute('aria-selected', 'true');
+  }
+
+  async goToIdentityProvidersTab(): Promise<void> {
+    await this.identityProvidersTab().click();
+    await expect(this.identityProvidersTab()).toHaveAttribute('aria-selected', 'true');
+  }
+
+  identityProvidersHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Identity providers' });
+  }
+
+  learnMoreLink(): Locator {
+    return this.page.getByRole('link', { name: /Learn more/ });
+  }
+
+  addIdentityProviderDropdown(): Locator {
+    return this.page.getByRole('button', { name: 'Add identity provider' });
+  }
+
+  addIdpDropdownItem(idpType: string): Locator {
+    return this.page.getByRole('menuitem', { name: idpType, exact: true });
+  }
+
+  async openAddIdpDropdown(): Promise<void> {
+    await this.addIdentityProviderDropdown().click();
+  }
+
+  async selectIdpType(
+    idpType: 'GitHub' | 'Google' | 'OpenID' | 'LDAP' | 'GitLab' | 'htpasswd',
+  ): Promise<void> {
+    await this.openAddIdpDropdown();
+    const item = this.addIdpDropdownItem(idpType);
+    await item.waitFor({ state: 'attached' });
+    await item.click();
+  }
+
+  idpTable(): Locator {
+    return this.page.getByRole('table', { name: 'Identity Providers' });
+  }
+
+  idpRow(idpName: string): Locator {
+    return this.page.getByRole('row').filter({ hasText: idpName });
+  }
+
+  idpKebabButton(idpName: string): Locator {
+    return this.idpRow(idpName).getByRole('button', { name: 'Kebab toggle' });
+  }
+
+  copyCallbackUrlButton(idpName: string): Locator {
+    return this.idpRow(idpName).getByRole('button', { name: /Copy URL to clipboard/i });
+  }
+
+  editMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Edit' });
+  }
+
+  deleteMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Delete' });
+  }
+
+  async openIdpActionsMenu(idpName: string): Promise<void> {
+    await this.idpKebabButton(idpName).click();
+  }
+
+  async clickEditIdp(idpName: string): Promise<void> {
+    await this.openIdpActionsMenu(idpName);
+    await Promise.all([
+      this.page.waitForURL(/\/edit-idp\//),
+      this.editMenuItem().click(),
+    ]);
+  }
+
+  async clickDeleteIdp(idpName: string): Promise<void> {
+    await this.openIdpActionsMenu(idpName);
+    await this.deleteMenuItem().click();
+  }
+
+  editIdpHeading(): Locator {
+    return this.page.getByRole('heading', { level: 1, name: /Edit identity provider/i });
+  }
+
+  nameInput(): Locator {
+    return this.page.getByRole('textbox', { name: /^name$/i });
+  }
+
+  clientIdInput(): Locator {
+    return this.page.getByLabel('Client ID');
+  }
+
+  clientSecretInput(): Locator {
+    return this.page.getByLabel('Client secret');
+  }
+
+  mappingMethodValue(): Locator {
+    return this.page.getByRole('button', { name: 'Options menu' });
+  }
+
+  hostnameInput(): Locator {
+    return this.page.getByLabel('Hostname');
+  }
+
+  caFileUpload(): Locator {
+    return this.page.locator('input[type="file"]');
+  }
+
+  caFileTextarea(): Locator {
+    return this.page.getByRole('textbox', { name: /CA file/i });
+  }
+
+  useOrganizationsRadio(): Locator {
+    return this.page.getByRole('radio', { name: /Use organizations/i });
+  }
+
+  useTeamsRadio(): Locator {
+    return this.page.getByRole('radio', { name: /Use teams/i });
+  }
+
+  organizationsInput(): Locator {
+    return this.page.getByPlaceholder('e.g. org').first();
+  }
+
+  teamsInput(): Locator {
+    return this.page.getByPlaceholder('e.g. org/team').first();
+  }
+
+  createButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add', exact: true });
+  }
+
+  confirmButton(): Locator {
+    return this.page.getByRole('button', { name: 'Save' });
+  }
+
+  cancelLink(): Locator {
+    return this.page.getByRole('link', { name: 'Cancel' });
+  }
+
+  async cancelFormAndReturnToIdpTab(): Promise<void> {
+    await this.cancelLink().click();
+    await this.goToIdentityProvidersTab();
+  }
+
+  deleteConfirmButton(): Locator {
+    return this.page.getByTestId('btn-primary');
+  }
+
+  requiredFieldError(): Locator {
+    return this.page.getByText(/Field is required|is required/i);
+  }
+
+  duplicateNameError(): Locator {
+    return this.page.getByText(/is already taken/i);
+  }
+
+  async uploadCaFile(content: string): Promise<void> {
+    await this.caFileUpload().setInputFiles({
+      name: 'ca.crt',
+      mimeType: 'application/x-pem-file',
+      buffer: Buffer.from(content),
+    });
+  }
+
+  async submitCreateAndVerify(): Promise<void> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'POST' &&
+          resp.url().includes('/identity_providers') &&
+          resp.status() === 201,
+        { timeout: 30000 },
+      ),
+      this.createButton().click(),
+    ]);
+    expect(response.status()).toBe(201);
+  }
+
+  async submitEditAndVerify(): Promise<void> {
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'PATCH' &&
+          resp.url().includes('/identity_providers/') &&
+          resp.status() === 200,
+        { timeout: 30000 },
+      ),
+      this.confirmButton().click(),
+    ]);
+    expect(response.status()).toBe(200);
+    await expect(this.editIdpHeading()).toBeHidden({ timeout: 30000 });
+  }
+
+  async deleteIdp(idpName: string): Promise<void> {
+    await this.clickDeleteIdp(idpName);
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'DELETE' && resp.url().includes('/identity_providers/'),
+        { timeout: 30000 },
+      ),
+      this.deleteConfirmButton().click(),
+    ]);
+    expect(response.status()).toBe(204);
+
+    await expect(this.idpRow(idpName)).toBeHidden({ timeout: 30000 });
+  }
+
+  async verifyIdpExists(idpName: string, idpType: string): Promise<void> {
+    await expect(this.idpRow(idpName)).toBeVisible({ timeout: 30000 });
+    await expect(this.idpRow(idpName)).toContainText(idpType);
+  }
+}

--- a/playwright/page-objects/identity-providers-page.ts
+++ b/playwright/page-objects/identity-providers-page.ts
@@ -43,7 +43,14 @@ export class IdentityProvidersPage extends BasePage {
   }
 
   async openAddIdpDropdown(): Promise<void> {
-    await this.addIdentityProviderDropdown().click();
+    const dropdown = this.addIdentityProviderDropdown();
+    await dropdown.waitFor({ state: 'visible' });
+    await dropdown.click();
+    // Webkit occasionally fails to register the first click on PF6 MenuToggle
+    if ((await dropdown.getAttribute('aria-expanded')) !== 'true') {
+      await dropdown.click();
+    }
+    await expect(dropdown).toHaveAttribute('aria-expanded', 'true');
   }
 
   async selectIdpType(
@@ -113,7 +120,10 @@ export class IdentityProvidersPage extends BasePage {
   }
 
   mappingMethodValue(): Locator {
-    return this.page.getByRole('button', { name: 'Options menu' });
+    return this.page
+      .locator('.pf-v6-c-form__group')
+      .filter({ has: this.page.getByText('Mapping method', { exact: true }) })
+      .getByRole('button', { name: 'Options menu' });
   }
 
   hostnameInput(): Locator {
@@ -121,7 +131,7 @@ export class IdentityProvidersPage extends BasePage {
   }
 
   caFileUpload(): Locator {
-    return this.page.locator('input[type="file"]');
+    return this.page.getByTestId('ca-upload-input-file');
   }
 
   caFileTextarea(): Locator {

--- a/playwright/page-objects/identity-providers-page.ts
+++ b/playwright/page-objects/identity-providers-page.ts
@@ -120,10 +120,7 @@ export class IdentityProvidersPage extends BasePage {
   }
 
   mappingMethodValue(): Locator {
-    return this.page
-      .locator('.pf-v6-c-form__group')
-      .filter({ has: this.page.getByText('Mapping method', { exact: true }) })
-      .getByRole('button', { name: 'Options menu' });
+    return this.page.getByRole('button', { name: 'Options menu' });
   }
 
   hostnameInput(): Locator {


### PR DESCRIPTION
# Summary

Migrates Polarion test cases OCP-23708 (Create GitHub IDP) and OCP-32006 (Edit GitHub IDP) to Playwright e2e tests. All automatable steps from both Polarion test cases have been converted. The only skipped steps require real GitHub OAuth login or Pendo analytics observation, which are not feasible in a browser automation context.

Assisted by: Cursor/claude-opus-4.6

# Jira

Fixes [OCMUI-3263](https://redhat.atlassian.net/browse/OCMUI-3263)

# Additional information

- Day 2 tests targeting an existing ROSA HCP cluster
- 13 serial tests covering Access Control & GitHub IDP crud ops including:  navigation, form layout, create with Organizations, create with Teams (Hostname + CA upload), duplicate name validation, table verification, edit pre-fill verification, field validations, PATCH updates, org→teams switch, and cleanup/delete

### Steps not automatable

| Step | Reason |
|------|--------|
| Login to console via IDP (OCP-32006 steps 2, 7) | Requires real GitHub OAuth flow with valid credentials |
| Pendo analytics events (OCP-32006 step 6) | Third-party analytics, not observable in UI |

# How to Test
1. create a Rosa HCP cluster, we'll refer to as "my-rosa-hcp-cluster"
2. In one terminal start local webserver
3. In another terminal run: `bash
CLUSTER_NAME=my-rosa-hcp-cluster yarn playwright-headless --project=chromium playwright/e2e/access-control/identity-providers-github.spec.ts`

Requires a running ROSA HCP cluster with no pre-existing GitHub IDPs. Environment variables `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `GITHUB_TEST_ORG` can be set for real credentials, otherwise test fixture defaults are used.


# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1322" height="820" alt="CleanShot 2026-05-13 at 12 18 57" src="https://github.com/user-attachments/assets/8f317155-dac7-4160-bb52-c9aaa0faca6c" /> | <img width="639" height="546" alt="CleanShot 2026-05-13 at 11 34 07" src="https://github.com/user-attachments/assets/f9228299-756e-4457-8d0b-d1c34b1bd74e" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3263]: https://redhat.atlassian.net/browse/OCMUI-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ