### PR TITLE
OCMUI-4396: ROSA wizard - Set default version from the API default

### DIFF
--- a/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.test.tsx
+++ b/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.test.tsx
@@ -316,6 +316,45 @@ describe('<VersionSelection />', () => {
     });
   });
 
+  describe('when Classic', () => {
+    it('Selects default API version when exists', async () => {
+      const defaultClassicVersion = {
+        ...versions[0],
+        raw_id: '4.12.99',
+        id: 'openshift-v4.12.99',
+        default: true,
+        enabled: true,
+        rosa_enabled: true,
+      };
+
+      const newVersions = [...versions, defaultClassicVersion];
+
+      const state = {
+        clusters: {
+          clusterVersions: {
+            ...fulfilledVersionsState,
+            versions: newVersions,
+          },
+        },
+      };
+      const newProps = {
+        ...defaultProps,
+        onChange: onChangeMock,
+      };
+
+      withState(state).render(
+        <Formik onSubmit={() => {}} initialValues={defaultFields}>
+          <VersionSelection {...newProps} />
+        </Formik>,
+      );
+
+      expect(await screen.findByText(defaultProps.label)).toBeInTheDocument();
+      // onChange is called on render to set the default version
+      expect(onChangeMock).toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalledWith(defaultClassicVersion);
+    });
+  });
+
   describe('when Hypershift', () => {
     it('hides versions prior to "4.11.4" when hypershift and an ARN with a managed policy are selected', async () => {
       // Arrange
@@ -370,7 +409,50 @@ describe('<VersionSelection />', () => {
       });
     });
 
-    it('Selects latest version when it is both rosa and hypershift enabled', async () => {
+    it('Selects default API version when exists', async () => {
+      const defaultHypershiftVersion = {
+        ...versions[0],
+        raw_id: '4.12.99',
+        id: 'openshift-v4.12.99',
+        default: false,
+        enabled: true,
+        rosa_enabled: true,
+        hosted_control_plane_enabled: true,
+        hosted_control_plane_default: true,
+      };
+
+      const newVersions = [...versions, defaultHypershiftVersion];
+
+      const state = {
+        clusters: {
+          clusterVersions: {
+            ...fulfilledVersionsState,
+            params: { product: 'hcp' },
+            versions: newVersions,
+          },
+        },
+      };
+      const newProps = {
+        ...defaultProps,
+        onChange: onChangeMock,
+      };
+      const newFields = {
+        ...defaultFields,
+        [FieldId.Hypershift]: 'true',
+      };
+      withState(state).render(
+        <Formik onSubmit={() => {}} initialValues={newFields}>
+          <VersionSelection {...newProps} />
+        </Formik>,
+      );
+
+      expect(await screen.findByText(defaultProps.label)).toBeInTheDocument();
+      // onChange is called on render to set the default version
+      expect(onChangeMock).toHaveBeenCalled();
+      expect(onChangeMock).toHaveBeenCalledWith(defaultHypershiftVersion);
+    });
+
+    it('Selects latest version when default API does not exist', async () => {
       const newVersions = [...versions];
 
       const latestVersion = {
@@ -511,6 +593,7 @@ describe('<VersionSelection />', () => {
       expect(onChangeMock).not.toHaveBeenCalledWith(latestVersion);
       expect(onChangeMock).toHaveBeenCalledWith(newVersions[1]);
     });
+
     it('shows all versions when hypershift regardless of ARN maxOS version settings', async () => {
       const newVersions = [
         {

--- a/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.tsx
+++ b/src/components/clusters/wizards/rosa/ClusterSettings/VersionSelection.tsx
@@ -187,30 +187,30 @@ function VersionSelection({
       const targetChannelGroup =
         isEUSChannelEnabled && channelGroup ? channelGroup : channelGroups.STABLE;
 
-      const defaultVersion = versions.find((version) => version.default === true);
+      const inTargetChannel = (version: Version) => version.channel_group === targetChannelGroup;
 
-      const defaultRosaVersion = versions.find(
-        (version) => isValidRosaVersion(version) && version.channel_group === targetChannelGroup,
+      const isValidVersion = (version: Version) =>
+        (!isHypershiftSelected || version.hosted_control_plane_enabled === true) &&
+        isValidRosaVersion(version) &&
+        inTargetChannel(version);
+
+      const defaultVersion = versions.find(
+        (version) =>
+          (isHypershiftSelected
+            ? version.hosted_control_plane_default === true
+            : version.default === true) && isValidVersion(version),
       );
 
-      const defaultHypershiftVersion =
-        isHypershiftSelected &&
-        versions.find(
-          (version) =>
-            version.hosted_control_plane_enabled && version.channel_group === targetChannelGroup,
-        );
+      const latestVersion = versions.find((version) => isValidVersion(version));
 
-      if (!defaultRosaVersion || (isHypershiftSelected && !defaultHypershiftVersion)) {
+      const version = defaultVersion ?? latestVersion;
+
+      if (!version) {
         setRosaVersionError(true);
         return;
       }
 
       setRosaVersionError(false);
-
-      // default to max: hypershift version supported (if hypershift), rosa version supported, version.default, or first version in list
-      const version =
-        defaultHypershiftVersion || defaultRosaVersion || defaultVersion || versions[0];
-
       setValue(version);
       onChange(version);
     }


### PR DESCRIPTION
# Summary

Update the default OpenShift version selection logic in the ROSA HCP and Classic wizards to align with backend semantics. The UI now prioritizes `hosted_control_plane_default` for HCP clusters and `default` for Classic clusters provided by the API and fall back to the newest available version when they are not provided.

Assisted by: Cursor/Auto

# Jira

Fixes [OCMUI-4396](https://issues.redhat.com/browse/OCMUI-4396)

# How to Test

1. Open ROSA wizard
2. Go to Cluster settings -> Details
3. Make sure the version chosen is the latest version (this is the fallback scenario)
3. Open dev tools
4. In the network tab, search for the api call `/api/clusters_mgmt/v1/versions`
5. Override the response content -> choose a version different from the latest version and change `hosted_control_plane_default` and `default` to true.
6. Refresh the page and make sure the chosen version is the one you changed in the API response.
7. Repeat this both for classic and hcp.
8. Run npm test

# Screen Captures

**Before (The default was always the latest no matter the API response)**
<img width="1644" height="868" alt="image" src="https://github.com/user-attachments/assets/e4e1db80-4bcb-4eb0-80af-834ecef06883" />
**After**  
<img width="1644" height="868" alt="image" src="https://github.com/user-attachments/assets/8dd37cbc-0a88-4d88-b599-523461ef00fc" /><img width="1644" height="868" alt="image" src="https://github.com/user-attachments/assets/584166b4-7104-4abd-9b70-9ee04eb8a70a" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4396]: https://redhat.atlassian.net/browse/OCMUI-4396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ