### PR TITLE
OCMUI-3267: E2e test spec(day2) to cover the access control > AWS infrastructure access for OSD

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -76,6 +76,9 @@ The test configuration uses `playwright.env.json` for environment-specific setti
   "QE_LOG_FORWARDING_S3_BUCKET_NAME": "AWS S3 bucket name for log forwarding",
   "QE_LOG_FORWARDING_S3_BUCKET_PREFIX": "AWS s3 bucket prefix or folder name for log forwarding",
   "QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN": "AWS cloud watch account arn role for log forwarding",
+  // exclusively for OSD AWS tests
+  "QE_AWS_IAM_USER": "AWS IAM username for OSD infrastructure access tests",
+  "QE_AWS_INFRA_ACCESS_IAM_ARN": "(optional) full IAM user ARN for OSD— defaults to arn:aws:iam::<QE_AWS_ID>:user/<QE_AWS_IAM_USER>",
   // Optional definitions for special day2 test runs
   "QE_ORGADMIN_USER": "org admin username",
   "QE_ORGADMIN_PASSWORD": "org admin password",

--- a/playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts
+++ b/playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts
@@ -22,7 +22,7 @@ let validIamUserArn: string;
 let invalidIamUserArn: string;
 
 test.describe.serial(
-  'OSD non-CCS AWS cluster - AWS infrastructure access',
+  'OSD non-CCS AWS cluster - AWS infrastructure access (OCP-27994, OCP-27996)',
   {
     tag: [
       '@day2',
@@ -106,6 +106,11 @@ test.describe.serial(
       await expect(awsInfrastructureAccessPage.iamArnInput()).toBeEmpty();
       await expect(awsInfrastructureAccessPage.grantRoleSubmitButton()).toBeDisabled();
 
+      await awsInfrastructureAccessPage.iamArnInput().fill('a');
+      await awsInfrastructureAccessPage.iamArnInput().clear();
+      await awsInfrastructureAccessPage.iamArnInput().blur();
+      await awsInfrastructureAccessPage.isTextContainsInPage(testData.Validation.EmptyArnError);
+
       await awsInfrastructureAccessPage.cancelButton().click();
       await expect(awsInfrastructureAccessPage.grantModalHeading()).toBeHidden();
     });
@@ -173,6 +178,11 @@ test.describe.serial(
         invalidIamUserArn,
         testData.GrantRole.ReadOnlyRoleName,
       );
+      const expectedFailureTitle = testData.Notifications.GrantFailureTitle.replace(
+        '{userArn}',
+        invalidIamUserArn,
+      );
+      await awsInfrastructureAccessPage.isTextContainsInPage(expectedFailureTitle);
       await expect(
         awsInfrastructureAccessPage.grantRow(
           invalidIamUserArn,
@@ -204,6 +214,10 @@ test.describe.serial(
         validIamUserArn,
         testData.GrantRole.ReadOnlyRoleName,
       );
+      const expectedReadOnlySuccessTitle = testData.Notifications.GrantSuccessTitle
+        .replace('{roleName}', testData.GrantRole.ReadOnlyRoleName)
+        .replace('{userArn}', validIamUserArn);
+      await awsInfrastructureAccessPage.isTextContainsInPage(expectedReadOnlySuccessTitle);
       await expect(
         awsInfrastructureAccessPage.grantRow(validIamUserArn, testData.GrantRole.ReadOnlyRoleName),
       ).toContainText(testData.GrantRole.ReadOnlyRoleName);
@@ -227,6 +241,10 @@ test.describe.serial(
         validIamUserArn,
         testData.GrantRole.NetworkManagementRoleName,
       );
+      const expectedNetworkMgmtSuccessTitle = testData.Notifications.GrantSuccessTitle
+        .replace('{roleName}', testData.GrantRole.NetworkManagementRoleName)
+        .replace('{userArn}', validIamUserArn);
+      await awsInfrastructureAccessPage.isTextContainsInPage(expectedNetworkMgmtSuccessTitle);
       await expect(
         awsInfrastructureAccessPage.grantRow(validIamUserArn, testData.GrantRole.ReadOnlyRoleName),
       ).toContainText('Ready');

--- a/playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts
+++ b/playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts
@@ -1,0 +1,256 @@
+import { expect, test } from '../../fixtures/pages';
+
+const testData = require('../../fixtures/access-control/cluster-aws-infrastructure-access.spec.json');
+const clusterFixture = require('../../fixtures/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.json');
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+};
+
+const clusterName =
+  process.env.CLUSTER_NAME ||
+  clusterFixture['osd-nonccs-aws-public-advanced']['day1-profile'].ClusterName;
+const runId = Math.random().toString(36).slice(2, 7);
+
+let awsAccountId: string;
+let iamUserName: string;
+let validIamUserArn: string;
+let invalidIamUserArn: string;
+
+test.describe.serial(
+  'OSD non-CCS AWS cluster - AWS infrastructure access',
+  {
+    tag: [
+      '@day2',
+      '@access-control',
+      '@osd',
+      '@aws',
+      '@advanced',
+      '@non-ccs',
+      '@aws-infrastructure-access',
+    ],
+  },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      awsAccountId = requireEnv('QE_AWS_ID');
+      validIamUserArn = process.env.QE_AWS_INFRA_ACCESS_IAM_ARN?.trim();
+      if (!validIamUserArn) {
+        iamUserName = requireEnv('QE_AWS_IAM_USER');
+        validIamUserArn = `arn:aws:iam::${awsAccountId}:user/${iamUserName}`;
+      }
+      invalidIamUserArn = `arn:aws:iam::${awsAccountId}:user/${testData.GrantRole.InvalidIamUserNamePrefix}-${runId}`;
+
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test.afterAll(async ({ awsInfrastructureAccessPage }) => {
+      for (const roleName of [
+        testData.GrantRole.ReadOnlyRoleName,
+        testData.GrantRole.NetworkManagementRoleName,
+      ]) {
+        await awsInfrastructureAccessPage
+          .deleteGrantIfExists(validIamUserArn, roleName)
+          .catch(() => {
+            console.error(
+              `Failed to delete ${roleName} grant for ${validIamUserArn} or already deleted`,
+            );
+          });
+      }
+      await awsInfrastructureAccessPage.deleteGrantIfExists(invalidIamUserArn).catch(() => {
+        console.error(`Failed to delete grant for ${invalidIamUserArn} or already deleted`);
+      });
+    });
+
+    test(`Navigate to ${clusterName} AWS infrastructure access tab`, async ({
+      clusterListPage,
+      clusterDetailsPage,
+      awsInfrastructureAccessPage,
+    }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterDetailsPage.waitForClusterDetailsLoad();
+      await awsInfrastructureAccessPage.goToAccessControlTab();
+      await awsInfrastructureAccessPage.goToAwsInfrastructureAccessTab();
+      await awsInfrastructureAccessPage.isAwsInfrastructureAccessPage();
+    });
+
+    test('Verify AWS infrastructure access tab layout', async ({ awsInfrastructureAccessPage }) => {
+      await expect(awsInfrastructureAccessPage.sectionHeading()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.awsLoginLink()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.grantRoleButton()).toBeEnabled();
+    });
+
+    test('Verify Access control sub-tabs for OSD non-CCS AWS cluster', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await expect(awsInfrastructureAccessPage.identityProvidersTab()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.clusterRolesAndAccessTab()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.ocmRolesAndAccessTab()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.awsInfrastructureAccessTab()).toBeVisible();
+    });
+
+    test('Verify Grant role dialog default state and field visibility', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.openGrantRoleModal();
+
+      await expect(awsInfrastructureAccessPage.grantModalHeading()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.iamArnInput()).toBeVisible();
+      await expect(awsInfrastructureAccessPage.iamArnInput()).toBeEmpty();
+      await expect(awsInfrastructureAccessPage.grantRoleSubmitButton()).toBeDisabled();
+
+      await awsInfrastructureAccessPage.cancelButton().click();
+      await expect(awsInfrastructureAccessPage.grantModalHeading()).toBeHidden();
+    });
+
+    test('Validate AWS IAM ARN - invalid format keeps submit disabled', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.openGrantRoleModal();
+
+      await awsInfrastructureAccessPage.iamArnInput().fill(testData.Validation.InvalidArnInput);
+      await awsInfrastructureAccessPage.iamArnInput().blur();
+      await expect(
+        awsInfrastructureAccessPage.getByText(testData.Validation.InvalidArnError),
+      ).toBeVisible();
+      await expect(awsInfrastructureAccessPage.grantRoleSubmitButton()).toBeDisabled();
+
+      await awsInfrastructureAccessPage.cancelButton().click();
+      await expect(awsInfrastructureAccessPage.grantModal()).toBeHidden();
+    });
+
+    test('Validate AWS IAM ARN - whitespace keeps submit disabled', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.openGrantRoleModal();
+
+      await awsInfrastructureAccessPage.iamArnInput().fill(testData.Validation.WhitespaceArnInput);
+      await awsInfrastructureAccessPage.iamArnInput().blur();
+      await expect(
+        awsInfrastructureAccessPage.getByText(testData.Validation.WhitespaceArnError),
+      ).toBeVisible();
+      await expect(awsInfrastructureAccessPage.grantRoleSubmitButton()).toBeDisabled();
+
+      await awsInfrastructureAccessPage.cancelButton().click();
+      await expect(awsInfrastructureAccessPage.grantModal()).toBeHidden();
+    });
+
+    test('Validate AWS IAM ARN - valid format enables submit button', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.openGrantRoleModal();
+
+      await awsInfrastructureAccessPage.iamArnInput().fill(validIamUserArn);
+      await expect(awsInfrastructureAccessPage.grantRoleSubmitButton()).toBeEnabled();
+
+      await awsInfrastructureAccessPage.cancelButton().click();
+      await expect(awsInfrastructureAccessPage.grantModal()).toBeHidden();
+    });
+
+    test('Grant role with non-existent IAM user shows failed status and failure notification', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      for (const roleName of [
+        testData.GrantRole.ReadOnlyRoleName,
+        testData.GrantRole.NetworkManagementRoleName,
+      ]) {
+        await awsInfrastructureAccessPage.deleteGrantIfExists(validIamUserArn, roleName);
+      }
+
+      await awsInfrastructureAccessPage.grantInfrastructureAccessRole(
+        invalidIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+
+      await awsInfrastructureAccessPage.waitForGrantFailure(
+        invalidIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+      await expect(
+        awsInfrastructureAccessPage.grantRow(
+          invalidIamUserArn,
+          testData.GrantRole.ReadOnlyRoleName,
+        ),
+      ).toContainText(testData.GrantRole.ReadOnlyRoleName);
+      await expect(
+        awsInfrastructureAccessPage.copyUrlButton(
+          invalidIamUserArn,
+          testData.GrantRole.ReadOnlyRoleName,
+        ),
+      ).toBeDisabled();
+
+      await awsInfrastructureAccessPage.deleteGrant(
+        invalidIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+    });
+
+    test('Grant Read Only role with valid IAM user shows ready status and success notification', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.grantInfrastructureAccessRole(
+        validIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+
+      await awsInfrastructureAccessPage.waitForGrantSuccess(
+        validIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+      await expect(
+        awsInfrastructureAccessPage.grantRow(validIamUserArn, testData.GrantRole.ReadOnlyRoleName),
+      ).toContainText(testData.GrantRole.ReadOnlyRoleName);
+      await expect(
+        awsInfrastructureAccessPage.copyUrlButton(
+          validIamUserArn,
+          testData.GrantRole.ReadOnlyRoleName,
+        ),
+      ).toBeEnabled();
+    });
+
+    test('Grant Network management role to the same IAM user shows ready status and success notification', async ({
+      awsInfrastructureAccessPage,
+    }) => {
+      await awsInfrastructureAccessPage.grantInfrastructureAccessRole(
+        validIamUserArn,
+        testData.GrantRole.NetworkManagementRoleName,
+      );
+
+      await awsInfrastructureAccessPage.waitForGrantSuccess(
+        validIamUserArn,
+        testData.GrantRole.NetworkManagementRoleName,
+      );
+      await expect(
+        awsInfrastructureAccessPage.grantRow(validIamUserArn, testData.GrantRole.ReadOnlyRoleName),
+      ).toContainText('Ready');
+      await expect(
+        awsInfrastructureAccessPage.grantRow(
+          validIamUserArn,
+          testData.GrantRole.NetworkManagementRoleName,
+        ),
+      ).toContainText('Ready');
+      await expect(
+        awsInfrastructureAccessPage.copyUrlButton(
+          validIamUserArn,
+          testData.GrantRole.NetworkManagementRoleName,
+        ),
+      ).toBeEnabled();
+
+      await awsInfrastructureAccessPage.deleteGrant(
+        validIamUserArn,
+        testData.GrantRole.ReadOnlyRoleName,
+      );
+      await awsInfrastructureAccessPage.deleteGrant(
+        validIamUserArn,
+        testData.GrantRole.NetworkManagementRoleName,
+      );
+    });
+  },
+);

--- a/playwright/e2e/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.ts
+++ b/playwright/e2e/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from '../../fixtures/pages';
+
+const fixtureData = require('../../fixtures/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.json');
+const clusterProperties = fixtureData['osd-nonccs-aws-public-advanced']['day1-profile'];
+const clusterName = process.env.CLUSTER_NAME || `${clusterProperties.ClusterName}`;
+
+test.describe(
+  'OSD Non CCS AWS cluster creation tests for advanced profile',
+  { tag: ['@day1', '@osd', '@aws', '@non-ccs', '@advanced', '@public'] },
+  () => {
+    // Iterate through each cluster configuration
+    test.beforeAll(async ({ navigateTo }) => {
+      // Navigate to create
+      await navigateTo('create');
+    });
+    test(`Launch OSD - ${clusterProperties.CloudProvider} cluster wizard`, async ({
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.waitAndClick(createOSDWizardPage.osdCreateClusterButton());
+      await createOSDWizardPage.isCreateOSDPage();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Billing model and its definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isBillingModelScreen();
+      await expect(createOSDWizardPage.subscriptionTypeAnnualFixedCapacityRadio()).toBeChecked();
+      await createOSDWizardPage.infrastructureTypeRedHatCloudAccountRadio().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Cluster Settings - Cloud provider definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isCloudProviderSelectionScreen();
+      await createOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Cluster Settings - Cluster details definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isClusterDetailsScreen();
+      await page.locator(createOSDWizardPage.clusterNameInput).fill(clusterName);
+      await createOSDWizardPage.hideClusterNameValidation();
+      await expect(createOSDWizardPage.singleZoneAvilabilityRadio()).toBeChecked();
+      await createOSDWizardPage.selectRegion(clusterProperties.Region);
+      await createOSDWizardPage.selectVersion(
+        clusterProperties.Version || process.env.VERSION || '',
+      );
+      await createOSDWizardPage.selectPersistentStorage(clusterProperties.PersistentStorage);
+      await createOSDWizardPage.selectLoadBalancers(clusterProperties.LoadBalancers);
+      await expect(createOSDWizardPage.enableUserWorkloadMonitoringCheckbox()).toBeChecked();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Cluster Settings - Default machinepool definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isMachinePoolScreen();
+      await createOSDWizardPage.selectComputeNodeType(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await createOSDWizardPage.selectComputeNodeCount(clusterProperties.MachinePools[0].NodeCount);
+      await expect(createOSDWizardPage.enableAutoscalingCheckbox()).not.toBeChecked();
+      await expect(createOSDWizardPage.addNodeLabelLink()).toBeVisible();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Networking configuration - cluster privacy definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await expect(createOSDWizardPage.clusterPrivacyPublicRadio()).toBeChecked();
+      await expect(createOSDWizardPage.clusterPrivacyPrivateRadio()).not.toBeChecked();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Networking configuration - CIDR definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isCIDRScreen();
+      await expect(createOSDWizardPage.cidrDefaultValuesCheckBox()).toBeChecked();
+      await expect(createOSDWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixInput()).toHaveValue(clusterProperties.HostPrefix);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Cluster updates definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isClusterUpdatesScreen();
+      await expect(createOSDWizardPage.updateStrategyIndividualRadio()).toBeChecked();
+      await expect(createOSDWizardPage.updateStrategyRecurringRadio()).not.toBeChecked();
+      await createOSDWizardPage.selectNodeDraining(clusterProperties.NodeDraining);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Review and create page and its definitions`, async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isReviewScreen();
+      await expect(createOSDWizardPage.subscriptionTypeValue()).toContainText(
+        clusterProperties.SubscriptionType,
+      );
+      await expect(createOSDWizardPage.infrastructureTypeValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+      await expect(createOSDWizardPage.cloudProviderValue()).toContainText(
+        clusterProperties.CloudProvider,
+      );
+      await expect(createOSDWizardPage.clusterNameValue()).toContainText(clusterName);
+      await expect(createOSDWizardPage.regionValue()).toContainText(
+        clusterProperties.Region.split(',')[0],
+      );
+      await expect(createOSDWizardPage.availabilityValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(createOSDWizardPage.userWorkloadMonitoringValue()).toContainText(
+        clusterProperties.UserWorkloadMonitoring,
+      );
+      await expect(createOSDWizardPage.persistentStorageValue()).toContainText(
+        clusterProperties.PersistentStorage,
+      );
+      await expect(createOSDWizardPage.additionalEtcdEncryptionValue()).toContainText(
+        clusterProperties.AdditionalEncryption,
+      );
+      await expect(createOSDWizardPage.fipsCryptographyValue()).toContainText(
+        clusterProperties.FIPSCryptography,
+      );
+      await expect(createOSDWizardPage.nodeInstanceTypeValue()).toContainText(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await expect(createOSDWizardPage.autoscalingValue()).toContainText(
+        clusterProperties.MachinePools[0].Autoscaling,
+      );
+      await expect(createOSDWizardPage.computeNodeCountValue()).toContainText(
+        clusterProperties.MachinePools[0].NodeCount.toString(),
+      );
+
+      await expect(createOSDWizardPage.clusterPrivacyValue()).toContainText(
+        clusterProperties.ClusterPrivacy,
+      );
+      await expect(createOSDWizardPage.machineCIDRValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRValue()).toContainText(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixValue()).toContainText(
+        clusterProperties.HostPrefix,
+      );
+      await expect(createOSDWizardPage.updateStratergyValue()).toContainText(
+        clusterProperties.UpdateStrategy,
+      );
+      await expect(createOSDWizardPage.nodeDrainingValue()).toContainText(
+        `${parseInt(clusterProperties.NodeDraining, 10) * 60} minutes`,
+      );
+    });
+
+    test(`OSD ${clusterProperties.CloudProvider} wizard - Cluster submission & overview definitions`, async ({
+      createOSDWizardPage,
+      clusterDetailsPage,
+    }) => {
+      await createOSDWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toContainText(
+        'Installing cluster',
+      );
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toBeVisible();
+      await expect(clusterDetailsPage.clusterInstallationExpectedText()).toContainText(
+        'Cluster creation usually takes 30 to 60 minutes to complete',
+      );
+      await expect(clusterDetailsPage.clusterInstallationExpectedText()).toBeVisible();
+      await expect(clusterDetailsPage.downloadOcCliLink()).toContainText('Download OC CLI');
+      await expect(clusterDetailsPage.downloadOcCliLink()).toBeVisible();
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+      await expect(clusterDetailsPage.clusterTypeLabelValue()).toContainText(
+        clusterProperties.Type,
+      );
+      await expect(clusterDetailsPage.clusterAutoScalingStatus()).toContainText(
+        clusterProperties.ClusterAutoscaling,
+      );
+      await expect(clusterDetailsPage.clusterRegionLabelValue()).toContainText(
+        clusterProperties.Region.split(',')[0],
+      );
+      await expect(clusterDetailsPage.clusterPersistentStorageLabelValue()).toContainText(
+        clusterProperties.PersistentStorage,
+      );
+      await expect(clusterDetailsPage.clusterAvailabilityLabelValue()).toContainText(
+        clusterProperties.Availability,
+      );
+      await expect(clusterDetailsPage.clusterMachineCIDRLabelValue()).toContainText(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(clusterDetailsPage.clusterServiceCIDRLabelValue()).toContainText(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(clusterDetailsPage.clusterPodCIDRLabelValue()).toContainText(
+        clusterProperties.PodCIDR,
+      );
+      await expect(clusterDetailsPage.clusterHostPrefixLabelValue()).toContainText(
+        clusterProperties.HostPrefix.replace('/', ''),
+      );
+      await expect(clusterDetailsPage.clusterSubscriptionBillingModelValue()).toContainText(
+        clusterProperties.SubscriptionBillingModel,
+      );
+      await expect(clusterDetailsPage.clusterInfrastructureBillingModelValue()).toContainText(
+        clusterProperties.InfrastructureType,
+      );
+    });
+  },
+);

--- a/playwright/fixtures/access-control/cluster-aws-infrastructure-access.spec.json
+++ b/playwright/fixtures/access-control/cluster-aws-infrastructure-access.spec.json
@@ -1,0 +1,18 @@
+{
+  "Validation": {
+    "EmptyArnError": "Field is required.",
+    "WhitespaceArnError": "Value must not contain whitespaces.",
+    "InvalidArnError": "ARN value should be in the format arn:aws:iam::123456789012:user/name.",
+    "InvalidArnInput": "invalid-arn",
+    "WhitespaceArnInput": "arn:aws:iam::123456789012:user/name with space"
+  },
+  "GrantRole": {
+    "ReadOnlyRoleName": "Read only",
+    "NetworkManagementRoleName": "Network management",
+    "InvalidIamUserNamePrefix": "playwright-infra-access"
+  },
+  "Notifications": {
+    "GrantFailureTitle": "Role creation failed for {userArn}",
+    "GrantSuccessTitle": "{roleName} role successfully created for {userArn}"
+  }
+}

--- a/playwright/fixtures/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.json
+++ b/playwright/fixtures/osd-aws/osd-non-ccs-aws-cluster-creation-advanced.spec.json
@@ -1,0 +1,49 @@
+{
+  "osd-nonccs-aws-public-advanced": {
+    "day1-profile": {
+      "ClusterName": "ocmui-playwright-pre-osd-nonccs-aws",
+      "Type": "OSD",
+      "CloudProvider": "AWS",
+      "SubscriptionType": "Annual: Fixed capacity subscription from Red Hat",
+      "SubscriptionBillingModel": "Annual Red Hat subscriptions",
+      "InfrastructureType": "Red Hat cloud account",
+      "Region": "us-west-2, US West, Oregon",
+      "Availability": "Single zone",
+      "PersistentStorage": "100 GiB",
+      "LoadBalancers": "0",
+      "UserWorkloadMonitoring": "Enabled",
+      "FIPSCryptography": "Disabled",
+      "AdditionalEncryption": "Disabled",
+      "Nodes": {
+        "Control plane": "3/3",
+        "Infra": "2/2",
+        "Compute": "3/3"
+      },
+      "ClusterAutoscaling": "Disabled",
+      "ClusterPrivacy": "Public",
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "HostPrefix": "/23",
+      "UpdateStrategy": "Individual updates",
+      "NodeDraining": "1 hour",
+      "MachinePools": [
+        {
+          "Name": "worker",
+          "InstanceType": "m5.xlarge",
+          "AvailabilityZones": "us-west-2a",
+          "NodeCount": 4,
+          "Autoscaling": "Disabled"
+        }
+      ],
+      "networking": {
+        "CIDRRanges": {
+          "MachineCIDR": "10.0.0.0/16",
+          "ServiceCIDR": "172.30.0.0/16",
+          "PodCIDR": "10.128.0.0/14",
+          "Hostprefix": "/23"
+        }
+      }
+    }
+  }
+}

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -26,6 +26,7 @@ import { RosaGetStartedPage } from '../page-objects/rosa-getstarted-page';
 import { SubscriptionsPage } from '../page-objects/subscriptions-page';
 import { TokensPage } from '../page-objects/tokens-page';
 import { ClusterIdentityProviderPage } from '../page-objects/cluster-identity-provider-page';
+import { AwsInfrastructureAccessPage } from '../page-objects/aws-infrastructure-access-page';
 import { CustomCommands } from '../support/custom-commands';
 import { STORAGE_STATE_PATH } from '../support/playwright-constants';
 
@@ -61,6 +62,7 @@ type WorkerFixtures = {
   tokensPage: TokensPage;
   customCommands: CustomCommands;
   clusterIdentityProviderPage: ClusterIdentityProviderPage;
+  awsInfrastructureAccessPage: AwsInfrastructureAccessPage;
 };
 
 /**
@@ -327,6 +329,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   clusterIdentityProviderPage: [
     async ({ authenticatedPage }, use) => {
       const pageObject = new ClusterIdentityProviderPage(authenticatedPage);
+      await use(pageObject);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Worker-scoped: AwsInfrastructureAccessPage instance - created once, reused across all tests in suite
+  awsInfrastructureAccessPage: [
+    async ({ authenticatedPage }, use) => {
+      const pageObject = new AwsInfrastructureAccessPage(authenticatedPage);
       await use(pageObject);
     },
     { scope: 'worker' },

--- a/playwright/page-objects/aws-infrastructure-access-page.ts
+++ b/playwright/page-objects/aws-infrastructure-access-page.ts
@@ -1,0 +1,210 @@
+import { expect, Locator } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class AwsInfrastructureAccessPage extends BasePage {
+  async isAwsInfrastructureAccessPage(): Promise<void> {
+    await expect(this.awsInfrastructureAccessTab()).toHaveAttribute('aria-selected', 'true');
+    await expect(this.sectionHeading()).toBeVisible();
+    await expect(this.grantRoleButton()).toBeVisible();
+  }
+
+  accessControlTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Access control' });
+  }
+
+  awsInfrastructureAccessTab(): Locator {
+    return this.page.getByRole('tab', { name: 'AWS infrastructure access' });
+  }
+
+  identityProvidersTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Identity providers' });
+  }
+
+  clusterRolesAndAccessTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Cluster Roles and Access' });
+  }
+
+  ocmRolesAndAccessTab(): Locator {
+    return this.page.getByRole('tab', { name: 'OCM Roles and Access' });
+  }
+
+  awsInfrastructureAccessPanel(): Locator {
+    return this.page.getByRole('tabpanel', { name: 'AWS infrastructure access' });
+  }
+
+  sectionCard(): Locator {
+    return this.awsInfrastructureAccessPanel();
+  }
+
+  sectionHeading(): Locator {
+    return this.awsInfrastructureAccessPanel().getByRole('heading', {
+      name: 'AWS infrastructure access',
+      level: 3,
+    });
+  }
+
+  awsLoginLink(): Locator {
+    return this.awsInfrastructureAccessPanel().getByRole('link', {
+      name: /Log in to your aws account/i,
+    });
+  }
+
+  grantRoleButton(): Locator {
+    return this.awsInfrastructureAccessPanel().getByRole('button', { name: 'Grant role' });
+  }
+
+  grantsTable(): Locator {
+    return this.page.getByRole('grid', { name: 'Grants' });
+  }
+
+  grantModal(): Locator {
+    return this.page.getByRole('dialog', { name: 'Grant AWS infrastructure role' });
+  }
+
+  grantModalHeading(): Locator {
+    return this.grantModal().getByRole('heading', { name: 'Grant AWS infrastructure role' });
+  }
+
+  iamArnInput(): Locator {
+    return this.grantModal().getByRole('textbox', { name: 'AWS IAM ARN' });
+  }
+
+  grantRoleSubmitButton(): Locator {
+    return this.grantModal().getByRole('button', { name: 'Grant role' });
+  }
+
+  cancelButton(): Locator {
+    return this.grantModal().getByRole('button', { name: 'Cancel' });
+  }
+
+  roleRadio(roleName: string): Locator {
+    return this.grantModal().getByRole('radio', { name: roleName });
+  }
+
+  grantRow(userArn: string, roleName?: string): Locator {
+    const row = this.grantsTable().getByRole('row').filter({ hasText: userArn });
+    return roleName ? row.filter({ hasText: roleName }) : row;
+  }
+
+  grantFailureNotification(userArn: string): Locator {
+    return this.page.getByText('Role creation failed for').filter({ hasText: userArn });
+  }
+
+  grantSuccessNotification(userArn: string, roleName: string): Locator {
+    return this.page
+      .getByText('role successfully created for')
+      .filter({ hasText: userArn })
+      .filter({ hasText: roleName });
+  }
+
+  copyUrlButton(userArn: string, roleName?: string): Locator {
+    return this.grantRow(userArn, roleName).getByRole('button', { name: 'Copy URL to clipboard' });
+  }
+
+  async goToAccessControlTab(): Promise<void> {
+    await this.accessControlTab().click();
+    await expect(this.accessControlTab()).toHaveAttribute('aria-selected', 'true');
+  }
+
+  async goToAwsInfrastructureAccessTab(): Promise<void> {
+    await this.awsInfrastructureAccessTab().click();
+    await expect(this.awsInfrastructureAccessTab()).toHaveAttribute('aria-selected', 'true');
+    await expect(this.grantRoleButton()).toBeVisible();
+  }
+
+  async openGrantRoleModal(): Promise<void> {
+    await this.goToAwsInfrastructureAccessTab();
+    await this.grantRoleButton().click();
+    await expect(this.grantModalHeading()).toBeVisible();
+  }
+
+  async grantInfrastructureAccessRole(userArn: string, roleName?: string): Promise<void> {
+    await this.openGrantRoleModal();
+    await this.iamArnInput().fill(userArn);
+
+    if (roleName) {
+      await this.roleRadio(roleName).click();
+    }
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'POST' &&
+          resp.url().includes('/aws_infrastructure_access_role_grants'),
+        { timeout: 30000 },
+      ),
+      this.grantRoleSubmitButton().click(),
+    ]);
+    expect(response.ok()).toBeTruthy();
+
+    await expect(this.grantModalHeading()).toBeHidden({ timeout: 30000 });
+  }
+
+  async waitForGrantInTable(userArn: string): Promise<void> {
+    await expect(this.grantRow(userArn)).toBeVisible({ timeout: 120000 });
+  }
+
+  async waitForGrantStatus(userArn: string, status: string): Promise<void> {
+    await this.waitForGrantInTable(userArn);
+    await expect(this.grantRow(userArn)).toContainText(status, { timeout: 120000 });
+  }
+
+  async waitForGrantFailure(userArn: string, roleName?: string): Promise<void> {
+    await Promise.all([
+      expect(this.grantFailureNotification(userArn)).toBeVisible({ timeout: 120000 }),
+      expect(this.grantRow(userArn, roleName)).toContainText('Failed', { timeout: 120000 }),
+    ]);
+  }
+
+  async waitForGrantSuccess(userArn: string, roleName: string): Promise<void> {
+    await Promise.all([
+      expect(this.grantSuccessNotification(userArn, roleName)).toBeVisible({ timeout: 120000 }),
+      expect(this.grantRow(userArn, roleName)).toContainText('Ready', { timeout: 120000 }),
+    ]);
+  }
+
+  async deleteGrant(userArn: string, roleName?: string): Promise<void> {
+    await this.goToAwsInfrastructureAccessTab();
+    await this.grantRow(userArn, roleName).getByRole('button', { name: 'Kebab toggle' }).click();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'DELETE' &&
+          resp.url().includes('/aws_infrastructure_access_role_grants/'),
+        { timeout: 30000 },
+      ),
+      this.page.getByRole('menuitem', { name: 'Delete' }).click(),
+    ]);
+    expect(response.status()).toBe(204);
+
+    await expect(this.grantRow(userArn, roleName)).toBeHidden({ timeout: 120000 });
+  }
+
+  async deleteGrantIfExists(userArn: string, roleName?: string): Promise<void> {
+    await this.goToAwsInfrastructureAccessTab();
+    const row = this.grantRow(userArn, roleName);
+
+    try {
+      await expect(row).toBeVisible({ timeout: 15000 });
+    } catch {
+      return;
+    }
+
+    await row.getByRole('button', { name: 'Kebab toggle' }).click();
+
+    const [response] = await Promise.all([
+      this.page.waitForResponse(
+        (resp) =>
+          resp.request().method() === 'DELETE' &&
+          resp.url().includes('/aws_infrastructure_access_role_grants/'),
+        { timeout: 30000 },
+      ),
+      this.page.getByRole('menuitem', { name: 'Delete' }).click(),
+    ]);
+    expect(response.status()).toBe(204);
+
+    await expect(row).toBeHidden({ timeout: 120000 });
+  }
+}


### PR DESCRIPTION


# Summary

E2e test spec(day2) to cover the access control > AWS infrastructure access for OSD

# Jira
Fixes [OCMUI-3267](https://issues.redhat.com/browse/OCMUI-3267)

# Additional information

 

# How to Test

1 . Create an OSD NonCCS AWS cluster and wait for the cluster to be ready.
2. Export the cluster name
```
export CLUSTER_NAME=<Your cluster name>
```
3. Export the AWS user ARN. (Note: Create a new AWS user and use the ARN or use your existing user ARN)
```
export QE_AWS_INFRA_ACCESS_IAM_ARN=<Your ARN i.e. arn:aws:iam::<AWS id>:user/your aws user name>
```
4. Run the following test case spec
```
% BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts
```


# Screen Captures

```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/access-control/cluster-aws-infrastructure-access.spec.ts

🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 10 tests using 1 worker
…s:204:9 › OSD non-CCS AWS cluster - AWS infrastructure access › Grant Network management role to the same IAM user shows ready status and success notification @day2 @access-control @osd @aws @advanced @non-ccs @aws-infrastructure-access
  10 passed (4.6m)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-3267]: https://redhat.atlassian.net/browse/OCMUI-3267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ