### PR TITLE
OCMUI-4565- E2e test case spec(playwright) for support tab flow

### DIFF
--- a/playwright/e2e/support/cluster-support-tab.spec.ts
+++ b/playwright/e2e/support/cluster-support-tab.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '../../fixtures/pages';
+
+const clusterProfiles = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const supportData = require('../../fixtures/support/cluster-support-tab.spec.json');
+
+const clusterName =
+  process.env.CLUSTER_NAME ||
+  clusterProfiles['rosa-hosted-public-advanced']['day1-profile']['ClusterName'];
+const notificationContact = supportData['NotificationContact'];
+
+test.describe.serial(
+  'ROSA HCP Cluster Support tab tests',
+  { tag: ['@day2', '@advanced', '@rosa-hosted', '@hcp'] },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test(`Navigate to ${clusterName} cluster`, async ({ clusterListPage, clusterDetailsPage }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+    });
+
+    test('Validate Support tab layout and sections', async ({ clusterSupportPage }) => {
+      await clusterSupportPage.goToSupportTab();
+      await clusterSupportPage.isClusterSupportPage();
+      await expect(clusterSupportPage.addNotificationContactButton()).toBeVisible();
+      await expect(clusterSupportPage.openSupportCaseButton()).toBeVisible();
+      await clusterSupportPage.checkSupportCaseTableHeaders();
+    });
+
+    test('Open and cancel Add notification contact modal', async ({ clusterSupportPage }) => {
+      await clusterSupportPage.openAddNotificationContactModal();
+      await expect(clusterSupportPage.addNotificationContactModalHeading()).toBeVisible();
+      await expect(clusterSupportPage.addNotificationContactModalDescription()).toBeVisible();
+      await clusterSupportPage.cancelButton().click();
+      await expect(clusterSupportPage.addNotificationContactModalHeading()).toBeHidden();
+    });
+
+    test('Add notification contact and verify in table', async ({ clusterSupportPage }) => {
+      await clusterSupportPage.addNotificationContact(notificationContact.ValidUsername);
+      await expect(clusterSupportPage.notificationContactAddedAlert()).toBeVisible();
+      await clusterSupportPage.checkNotificationContactTableHeaders();
+      await clusterSupportPage.checkNotificationContacts(
+        notificationContact.ValidUsername,
+        notificationContact.ExpectedFirstName,
+        notificationContact.ExpectedLastName,
+      );
+    });
+
+    test('Delete notification contact and verify removal', async ({ clusterSupportPage }) => {
+      await clusterSupportPage.deleteNotificationContactByUsername(
+        notificationContact.ValidUsername,
+      );
+      await expect(clusterSupportPage.notificationContactDeletedAlert()).toBeVisible();
+      await expect(
+        clusterSupportPage.notificationContactRow(notificationContact.ValidUsername),
+      ).toHaveCount(0);
+    });
+
+    test('Validate username field - illegal symbols show inline error', async ({
+      clusterSupportPage,
+    }) => {
+      await clusterSupportPage.openAddNotificationContactModal();
+      await clusterSupportPage.usernameInput().fill(notificationContact.InvalidUsernameWithSymbols);
+      await expect(
+        clusterSupportPage.inlineValidationError(notificationContact.InvalidUsernameSymbolsError),
+      ).toBeVisible();
+      await clusterSupportPage.usernameInput().clear();
+      await clusterSupportPage.cancelButton().click();
+    });
+
+    test('Validate username field - unknown username shows server error', async ({
+      clusterSupportPage,
+    }) => {
+      await clusterSupportPage.openAddNotificationContactModal();
+      await clusterSupportPage.usernameInput().fill(notificationContact.ValidUsernameNotFound);
+      await clusterSupportPage.addContactButton().click();
+      await expect(
+        clusterSupportPage.inlineValidationError(notificationContact.UsernameNotFoundError),
+      ).toBeVisible();
+      await clusterSupportPage.cancelButton().click();
+    });
+  },
+);

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -15,6 +15,7 @@ import { CreateClusterPage } from '../page-objects/create-cluster-page';
 import { CreateRosaWizardPage } from '../page-objects/create-rosa-wizard-page';
 import { DownloadsPage } from '../page-objects/downloads-page';
 import { ClusterRolesAndAccessPage } from '../page-objects/cluster-roles-access-page';
+import { ClusterSupportPage } from '../page-objects/cluster-support-page';
 import { OCMRolesAndAccessPage } from '../page-objects/ocm-roles-access-page';
 import { OsdProductPage } from '../page-objects/osd-product-page';
 import { OverviewPage } from '../page-objects/overview-page';
@@ -47,6 +48,7 @@ type WorkerFixtures = {
   createRosaWizardPage: CreateRosaWizardPage;
   downloadsPage: DownloadsPage;
   clusterRolesAndAccessPage: ClusterRolesAndAccessPage;
+  clusterSupportPage: ClusterSupportPage;
   ocmRolesAndAccessPage: OCMRolesAndAccessPage;
   osdProductPage: OsdProductPage;
   overviewPage: OverviewPage;
@@ -217,6 +219,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   clusterRolesAndAccessPage: [
     async ({ authenticatedPage }, use) => {
       const pageObject = new ClusterRolesAndAccessPage(authenticatedPage);
+      await use(pageObject);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Worker-scoped: ClusterSupportPage instance - created once, reused across all tests in suite
+  clusterSupportPage: [
+    async ({ authenticatedPage }, use) => {
+      const pageObject = new ClusterSupportPage(authenticatedPage);
       await use(pageObject);
     },
     { scope: 'worker' },

--- a/playwright/fixtures/support/cluster-support-tab.spec.json
+++ b/playwright/fixtures/support/cluster-support-tab.spec.json
@@ -1,0 +1,11 @@
+{
+  "NotificationContact": {
+    "ValidUsername": "ocmui-orgadmin",
+    "ExpectedFirstName": "ocmui",
+    "ExpectedLastName": "admin",
+    "InvalidUsernameWithSymbols": "admin$test",
+    "InvalidUsernameSymbolsError": "Username includes illegal symbols",
+    "ValidUsernameNotFound": "admintest",
+    "UsernameNotFoundError": "Could not find any account identified by admintest"
+  }
+}

--- a/playwright/page-objects/cluster-support-page.ts
+++ b/playwright/page-objects/cluster-support-page.ts
@@ -1,0 +1,143 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class ClusterSupportPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isClusterSupportPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/#support/);
+    await expect(this.notificationContactsHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  supportTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Support' });
+  }
+
+  notificationContactsHeading(): Locator {
+    return this.page.getByText('Notification contacts', { exact: true });
+  }
+
+  supportCasesHeading(): Locator {
+    return this.page.getByText('Support cases', { exact: true });
+  }
+
+  addNotificationContactButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add notification contact' });
+  }
+
+  addContactButton(): Locator {
+    return this.page.getByRole('dialog').getByRole('button', { name: 'Add contact' });
+  }
+
+  cancelButton(): Locator {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  openSupportCaseButton(): Locator {
+    return this.page.getByRole('button', { name: 'Open support case' });
+  }
+
+  usernameInput(): Locator {
+    return this.page.getByLabel('user name');
+  }
+
+  notificationContactsTable(): Locator {
+    return this.page.getByRole('grid', { name: 'Notification Contacts' });
+  }
+
+  supportCasesTable(): Locator {
+    return this.page.getByTestId('support-cases-table');
+  }
+
+  addNotificationContactModalHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Add notification contact' });
+  }
+
+  notificationContactRow(username: string): Locator {
+    return this.notificationContactsTable()
+      .getByRole('row')
+      .filter({ has: this.page.getByRole('gridcell', { name: username, exact: true }) });
+  }
+
+  addNotificationContactModalDescription(): Locator {
+    return this.page.getByText(
+      'Identify the user to be added as notification contact. These users will be contacted in the event of notifications about this cluster.',
+    );
+  }
+
+  notificationContactAddedAlert(): Locator {
+    return this.page.getByText('Notification contact added successfully');
+  }
+
+  notificationContactDeletedAlert(): Locator {
+    return this.page.getByText('Notification contact deleted successfully');
+  }
+
+  inlineValidationError(message: string): Locator {
+    return this.page.getByText(message);
+  }
+
+  async goToSupportTab(): Promise<void> {
+    await this.supportTab().click();
+    await expect(this.supportTab()).toHaveAttribute('aria-selected', 'true');
+  }
+
+  async openAddNotificationContactModal(): Promise<void> {
+    await this.addNotificationContactButton().click();
+    await expect(this.addNotificationContactModalHeading()).toBeVisible();
+  }
+
+  async addNotificationContact(username: string): Promise<void> {
+    await this.openAddNotificationContactModal();
+    await this.usernameInput().fill(username);
+    await this.addContactButton().click();
+    await expect(this.addNotificationContactModalHeading()).toBeHidden({ timeout: 30000 });
+  }
+
+  async deleteNotificationContactByUsername(username: string): Promise<void> {
+    await this.notificationContactRow(username)
+      .getByRole('button', { name: 'Kebab toggle' })
+      .click();
+    await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    await expect(this.notificationContactRow(username)).toHaveCount(0, { timeout: 30000 });
+  }
+
+  async checkSupportCaseTableHeaders(): Promise<void> {
+    const expectedHeaders = [
+      'Case ID',
+      'Issue summary',
+      'Owner',
+      'Modified by',
+      'Severity',
+      'Status',
+    ];
+    for (const header of expectedHeaders) {
+      await expect(
+        this.supportCasesTable().getByRole('columnheader', { name: header }),
+      ).toBeVisible();
+    }
+  }
+
+  async checkNotificationContactTableHeaders(): Promise<void> {
+    const expectedHeaders = ['Username', 'Email', 'First Name', 'Last Name'];
+    for (const header of expectedHeaders) {
+      await expect(
+        this.notificationContactsTable().getByRole('columnheader', { name: header }),
+      ).toBeVisible();
+    }
+  }
+
+  async checkNotificationContacts(
+    username: string,
+    firstName: string,
+    lastName: string,
+  ): Promise<void> {
+    const row = this.notificationContactRow(username);
+    await expect(row).toBeVisible();
+    await expect(row.getByRole('gridcell', { name: firstName, exact: true })).toBeVisible();
+    await expect(row.getByRole('gridcell', { name: lastName, exact: true })).toBeVisible();
+  }
+}


### PR DESCRIPTION
# Summary

E2e test case spec(playwright) for support tab flow
# Jira

 Fixes [OCMUI-4565](https://issues.redhat.com/browse/OCMUI-4565)

# Additional information

New e2e test case spec definition for support tab functionalities.
Added related fixture and page object definitions.

# How to Test

Create a ROSA Hosted cluster or use an existing ROSA hosted cluster
Export cluster name using below command
```
export CLUSTER_NAME=<Your cluster name>
```
Run the test execution command as below
```
 BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/support/cluster-support-tab.spec.ts 
```
**Note: Replace playwright/fixtures/support/cluster-support-tab.spec.json >> ValidUsername with your org test user.**

# Screen Captures

```
 BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/support/cluster-support-tab.spec.ts 

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/support/cluster-support-tab.spec.ts

🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: cypress-orgadmin
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 7 tests using 1 worker
  7 passed (42.4s)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).


[OCMUI-4565]: https://redhat.atlassian.net/browse/OCMUI-4565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ