### PR TITLE
OCMUI-3295: Playwright e2e day2 test spec for delete protection features

### DIFF
--- a/playwright/e2e/cluster-actions-common/cluster-delete-protection.spec.ts
+++ b/playwright/e2e/cluster-actions-common/cluster-delete-protection.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from '../../fixtures/pages';
+
+const fixtureData = require('../../fixtures/cluster-actions-common/cluster-delete-protection.spec.json');
+const rosaHostedFixture = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const testData = fixtureData['delete-protection'];
+const clusterName =
+  process.env.CLUSTER_NAME ||
+  rosaHostedFixture['rosa-hosted-public-advanced']['day1-profile'].ClusterName;
+
+test.describe.serial(
+  'Cluster delete protection - Day 2 management (OCP-72600)',
+  { tag: ['@day2', '@clusters', '@advanced', '@delete-protection', '@rosa-hosted', '@hcp'] },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage, clusterDetailsPage }) => {
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterDetailsPage.waitForClusterDetailsLoad();
+      await clusterDetailsPage.isClusterDetailsPage(clusterName);
+    });
+
+    test('can see the Delete Protection section on the Overview tab', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.deleteProtectionTerm()).toBeVisible();
+    });
+
+    test('can open the enable deletion protection modal and verify its content', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openEnableDeleteProtectionModal();
+
+      await expect(clusterDetailsPage.deleteProtectionModalHeading('Enable')).toBeVisible();
+      await expect(clusterDetailsPage.deleteProtectionModalDialog()).toContainText(
+        testData.ModalContent.EnableDescription,
+      );
+      await expect(clusterDetailsPage.deleteProtectionModalPrimaryButton()).toContainText('Enable');
+      await expect(clusterDetailsPage.deleteProtectionModalCancelButton()).toBeVisible();
+    });
+
+    test('can cancel the enable deletion protection modal without changing state', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.cancelDeleteProtectionModal();
+
+      await expect(clusterDetailsPage.deleteProtectionModalDialog()).toBeHidden();
+      await expect(clusterDetailsPage.deleteProtectionEnableButton()).toBeVisible();
+    });
+
+    test('can enable delete protection and verify the state changes to enabled', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.enableDeleteProtection();
+
+      await expect(clusterDetailsPage.deleteProtectionDisableButton()).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    test('Delete cluster action is disabled with a locked tooltip in Actions dropdown when delete protection is enabled', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openActionsDropdown();
+
+      await expect(clusterDetailsPage.deleteClusterDropdownItem()).toBeDisabled();
+
+      await clusterDetailsPage.deleteClusterDropdownItem().hover();
+      await expect(clusterDetailsPage.deleteProtectionDropdownTooltip()).toBeVisible({
+        timeout: 5000,
+      });
+      await expect(clusterDetailsPage.deleteProtectionDropdownTooltip()).toContainText(
+        testData.TooltipContent.DeleteProtectionLocked,
+      );
+
+      await clusterDetailsPage.closeActionsDropdown();
+    });
+
+    test('can open the disable deletion protection modal and verify its content', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openDisableDeleteProtectionModal();
+
+      await expect(clusterDetailsPage.deleteProtectionModalHeading('Disable')).toBeVisible();
+      await expect(clusterDetailsPage.deleteProtectionModalDialog()).toContainText(
+        testData.ModalContent.DisableDescription,
+      );
+      await expect(clusterDetailsPage.deleteProtectionModalPrimaryButton()).toContainText(
+        'Disable',
+      );
+      await expect(clusterDetailsPage.deleteProtectionModalCancelButton()).toBeVisible();
+    });
+
+    test('can cancel the disable deletion protection modal without changing state', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.cancelDeleteProtectionModal();
+
+      await expect(clusterDetailsPage.deleteProtectionModalDialog()).toBeHidden();
+      await expect(clusterDetailsPage.deleteProtectionDisableButton()).toBeVisible();
+    });
+
+    test('can disable delete protection and restore to initial disabled state', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.disableDeleteProtection();
+
+      await expect(clusterDetailsPage.deleteProtectionEnableButton()).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    test('Delete cluster action is enabled with no locked tooltip in Actions dropdown when delete protection is disabled', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openActionsDropdown();
+
+      await expect(clusterDetailsPage.deleteClusterDropdownItem()).not.toBeDisabled();
+
+      await clusterDetailsPage.deleteClusterDropdownItem().hover();
+      await expect(clusterDetailsPage.deleteProtectionDropdownTooltip()).toBeHidden({
+        timeout: 5000,
+      });
+
+      await clusterDetailsPage.closeActionsDropdown();
+    });
+
+    test.afterAll(async ({ clusterDetailsPage }) => {
+      const isEnabled = await clusterDetailsPage
+        .deleteProtectionDisableButton()
+        .isVisible()
+        .catch(() => false);
+
+      if (isEnabled) {
+        await clusterDetailsPage.disableDeleteProtection().catch((error) => {
+          console.error('afterAll: failed to restore delete protection to disabled state', error);
+        });
+      }
+    });
+  },
+);

--- a/playwright/fixtures/cluster-actions-common/cluster-delete-protection.spec.json
+++ b/playwright/fixtures/cluster-actions-common/cluster-delete-protection.spec.json
@@ -1,0 +1,12 @@
+{
+  "delete-protection": {
+    "Description": "Day 2 delete protection toggle tests against an existing managed cluster",
+    "ModalContent": {
+      "EnableDescription": "The cluster cannot be deleted if the Deletion Protection is enabled to safeguard from accidental deletion. You can disable the Deletion Protection at any time.",
+      "DisableDescription": "Disabling the Deletion Protection will allow you to delete this cluster. Cluster deletion can result in data loss or service disruption."
+    },
+    "TooltipContent": {
+      "DeleteProtectionLocked": "Cluster is locked and cannot be deleted. To unlock, go to cluster details and disable deletion protection."
+    }
+  }
+}

--- a/playwright/page-objects/cluster-details-page.ts
+++ b/playwright/page-objects/cluster-details-page.ts
@@ -456,4 +456,79 @@ export class ClusterDetailsPage extends BasePage {
     await this.saveAutoNodeButton().click();
     await expect(this.editAutoNodeModalHeading()).toBeHidden({ timeout: 30000 });
   }
+
+  // Delete protection – Overview tab
+  deleteProtectionTerm(): Locator {
+    return this.page.getByRole('term').filter({ hasText: 'Delete Protection' });
+  }
+
+  deleteProtectionEnableButton(): Locator {
+    return this.page.getByRole('button', { name: 'Enable delete protection' });
+  }
+
+  deleteProtectionDisableButton(): Locator {
+    return this.page.getByRole('button', { name: 'Disable delete protection' });
+  }
+
+  deleteProtectionModalDialog(): Locator {
+    return this.page.getByTestId('delete-protection-dialog');
+  }
+
+  deleteProtectionModalHeading(action: 'Enable' | 'Disable'): Locator {
+    return this.page.getByRole('heading', {
+      name: `${action} deletion protection`,
+    });
+  }
+
+  deleteProtectionModalPrimaryButton(): Locator {
+    return this.deleteProtectionModalDialog().getByTestId('btn-primary');
+  }
+
+  deleteProtectionModalCancelButton(): Locator {
+    return this.deleteProtectionModalDialog().getByRole('button', { name: 'Cancel' });
+  }
+
+  async openEnableDeleteProtectionModal(): Promise<void> {
+    await this.deleteProtectionEnableButton().click();
+    await expect(this.deleteProtectionModalHeading('Enable')).toBeVisible({ timeout: 10000 });
+  }
+
+  async openDisableDeleteProtectionModal(): Promise<void> {
+    await this.deleteProtectionDisableButton().click();
+    await expect(this.deleteProtectionModalHeading('Disable')).toBeVisible({ timeout: 10000 });
+  }
+
+  async cancelDeleteProtectionModal(): Promise<void> {
+    await this.deleteProtectionModalCancelButton().click();
+    await expect(this.deleteProtectionModalDialog()).toBeHidden({ timeout: 10000 });
+  }
+
+  async enableDeleteProtection(): Promise<void> {
+    await this.deleteProtectionEnableButton().click();
+    await expect(this.deleteProtectionModalHeading('Enable')).toBeVisible({ timeout: 10000 });
+    await this.deleteProtectionModalPrimaryButton().click();
+    await expect(this.deleteProtectionModalDialog()).toBeHidden({ timeout: 30000 });
+  }
+
+  async disableDeleteProtection(): Promise<void> {
+    await this.deleteProtectionDisableButton().click();
+    await expect(this.deleteProtectionModalHeading('Disable')).toBeVisible({ timeout: 10000 });
+    await this.deleteProtectionModalPrimaryButton().click();
+    await expect(this.deleteProtectionModalDialog()).toBeHidden({ timeout: 30000 });
+  }
+
+  deleteProtectionDropdownTooltip(): Locator {
+    return this.page.getByTestId('delete-protection-tooltip');
+  }
+
+  async openActionsDropdown(): Promise<void> {
+    await this.actionsDropdownToggle().click();
+    await expect(this.deleteClusterDropdownItem()).toBeVisible({ timeout: 5000 });
+  }
+
+  async closeActionsDropdown(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await expect(this.deleteClusterDropdownItem()).toBeHidden({ timeout: 5000 });
+  }
+  
 }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DeleteProtection/DeleteProtection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DeleteProtection/DeleteProtection.tsx
@@ -39,7 +39,7 @@ const DeleteProtection = ({
     <EditButton
       disableReason={disableToggleReason}
       isAriaDisabled={!!disableToggleReason || pending}
-      ariaLabel={`${protectionEnabled ? 'Disable' : 'Enable'}`}
+      ariaLabel={`${protectionEnabled ? 'Disable' : 'Enable'} delete protection`}
       onClick={() =>
         dispatch(openModal(modals.DELETE_PROTECTION, { clusterID, protectionEnabled, region }))
       }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DeleteProtection/__tests__/DeleteProtection.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DeleteProtection/__tests__/DeleteProtection.test.tsx
@@ -52,7 +52,10 @@ describe('<DeleteProtection />', () => {
     };
     render(<DeleteProtection {...props} />);
 
-    expect(screen.getByRole('button', { name: 'Enable' })).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'Enable delete protection' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
   });
 
   it('Disables the "Disable" button if not enough permission', () => {
@@ -63,7 +66,7 @@ describe('<DeleteProtection />', () => {
     };
     render(<DeleteProtection {...props} />);
 
-    expect(screen.getByRole('button', { name: 'Disable' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Disable delete protection' })).toHaveAttribute(
       'aria-disabled',
       'true',
     );
@@ -78,7 +81,7 @@ describe('<DeleteProtection />', () => {
     };
     render(<DeleteProtection {...props} />);
 
-    expect(screen.getByRole('button', { name: 'Disable' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: 'Disable delete protection' })).toHaveAttribute(
       'aria-disabled',
       'true',
     );

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
@@ -82,7 +82,7 @@ function actionResolver(
   );
 
   const deleteProtectionMessage = cluster.delete_protection?.enabled && (
-    <span>
+    <span data-testid="delete-protection-tooltip">
       Cluster is locked and cannot be deleted. To unlock, go to cluster details and disable deletion
       protection.
     </span>


### PR DESCRIPTION
# Summary

Playwright e2e day2 test spec for delete protection features

# Jira

 Fixes [OCMUI-3295](https://issues.redhat.com/browse/OCMUI-3295)

# Additional information

New day2 e2e spec to validate the delete protection features for cluster.
Currently coverage has done only for ROSA hosted clusters.
Note : Permission vs delete protection feature coverage is out of scope for this PR and will be handled seperately.

# How to Test

1. Create a ROSA Hosted cluster or Use an existing one.
2. Export the cluster name 
3. 
```
export CLUSTER_NAME=<Cluster Name>
```
4. Download the code and start the local server.
5. Run the following test spec.
6. 
```
BROWSER=chromium BASE_URL= https://prod.foo.redhat.com:1337/openshift/  npm run playwright-headless playwright/e2e/cluster-actions-common/cluster-delete-protection.spec.ts 
```


# Screen Captures
```javascript
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/cluster-actions-common/cluster-delete-protection.spec.ts         

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/cluster-actions-common/cluster-delete-protection.spec.ts

🔍 Base URL from config: https://console.dev.redhat.com/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://console.dev.redhat.com/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 9 tests using 1 worker
  9 passed (58.8s)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports

```

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-3295]: https://redhat.atlassian.net/browse/OCMUI-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ