### PR TITLE
OCMUI-3880 : E2e test case spec(day1 and day2) updates for log forwarding features.

### DIFF
--- a/playwright/README.md
+++ b/playwright/README.md
@@ -73,7 +73,7 @@ The test configuration uses `playwright.env.json` for environment-specific setti
   "QE_OCM_ROLE_PREFIX": "cypress-ocm-role",
   "QE_USER_ROLE_PREFIX": "cypress-user-role",
   "QE_OIDC_CONFIG_ID" : "Oidc config id for ROSA hosted clusters",
-  "QE_LOG_FORWARDING_S3_BUCKET_NAME": " AWS S3 bucket name for log forwarding",
+  "QE_LOG_FORWARDING_S3_BUCKET_NAME": "AWS S3 bucket name for log forwarding",
   "QE_LOG_FORWARDING_S3_BUCKET_PREFIX": "AWS s3 bucket prefix or folder name for log forwarding",
   "QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN": "AWS cloud watch account arn role for log forwarding",
   // Optional definitions for special day2 test runs

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -73,6 +73,9 @@ The test configuration uses `playwright.env.json` for environment-specific setti
   "QE_OCM_ROLE_PREFIX": "cypress-ocm-role",
   "QE_USER_ROLE_PREFIX": "cypress-user-role",
   "QE_OIDC_CONFIG_ID" : "Oidc config id for ROSA hosted clusters",
+  "QE_LOG_FORWARDING_S3_BUCKET_NAME": " AWS S3 bucket name for log forwarding",
+  "QE_LOG_FORWARDING_S3_BUCKET_PREFIX": "AWS s3 bucket prefix or folder name for log forwarding",
+  "QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN": "AWS cloud watch account arn role for log forwarding",
   // Optional definitions for special day2 test runs
   "QE_ORGADMIN_USER": "org admin username",
   "QE_ORGADMIN_PASSWORD": "org admin password",

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
@@ -30,7 +30,6 @@ test.describe.serial(
       clusterProperties.MachinePools[0].AvailabilityZones;
 
     test.beforeAll(async ({ navigateTo }) => {
-      // Navigate to create
       await navigateTo('create');
     });
     test('Open Rosa cluster wizard', async ({ page, createRosaWizardPage }) => {

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
@@ -294,8 +294,13 @@ test.describe.serial(
     }) => {
       await expect(createRosaWizardPage.logForwardingReviewSection()).toBeVisible();
       await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewPropertyValue('s3', 'configuration'),
+      ).toHaveText('Disabled');
       await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
-      await expect(createRosaWizardPage.logForwardingReviewConfigurationValues()).toHaveCount(2);
+      await expect(
+        createRosaWizardPage.logForwardingReviewPropertyValue('cw', 'configuration'),
+      ).toHaveText('Disabled');
     });
 
     test('Create cluster and check the installation progress', async ({
@@ -352,9 +357,13 @@ test.describe.serial(
       await expect(clusterDetailsPage.clusterHostPrefixLabelValue()).toContainText(
         clusterProperties.HostPrefix.replace('/', ''),
       );
+
+      await expect(clusterDetailsPage.controlPlaneLogForwardingDescription()).toContainText(
+        'Disabled',
+      );
     });
 
-    test('Delete the cluster', async ({ page, clusterDetailsPage }) => {
+    test('Delete the cluster', async ({clusterDetailsPage }) => {
       await clusterDetailsPage.actionsDropdownToggle().click();
       await clusterDetailsPage.deleteClusterDropdownItem().click();
       await clusterDetailsPage.deleteClusterNameInput().clear();

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts
@@ -59,10 +59,10 @@ test.describe.serial(
         timeout: 30000,
       });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Configuration', 'Enabled'),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Bucket name', s3BucketName),
       ).toBeVisible();
       await expect(clusterDetailsPage.logForwardingCardKebab('Amazon S3')).toBeVisible();
     });
@@ -74,13 +74,13 @@ test.describe.serial(
         timeout: 30000,
       });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Configuration', 'Enabled'),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Log group name', cwLogGroupName),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Log group name', cwLogGroupName),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Role ARN', cwRoleArn),
       ).toBeVisible();
       await expect(clusterDetailsPage.logForwardingCardKebab('CloudWatch')).toBeVisible();
     });
@@ -128,6 +128,13 @@ test.describe.serial(
     }) => {
       await expect(clusterDetailsPage.logForwardingEmptyState()).toBeVisible({ timeout: 30000 });
       await expect(clusterDetailsPage.addConfigurationButton()).toBeEnabled();
+
+      await clusterDetailsPage.navigateToOverviewTab();
+      await expect(clusterDetailsPage.controlPlaneLogForwardingDescription()).toContainText(
+        'Disabled',
+      );
+      await clusterDetailsPage.controlPlaneLogForwardingViewDetailsLink().click();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
     });
 
     // ── Amazon S3 dialog form validations ─────────────────────────────────
@@ -274,16 +281,24 @@ test.describe.serial(
         timeout: 30000,
       });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Configuration', 'Enabled'),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Bucket name', s3BucketName),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Bucket prefix', s3BucketPrefix),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Bucket prefix', s3BucketPrefix),
       ).toBeVisible();
       await expect(clusterDetailsPage.logForwardingCardKebab('Amazon S3')).toBeVisible();
       await expect(clusterDetailsPage.logForwardingEmptyState()).toBeHidden();
+
+      const logForwardingDescription =
+        clusterDetailsPage.controlPlaneLogForwardingDescription();
+      await clusterDetailsPage.navigateToOverviewTab();
+      await expect(logForwardingDescription).toContainText('Amazon S3: Enabled');
+      await expect(logForwardingDescription).toContainText('CloudWatch: Disabled');
+      await clusterDetailsPage.controlPlaneLogForwardingViewDetailsLink().click();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
     });
 
     test('Verify Amazon S3 selected groups and applications are displayed', async ({
@@ -324,13 +339,13 @@ test.describe.serial(
         timeout: 30000,
       });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Configuration', 'Enabled'),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Log group name', updatedCwLogGroupName),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Log group name', updatedCwLogGroupName),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Role ARN', cwRoleArn),
       ).toBeVisible();
     });
 
@@ -340,6 +355,14 @@ test.describe.serial(
       await expect(clusterDetailsPage.addConfigurationButton()).toBeDisabled();
       const tooltip = await clusterDetailsPage.hoverAddConfigurationButton();
       await expect(tooltip).toBeVisible();
+
+      const logForwardingDescription =
+        clusterDetailsPage.controlPlaneLogForwardingDescription();
+      await clusterDetailsPage.navigateToOverviewTab();
+      await expect(logForwardingDescription).toContainText('Amazon S3: Enabled');
+      await expect(logForwardingDescription).toContainText('CloudWatch: Enabled');
+      await clusterDetailsPage.controlPlaneLogForwardingViewDetailsLink().click();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
     });
 
     // ── Edit existing configuration ───────────────────────────────────────
@@ -358,13 +381,13 @@ test.describe.serial(
       clusterDetailsPage,
     }) => {
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Bucket prefix', updatedS3BucketPrefix),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Bucket prefix', updatedS3BucketPrefix),
       ).toBeVisible({ timeout: 30000 });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Bucket name', s3BucketName),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('Amazon S3', 'Configuration', 'Enabled'),
       ).toBeVisible();
     });
 
@@ -389,13 +412,13 @@ test.describe.serial(
       clusterDetailsPage,
     }) => {
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Log group name', editedCwLogGroupName),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Log group name', editedCwLogGroupName),
       ).toBeVisible({ timeout: 30000 });
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Role ARN', cwRoleArn),
       ).toBeVisible();
       await expect(
-        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+        clusterDetailsPage.logForwardingPropertyValue('CloudWatch', 'Configuration', 'Enabled'),
       ).toBeVisible();
     });
 
@@ -420,6 +443,14 @@ test.describe.serial(
       });
       await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeVisible();
       await expect(clusterDetailsPage.addConfigurationButton()).toBeEnabled();
+
+      const logForwardingDescription =
+        clusterDetailsPage.controlPlaneLogForwardingDescription();
+      await clusterDetailsPage.navigateToOverviewTab();
+      await expect(logForwardingDescription).toContainText('Amazon S3: Enabled');
+      await expect(logForwardingDescription).toContainText('CloudWatch: Disabled');
+      await clusterDetailsPage.controlPlaneLogForwardingViewDetailsLink().click();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
     });
 
     test('Re-add CloudWatch configuration after deletion', async ({ clusterDetailsPage }) => {
@@ -439,6 +470,14 @@ test.describe.serial(
       });
       await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeVisible();
       await expect(clusterDetailsPage.addConfigurationButton()).toBeDisabled();
+
+      const logForwardingDescription =
+        clusterDetailsPage.controlPlaneLogForwardingDescription();
+      await clusterDetailsPage.navigateToOverviewTab();
+      await expect(logForwardingDescription).toContainText('Amazon S3: Enabled');
+      await expect(logForwardingDescription).toContainText('CloudWatch: Enabled');
+      await clusterDetailsPage.controlPlaneLogForwardingViewDetailsLink().click();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
     });
 
     // ── Restore initial state (runs even if tests fail) ─────────────────

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts
@@ -1,0 +1,478 @@
+import { test, expect } from '../../fixtures/pages';
+
+const clusterProfiles = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const clusterProperties = clusterProfiles['rosa-hosted-public-advanced']['day1-profile'];
+const day2Properties = clusterProfiles['rosa-hosted-public-advanced']['day2-profile'];
+const logForwardingProperties = day2Properties.ControlPlaneLogForwarding;
+const validationFixture = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.json');
+
+test.describe.serial(
+  'ROSA HCP Day2 - Control plane log forwarding management',
+  { tag: ['@day2', '@rosa-hosted', '@rosa', '@hcp', '@log-forwarding', '@advanced'] },
+  () => {
+    const clusterName = process.env.CLUSTER_NAME || clusterProperties.ClusterName;
+    const s3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
+    const s3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
+    const cwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
+    const cwLogGroupName = clusterProperties.CloudWatchLogGroupName;
+    const updatedS3BucketPrefix = logForwardingProperties.UpdatedS3BucketPrefix;
+    const updatedCwLogGroupName = logForwardingProperties.UpdatedCwLogGroupName;
+    const editedCwLogGroupName = logForwardingProperties.EditedCwLogGroupName;
+    const s3SelectedGroup = logForwardingProperties.SelectedGroup;
+    const s3Validation = validationFixture.LogForwarding.S3;
+    const cwValidation = validationFixture.LogForwarding.CloudWatch;
+
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      if (!s3BucketName || !s3BucketPrefix || !cwRoleArn) {
+        throw new Error(
+          'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
+        );
+      }
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test('Navigate to cluster and open the Settings tab', async ({
+      clusterListPage,
+      clusterDetailsPage,
+    }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterDetailsPage.navigateToSettingsTab();
+    });
+
+    test('Verify Control plane log forwarding section is visible', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.scrollToLogForwardingSection();
+      await clusterDetailsPage.isLogForwardingSectionVisible();
+    });
+
+    // ── Verify pre-existing configurations ────────────────────────────────
+
+    test('Verify pre-existing Amazon S3 configuration properties', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingCardKebab('Amazon S3')).toBeVisible();
+    });
+
+    test('Verify pre-existing CloudWatch configuration properties', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Log group name', cwLogGroupName),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingCardKebab('CloudWatch')).toBeVisible();
+    });
+
+    test('Verify Add configuration button is disabled when both exist', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.addConfigurationButton()).toBeDisabled();
+      const tooltip = await clusterDetailsPage.hoverAddConfigurationButton();
+      await expect(tooltip).toBeVisible();
+    });
+
+    // ── Delete pre-existing configurations to reach empty state ───────────
+
+    test('Delete pre-existing CloudWatch configuration', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openCardKebabAction('CloudWatch', 'Delete configuration');
+      await expect(
+        clusterDetailsPage.logForwardingModalHeading('Delete', 'CloudWatch'),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingDeleteDescription()).toContainText(
+        'will stop the stream of cluster logs to CloudWatch',
+      );
+      await clusterDetailsPage.confirmDeleteLogForwarding();
+      await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeHidden({
+        timeout: 30000,
+      });
+    });
+
+    test('Delete pre-existing Amazon S3 configuration', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openCardKebabAction('Amazon S3', 'Delete configuration');
+      await expect(
+        clusterDetailsPage.logForwardingModalHeading('Delete', 'Amazon S3'),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingDeleteDescription()).toContainText(s3BucketName);
+      await clusterDetailsPage.confirmDeleteLogForwarding();
+      await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeHidden({
+        timeout: 30000,
+      });
+    });
+
+    // ── Verify empty state ────────────────────────────────────────────────
+
+    test('Verify empty state shows "No log forwarding configured"', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingEmptyState()).toBeVisible({ timeout: 30000 });
+      await expect(clusterDetailsPage.addConfigurationButton()).toBeEnabled();
+    });
+
+    // ── Amazon S3 dialog form validations ─────────────────────────────────
+
+    test('Validate Amazon S3 dialog - bucket name field errors', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('Amazon S3');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'Amazon S3')).toBeVisible();
+
+      await clusterDetailsPage.logForwardingBucketNameInput().fill(s3Validation.BucketNameTooShort);
+      await clusterDetailsPage.logForwardingBucketPrefixInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketNameTooShortError);
+
+      await clusterDetailsPage.logForwardingBucketNameInput().clear();
+      await clusterDetailsPage.logForwardingBucketNameInput().fill(s3Validation.BucketNameTooLong);
+      await clusterDetailsPage.logForwardingBucketPrefixInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketNameTooLongError);
+
+      await clusterDetailsPage.logForwardingBucketNameInput().clear();
+      await clusterDetailsPage
+        .logForwardingBucketNameInput()
+        .fill(s3Validation.BucketNameStartsUppercase);
+      await clusterDetailsPage.logForwardingBucketPrefixInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketNameStartsUppercaseError);
+
+      await clusterDetailsPage.logForwardingBucketNameInput().clear();
+      await clusterDetailsPage
+        .logForwardingBucketNameInput()
+        .fill(s3Validation.BucketNameConsecutiveDots);
+      await clusterDetailsPage.logForwardingBucketPrefixInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketNameConsecutiveDotsError);
+
+      await clusterDetailsPage.logForwardingBucketNameInput().clear();
+      await clusterDetailsPage
+        .logForwardingBucketNameInput()
+        .fill(s3Validation.BucketNameIPAddress);
+      await clusterDetailsPage.logForwardingBucketPrefixInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketNameIPAddressError);
+
+      await clusterDetailsPage.logForwardingModalCancelButton().click();
+    });
+
+    test('Validate Amazon S3 dialog - bucket prefix field errors', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('Amazon S3');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'Amazon S3')).toBeVisible();
+
+      await clusterDetailsPage.logForwardingBucketNameInput().fill(s3BucketName);
+      await clusterDetailsPage
+        .logForwardingBucketPrefixInput()
+        .fill(s3Validation.BucketPrefixConsecutiveDots);
+      await clusterDetailsPage.logForwardingBucketNameInput().click();
+      await clusterDetailsPage.isTextContainsInPage(s3Validation.BucketPrefixConsecutiveDotsError);
+
+      await clusterDetailsPage.logForwardingBucketPrefixInput().clear();
+      await clusterDetailsPage.logForwardingBucketNameInput().click();
+      await clusterDetailsPage.isTextContainsInPage(
+        s3Validation.BucketPrefixConsecutiveDotsError,
+        false,
+      );
+
+      await clusterDetailsPage.logForwardingModalCancelButton().click();
+    });
+
+    // ── CloudWatch dialog form validations ──────────────────────────────
+
+    test('Validate CloudWatch dialog - required field errors', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'CloudWatch')).toBeVisible();
+
+      await clusterDetailsPage.logForwardingLogGroupNameInput().clear();
+      await clusterDetailsPage.logForwardingRoleArnInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.LogGroupNameRequired);
+
+      await clusterDetailsPage.logForwardingRoleArnInput().clear();
+      await clusterDetailsPage.logForwardingLogGroupNameInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.RoleArnRequired);
+
+      await clusterDetailsPage.logForwardingModalCancelButton().click();
+    });
+
+    test('Validate CloudWatch dialog - log group name field errors', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'CloudWatch')).toBeVisible();
+
+      await clusterDetailsPage
+        .logForwardingLogGroupNameInput()
+        .fill(cwValidation.LogGroupNameInvalidChars);
+      await clusterDetailsPage.logForwardingRoleArnInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.LogGroupNameInvalidCharsError);
+
+      await clusterDetailsPage.logForwardingLogGroupNameInput().clear();
+      await clusterDetailsPage
+        .logForwardingLogGroupNameInput()
+        .fill(cwValidation.LogGroupNameWithColon);
+      await clusterDetailsPage.logForwardingRoleArnInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.LogGroupNameWithColonError);
+
+      await clusterDetailsPage.logForwardingLogGroupNameInput().clear();
+      await clusterDetailsPage
+        .logForwardingLogGroupNameInput()
+        .fill(cwValidation.LogGroupNameTooLong);
+      await clusterDetailsPage.logForwardingRoleArnInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.LogGroupNameTooLongError);
+
+      await clusterDetailsPage.logForwardingModalCancelButton().click();
+    });
+
+    test('Validate CloudWatch dialog - role ARN field errors', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'CloudWatch')).toBeVisible();
+
+      await clusterDetailsPage.logForwardingRoleArnInput().fill(cwValidation.RoleArnInvalidFormat);
+      await clusterDetailsPage.logForwardingLogGroupNameInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.RoleArnInvalidFormatError);
+
+      await clusterDetailsPage.logForwardingRoleArnInput().clear();
+      await clusterDetailsPage.logForwardingRoleArnInput().fill(cwValidation.RoleArnWhitespace);
+      await clusterDetailsPage.logForwardingLogGroupNameInput().click();
+      await clusterDetailsPage.isTextContainsInPage(cwValidation.RoleArnWhitespaceError);
+
+      await clusterDetailsPage.logForwardingModalCancelButton().click();
+    });
+
+    // ── Add new configurations ────────────────────────────────────────────
+
+    test('Add Amazon S3 log forwarding configuration with first group only', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('Amazon S3');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'Amazon S3')).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingSubmitButton()).toBeDisabled();
+      await clusterDetailsPage.fillS3Configuration(s3BucketName, s3BucketPrefix);
+      await clusterDetailsPage.selectLogForwardingGroup(s3SelectedGroup);
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+
+    test('Verify Amazon S3 configuration card is displayed with correct details', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Bucket prefix', s3BucketPrefix),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingCardKebab('Amazon S3')).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingEmptyState()).toBeHidden();
+    });
+
+    test('Verify Amazon S3 selected groups and applications are displayed', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingSelectedGroupsHeading()).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingGroupCategory(s3SelectedGroup)).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingGroupLabel(s3SelectedGroup, 'kube-apiserver'),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingGroupLabel(s3SelectedGroup, 'audit-webhook'),
+      ).toBeVisible();
+    });
+
+    test('Verify Add configuration dropdown still shows CloudWatch option', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.addConfigurationButton().click();
+      await expect(clusterDetailsPage.addConfigurationMenuItem('CloudWatch')).toBeVisible();
+      await clusterDetailsPage.pressKey('Escape');
+    });
+
+    test('Add CloudWatch log forwarding configuration', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'CloudWatch')).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingSubmitButton()).toBeDisabled();
+      await clusterDetailsPage.logForwardingPrerequisiteCheckbox().check();
+      await clusterDetailsPage.fillCloudWatchConfiguration(updatedCwLogGroupName, cwRoleArn);
+      await clusterDetailsPage.selectAllLogForwardingGroups();
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+
+    test('Verify CloudWatch configuration card is displayed with correct details', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Log group name', updatedCwLogGroupName),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+      ).toBeVisible();
+    });
+
+    test('Verify Add configuration button is disabled after both are added', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.addConfigurationButton()).toBeDisabled();
+      const tooltip = await clusterDetailsPage.hoverAddConfigurationButton();
+      await expect(tooltip).toBeVisible();
+    });
+
+    // ── Edit existing configuration ───────────────────────────────────────
+
+    test('Edit Amazon S3 configuration - update bucket prefix', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openCardKebabAction('Amazon S3', 'Edit configuration');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Edit', 'Amazon S3')).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingBucketNameInput()).toHaveValue(s3BucketName);
+      await expect(clusterDetailsPage.logForwardingSubmitButton()).toBeDisabled();
+      await clusterDetailsPage.logForwardingBucketPrefixInput().clear();
+      await clusterDetailsPage.logForwardingBucketPrefixInput().fill(updatedS3BucketPrefix);
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+
+    test('Verify edited Amazon S3 configuration shows updated bucket prefix', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Bucket prefix', updatedS3BucketPrefix),
+      ).toBeVisible({ timeout: 30000 });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Bucket name', s3BucketName),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+    });
+
+    test('Edit CloudWatch configuration - update log group name', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openCardKebabAction('CloudWatch', 'Edit configuration');
+      await expect(
+        clusterDetailsPage.logForwardingModalHeading('Edit', 'CloudWatch'),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingLogGroupNameInput()).toHaveValue(
+        updatedCwLogGroupName,
+      );
+      await expect(clusterDetailsPage.logForwardingRoleArnInput()).toHaveValue(cwRoleArn);
+      await expect(clusterDetailsPage.logForwardingSubmitButton()).toBeDisabled();
+      await clusterDetailsPage.logForwardingLogGroupNameInput().clear();
+      await clusterDetailsPage.logForwardingLogGroupNameInput().fill(editedCwLogGroupName);
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+
+    test('Verify edited CloudWatch configuration shows updated log group name', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Log group name', editedCwLogGroupName),
+      ).toBeVisible({ timeout: 30000 });
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Role ARN', cwRoleArn),
+      ).toBeVisible();
+      await expect(
+        clusterDetailsPage.logForwardingPropertyValue('Configuration', 'Enabled'),
+      ).toBeVisible();
+    });
+
+    // ── Delete and re-add to leave cluster in a consistent state ──────────
+
+    test('Delete CloudWatch configuration via kebab menu', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openCardKebabAction('CloudWatch', 'Delete configuration');
+      await expect(
+        clusterDetailsPage.logForwardingModalHeading('Delete', 'CloudWatch'),
+      ).toBeVisible();
+      await expect(clusterDetailsPage.logForwardingDeleteDescription()).toContainText(
+        editedCwLogGroupName,
+      );
+      await clusterDetailsPage.confirmDeleteLogForwarding();
+    });
+
+    test('Verify CloudWatch card is removed and Add configuration is re-enabled', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeVisible();
+      await expect(clusterDetailsPage.addConfigurationButton()).toBeEnabled();
+    });
+
+    test('Re-add CloudWatch configuration after deletion', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await expect(clusterDetailsPage.logForwardingModalHeading('Add', 'CloudWatch')).toBeVisible();
+      await clusterDetailsPage.logForwardingPrerequisiteCheckbox().check();
+      await clusterDetailsPage.fillCloudWatchConfiguration(updatedCwLogGroupName, cwRoleArn);
+      await clusterDetailsPage.selectAllLogForwardingGroups();
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+
+    test('Verify both configurations are present after full CRUD cycle', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeVisible({
+        timeout: 30000,
+      });
+      await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeVisible();
+      await expect(clusterDetailsPage.addConfigurationButton()).toBeDisabled();
+    });
+
+    // ── Restore initial state (runs even if tests fail) ─────────────────
+
+    test.afterAll(async ({ clusterDetailsPage }) => {
+      // Delete existing configs if present
+      if (await clusterDetailsPage.logForwardingCardTitle('CloudWatch').isVisible()) {
+        await clusterDetailsPage.openCardKebabAction('CloudWatch', 'Delete configuration');
+        await clusterDetailsPage.confirmDeleteLogForwarding();
+        await expect(clusterDetailsPage.logForwardingCardTitle('CloudWatch')).toBeHidden({
+          timeout: 30000,
+        });
+      }
+
+      if (await clusterDetailsPage.logForwardingCardTitle('Amazon S3').isVisible()) {
+        await clusterDetailsPage.openCardKebabAction('Amazon S3', 'Delete configuration');
+        await clusterDetailsPage.confirmDeleteLogForwarding();
+        await expect(clusterDetailsPage.logForwardingCardTitle('Amazon S3')).toBeHidden({
+          timeout: 30000,
+        });
+      }
+
+      // Add CloudWatch with initial values
+      await clusterDetailsPage.openAddConfigurationMenu('CloudWatch');
+      await clusterDetailsPage.logForwardingPrerequisiteCheckbox().check();
+      await clusterDetailsPage.fillCloudWatchConfiguration(cwLogGroupName, cwRoleArn);
+      await clusterDetailsPage.selectAllLogForwardingGroups();
+      await clusterDetailsPage.submitLogForwardingModal();
+
+      // Add Amazon S3 with initial values
+      await clusterDetailsPage.openAddConfigurationMenu('Amazon S3');
+      await clusterDetailsPage.fillS3Configuration(s3BucketName, s3BucketPrefix);
+      await clusterDetailsPage.selectAllLogForwardingGroups();
+      await clusterDetailsPage.submitLogForwardingModal();
+    });
+  },
+);

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
@@ -26,13 +26,13 @@ test.describe.serial(
     const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
     const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
     const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
-    if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
-      throw new Error(
-        'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
-      );
-    }
+
     test.beforeAll(async ({ navigateTo }) => {
-      // Initial navigation using navigateTo
+      if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
+        throw new Error(
+          'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
+        );
+      }
       await navigateTo('create');
     });
 

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
@@ -23,7 +23,14 @@ test.describe.serial(
     const installerARN = `arn:aws:iam::${awsAccountID}:role/${rolePrefix}-HCP-ROSA-Installer-Role`;
     const clusterName = clusterProperties.ClusterName;
     const oidcConfigId = process.env.QE_OIDC_CONFIG_ID ?? clusterProperties.OidcConfigId;
-
+    const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
+    const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
+    const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
+    if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
+      throw new Error(
+        'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
+      );
+    }
     test.beforeAll(async ({ navigateTo }) => {
       // Initial navigation using navigateTo
       await navigateTo('create');
@@ -163,6 +170,28 @@ test.describe.serial(
       await createRosaWizardPage.rosaNextButton().click();
     });
 
+    test('Step - Control plane log forwarding - enable S3 and CloudWatch', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isLogForwardingScreen();
+      await createRosaWizardPage.amazonS3EnableCheckbox().check();
+      await createRosaWizardPage.logForwardingS3BucketNameInput().fill(logForwardingS3BucketName);
+      await createRosaWizardPage
+        .logForwardingS3BucketPrefixInput()
+        .fill(logForwardingS3BucketPrefix);
+      await createRosaWizardPage.selectAllLogForwardingGroups('S3');
+
+      await createRosaWizardPage.cloudWatchEnableCheckbox().check();
+      await expect(createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput()).toHaveValue(
+        new RegExp(`^${clusterName.slice(0, 15)}`),
+      );
+      await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().fill(logForwardingCwRoleArn);
+      await createRosaWizardPage.logForwardingCloudWatchPrerequisiteCheckbox().check();
+      await createRosaWizardPage.selectAllLogForwardingGroups('CloudWatch');
+
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
     test('Step - Review and create : Accounts and roles definitions', async ({
       createRosaWizardPage,
     }) => {
@@ -285,6 +314,25 @@ test.describe.serial(
         'OIDC Configuration ID',
         oidcConfigId,
       );
+    });
+
+    test('Step - Review and create : Log forwarding definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketName),
+      ).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketPrefix),
+      ).toBeVisible();
+      await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(clusterName.slice(0, 15)),
+      ).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingCwRoleArn),
+      ).toBeVisible();
     });
 
     test('Create cluster and check the installation progress', async ({

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-private-advanced-creation.spec.ts
@@ -23,16 +23,7 @@ test.describe.serial(
     const installerARN = `arn:aws:iam::${awsAccountID}:role/${rolePrefix}-HCP-ROSA-Installer-Role`;
     const clusterName = clusterProperties.ClusterName;
     const oidcConfigId = process.env.QE_OIDC_CONFIG_ID ?? clusterProperties.OidcConfigId;
-    const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
-    const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
-    const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
-
     test.beforeAll(async ({ navigateTo }) => {
-      if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
-        throw new Error(
-          'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
-        );
-      }
       await navigateTo('create');
     });
 
@@ -170,25 +161,14 @@ test.describe.serial(
       await createRosaWizardPage.rosaNextButton().click();
     });
 
-    test('Step - Control plane log forwarding - enable S3 and CloudWatch', async ({
+    test('Step - Additional set up - Control plane log forwarding options', async ({
       createRosaWizardPage,
     }) => {
       await createRosaWizardPage.isLogForwardingScreen();
-      await createRosaWizardPage.amazonS3EnableCheckbox().check();
-      await createRosaWizardPage.logForwardingS3BucketNameInput().fill(logForwardingS3BucketName);
-      await createRosaWizardPage
-        .logForwardingS3BucketPrefixInput()
-        .fill(logForwardingS3BucketPrefix);
-      await createRosaWizardPage.selectAllLogForwardingGroups('S3');
-
-      await createRosaWizardPage.cloudWatchEnableCheckbox().check();
-      await expect(createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput()).toHaveValue(
-        new RegExp(`^${clusterName.slice(0, 15)}`),
-      );
-      await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().fill(logForwardingCwRoleArn);
-      await createRosaWizardPage.logForwardingCloudWatchPrerequisiteCheckbox().check();
-      await createRosaWizardPage.selectAllLogForwardingGroups('CloudWatch');
-
+      await expect(createRosaWizardPage.amazonS3Heading()).toBeVisible();
+      await expect(createRosaWizardPage.cloudWatchHeading()).toBeVisible();
+      await expect(createRosaWizardPage.amazonS3EnableCheckbox()).not.toBeChecked();
+      await expect(createRosaWizardPage.cloudWatchEnableCheckbox()).not.toBeChecked();
       await createRosaWizardPage.rosaNextButton().click();
     });
 
@@ -316,23 +296,18 @@ test.describe.serial(
       );
     });
 
-    test('Step - Review and create : Log forwarding definitions', async ({
+    test('Step - Review and create : Control plane log forwarding definitions', async ({
       createRosaWizardPage,
     }) => {
+      await expect(createRosaWizardPage.logForwardingReviewSection()).toBeVisible();
       await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
       await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketName),
-      ).toBeVisible();
-      await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketPrefix),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('s3', 'configuration'),
+      ).toHaveText('Disabled');
       await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
       await expect(
-        createRosaWizardPage.logForwardingReviewText(clusterName.slice(0, 15)),
-      ).toBeVisible();
-      await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingCwRoleArn),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('cw', 'configuration'),
+      ).toHaveText('Disabled');
     });
 
     test('Create cluster and check the installation progress', async ({

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
@@ -23,9 +23,15 @@ test.describe.serial(
     const installerARN = `arn:aws:iam::${awsAccountID}:role/${rolePrefix}-HCP-ROSA-Installer-Role`;
     const clusterName = clusterProperties.ClusterName;
     const oidcConfigId = process.env.QE_OIDC_CONFIG_ID ?? clusterProperties.OidcConfigId;
-
+    const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
+    const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
+    const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
+    if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
+      throw new Error(
+        'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
+      );
+    }
     test.beforeAll(async ({ navigateTo }) => {
-      // Initial navigation using navigateTo
       await navigateTo('create');
     });
 
@@ -171,6 +177,28 @@ test.describe.serial(
       } else {
         await createRosaWizardPage.individualUpdateRadio().check({ force: true });
       }
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Control plane log forwarding - enable S3 and CloudWatch', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isLogForwardingScreen();
+      await createRosaWizardPage.amazonS3EnableCheckbox().check();
+      await createRosaWizardPage.logForwardingS3BucketNameInput().fill(logForwardingS3BucketName);
+      await createRosaWizardPage
+        .logForwardingS3BucketPrefixInput()
+        .fill(logForwardingS3BucketPrefix);
+      await createRosaWizardPage.selectAllLogForwardingGroups('S3');
+
+      await createRosaWizardPage.cloudWatchEnableCheckbox().check();
+      await expect(createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput()).toHaveValue(
+        new RegExp(`^${clusterName.slice(0, 15)}`),
+      );
+      await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().fill(logForwardingCwRoleArn);
+      await createRosaWizardPage.logForwardingCloudWatchPrerequisiteCheckbox().check();
+      await createRosaWizardPage.selectAllLogForwardingGroups('CloudWatch');
+
       await createRosaWizardPage.rosaNextButton().click();
     });
 
@@ -324,6 +352,25 @@ test.describe.serial(
         'OIDC Configuration ID',
         oidcConfigId,
       );
+    });
+
+    test('Step - Review and create : Log forwarding definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketName),
+      ).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketPrefix),
+      ).toBeVisible();
+      await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(clusterName.slice(0, 15)),
+      ).toBeVisible();
+      await expect(
+        createRosaWizardPage.logForwardingReviewText(logForwardingCwRoleArn),
+      ).toBeVisible();
     });
 
     test('Create cluster and check the installation progress', async ({

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
@@ -365,18 +365,24 @@ test.describe.serial(
     }) => {
       await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
       await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketName),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('s3', 'configuration'),
+      ).toHaveText('Enabled');
       await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingS3BucketPrefix),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('s3', 'bucket-name'),
+      ).toHaveText(logForwardingS3BucketName);
+      await expect(
+        createRosaWizardPage.logForwardingReviewPropertyValue('s3', 'bucket-prefix'),
+      ).toHaveText(logForwardingS3BucketPrefix);
       await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
       await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingCwLogGroupName),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('cw', 'configuration'),
+      ).toHaveText('Enabled');
       await expect(
-        createRosaWizardPage.logForwardingReviewText(logForwardingCwRoleArn),
-      ).toBeVisible();
+        createRosaWizardPage.logForwardingReviewPropertyValue('cw', 'log-group-name'),
+      ).toHaveText(logForwardingCwLogGroupName);
+      await expect(
+        createRosaWizardPage.logForwardingReviewPropertyValue('cw', 'role-arn'),
+      ).toHaveText(logForwardingCwRoleArn);
     });
 
     test('Create cluster and check the installation progress', async ({
@@ -400,6 +406,11 @@ test.describe.serial(
       await clusterDetailsPage.checkInstallationStepStatus('Network settings');
       await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
       await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+
+      const logForwardingDescription =
+        clusterDetailsPage.controlPlaneLogForwardingDescription();
+      await expect(logForwardingDescription).toContainText('Amazon S3: Enabled');
+      await expect(logForwardingDescription).toContainText('CloudWatch: Enabled');
     });
   },
 );

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
@@ -26,6 +26,7 @@ test.describe.serial(
     const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
     const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
     const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
+    const logForwardingCwLogGroupName = clusterProperties.CloudWatchLogGroupName;
 
     test.beforeAll(async ({ navigateTo }) => {
       if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
@@ -196,6 +197,10 @@ test.describe.serial(
       await expect(createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput()).toHaveValue(
         new RegExp(`^${clusterName.slice(0, 15)}`),
       );
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchLogGroupNameInput()
+        .fill(logForwardingCwLogGroupName);
       await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().fill(logForwardingCwRoleArn);
       await createRosaWizardPage.logForwardingCloudWatchPrerequisiteCheckbox().check();
       await createRosaWizardPage.selectAllLogForwardingGroups('CloudWatch');
@@ -367,7 +372,7 @@ test.describe.serial(
       ).toBeVisible();
       await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
       await expect(
-        createRosaWizardPage.logForwardingReviewText(clusterName.slice(0, 15)),
+        createRosaWizardPage.logForwardingReviewText(logForwardingCwLogGroupName),
       ).toBeVisible();
       await expect(
         createRosaWizardPage.logForwardingReviewText(logForwardingCwRoleArn),

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
@@ -26,12 +26,13 @@ test.describe.serial(
     const logForwardingS3BucketName = process.env.QE_LOG_FORWARDING_S3_BUCKET_NAME || '';
     const logForwardingS3BucketPrefix = process.env.QE_LOG_FORWARDING_S3_BUCKET_PREFIX || '';
     const logForwardingCwRoleArn = process.env.QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN || '';
-    if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
-      throw new Error(
-        'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
-      );
-    }
+
     test.beforeAll(async ({ navigateTo }) => {
+      if (!logForwardingS3BucketName || !logForwardingS3BucketPrefix || !logForwardingCwRoleArn) {
+        throw new Error(
+          'Missing required env vars: QE_LOG_FORWARDING_S3_BUCKET_NAME, QE_LOG_FORWARDING_S3_BUCKET_PREFIX, QE_LOG_FORWARDING_CLOUDWATCH_ROLE_ARN',
+        );
+      }
       await navigateTo('create');
     });
 

--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
@@ -797,6 +797,237 @@ test.describe.serial(
       await createRosaWizardPage.customOperatorPrefixInput().selectText();
       await createRosaWizardPage.customOperatorPrefixInput().fill('test-123-test');
       await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Cluster updates - navigate through', async ({ createRosaWizardPage }) => {
+      await createRosaWizardPage.isUpdatesScreen();
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
+    test('Step - Control plane log forwarding - widget validations', async ({
+      createRosaWizardPage,
+    }) => {
+      // --- S3 validations ---
+      await createRosaWizardPage.amazonS3EnableCheckbox().check();
+
+      // Click Next with empty S3 bucket name → required error
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameRequired,
+      );
+
+      // Bucket name too short (< 3 chars)
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameTooShort);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameTooShortError,
+      );
+
+      // Bucket name too long (> 63 chars)
+      await createRosaWizardPage.logForwardingS3BucketNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameTooLong);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameTooLongError,
+      );
+
+      // Bucket name starts with uppercase
+      await createRosaWizardPage.logForwardingS3BucketNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameStartsUppercase);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameStartsUppercaseError,
+      );
+
+      // Bucket name with consecutive dots
+      await createRosaWizardPage.logForwardingS3BucketNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameConsecutiveDots);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameConsecutiveDotsError,
+      );
+
+      // Bucket name formatted as IP address
+      await createRosaWizardPage.logForwardingS3BucketNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameIPAddress);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketNameIPAddressError,
+      );
+
+      // Bucket prefix with consecutive dots
+      await createRosaWizardPage.logForwardingS3BucketNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketNameValid);
+      await createRosaWizardPage
+        .logForwardingS3BucketPrefixInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.BucketPrefixConsecutiveDots);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketPrefixConsecutiveDotsError,
+      );
+
+      // Clear prefix error with valid bucket name
+      await createRosaWizardPage.logForwardingS3BucketPrefixInput().clear();
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.BucketPrefixConsecutiveDotsError,
+        false,
+      );
+
+      // Click Next without selecting any S3 groups → required error
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.SelectedItemsRequired,
+      );
+
+      // Uncheck S3 to clear its errors
+      await createRosaWizardPage.amazonS3EnableCheckbox().uncheck();
+
+      // --- CloudWatch validations ---
+      await createRosaWizardPage.cloudWatchEnableCheckbox().check();
+
+      // Log group name auto-fills; clear it and verify required error
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameRequired,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.RoleArnRequired,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.PrerequisiteAckRequired,
+      );
+
+      // Log group name with invalid characters
+      await createRosaWizardPage
+        .logForwardingCloudWatchLogGroupNameInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameInvalidChars);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameInvalidCharsError,
+      );
+
+      // Log group name with colon (rejected by OCM)
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchLogGroupNameInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameWithColon);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameWithColonError,
+      );
+
+      // Log group name too long (> 512 chars)
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchLogGroupNameInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameTooLong);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameTooLongError,
+      );
+
+      // Valid log group name → error clears
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().fill('valid-log-group');
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameRequired,
+        false,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.LogGroupNameInvalidCharsError,
+        false,
+      );
+
+      // Role ARN with invalid format
+      await createRosaWizardPage
+        .logForwardingCloudWatchRoleArnInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.RoleArnInvalidFormat);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.RoleArnInvalidFormatError,
+      );
+
+      // Role ARN with whitespace
+      await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchRoleArnInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.RoleArnWhitespace);
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.RoleArnWhitespaceError,
+      );
+
+      // --- Fill valid S3 and CloudWatch data, then verify group selection required ---
+
+      // Enable S3 and fill valid data
+      await createRosaWizardPage.amazonS3EnableCheckbox().check();
+      await createRosaWizardPage
+        .logForwardingS3BucketNameInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.ValidBucketName);
+      await createRosaWizardPage
+        .logForwardingS3BucketPrefixInput()
+        .fill(clusterFieldValidations.LogForwarding.S3.ValidBucketPrefix);
+
+      // Clear CloudWatch errors and fill valid data
+      await createRosaWizardPage.logForwardingCloudWatchRoleArnInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchRoleArnInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.ValidRoleArn);
+      await createRosaWizardPage.logForwardingCloudWatchLogGroupNameInput().clear();
+      await createRosaWizardPage
+        .logForwardingCloudWatchLogGroupNameInput()
+        .fill(clusterFieldValidations.LogForwarding.CloudWatch.ValidLogGroupName);
+      await createRosaWizardPage.logForwardingCloudWatchPrerequisiteCheckbox().check();
+
+      // Click Next without selecting any groups → both S3 and CloudWatch group errors
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.SelectedItemsRequired,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.SelectedItemsRequired,
+      );
+
+      // Select groups (both S3 and CloudWatch trees are visible: S3=nth(0), CloudWatch=nth(1))
+      await createRosaWizardPage.selectLogForwardingGroup('api', 'S3');
+      await createRosaWizardPage.selectLogForwardingGroup('api', 'CloudWatch');
+
+      // Navigate to Review and Create
+      await createRosaWizardPage.rosaNextButton().click();
+      await createRosaWizardPage.waitForReviewScreenReady();
+
+      // Verify S3 details on review screen
+      await createRosaWizardPage.isTextContainsInPage('Amazon S3');
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.ValidBucketName,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.S3.ValidBucketPrefix,
+      );
+      // Verify CloudWatch details on review screen
+      await createRosaWizardPage.isTextContainsInPage('CloudWatch');
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.ValidLogGroupName,
+      );
+      await createRosaWizardPage.isTextContainsInPage(
+        clusterFieldValidations.LogForwarding.CloudWatch.ValidRoleArn,
+      );
+
       await createRosaWizardPage.rosaCancelButton().click();
     });
   },

--- a/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json
+++ b/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json
@@ -31,6 +31,7 @@
         "MiniNodeCount": "2",
         "MaxNodeCount": "4"
       },
+      "CloudWatchLogGroupName": "ply-rosa-hosted-cw-log-group",
       "ClusterProxy": {
         "HttpProxy": "http://test.com",
         "HttpsProxy": "https://test.com",
@@ -51,6 +52,12 @@
           "CompatibleInstanceType": "c5.metal",
           "IncompatibleInstanceType": "m5.xlarge"
         }
+      },
+      "ControlPlaneLogForwarding": {
+        "UpdatedS3BucketPrefix": "updated-logs",
+        "UpdatedCwLogGroupName": "ocm-e2e-cw-log-group-updated",
+        "EditedCwLogGroupName": "ocm-e2e-cw-log-group-edited",
+        "SelectedGroup": "api"
       }
     }
   }

--- a/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.json
+++ b/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.json
@@ -131,5 +131,44 @@
         "Error": "Custom operator roles prefix 'CustomRoles-123' isn't valid, must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. For example, 'my-name', or 'abc-123'"
       }
     ]
+  },
+  "LogForwarding": {
+    "S3": {
+      "BucketNameRequired": "Bucket name is required.",
+      "BucketNameTooShort": "ab",
+      "BucketNameTooShortError": "Bucket name must be between 3 and 63 characters.",
+      "BucketNameTooLong": "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01234",
+      "BucketNameTooLongError": "Bucket name must be between 3 and 63 characters.",
+      "BucketNameStartsUppercase": "Abcbucket",
+      "BucketNameStartsUppercaseError": "Bucket name must start and end with a lowercase letter or number.",
+      "BucketNameConsecutiveDots": "my..bucket",
+      "BucketNameConsecutiveDotsError": "Bucket name cannot contain consecutive periods.",
+      "BucketNameIPAddress": "192.168.1.1",
+      "BucketNameIPAddressError": "Bucket name cannot be formatted as an IP address.",
+      "BucketNameValid": "my-valid-bucket-name",
+      "BucketPrefixConsecutiveDots": "prefix..value",
+      "BucketPrefixConsecutiveDotsError": "Prefix cannot contain consecutive periods.",
+      "SelectedItemsRequired": "Select at least one group or application.",
+      "ValidBucketName": "my-test-s3-bucket",
+      "ValidBucketPrefix": "logs/rosa"
+    },
+    "CloudWatch": {
+      "LogGroupNameRequired": "Log group name is required.",
+      "LogGroupNameInvalidChars": "log group @invalid!",
+      "LogGroupNameInvalidCharsError": "Log group name contains invalid characters.",
+      "LogGroupNameWithColon": "rosa:log-group",
+      "LogGroupNameWithColonError": "Log group name contains invalid characters.",
+      "LogGroupNameTooLong": "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01234567890123456789012",
+      "LogGroupNameTooLongError": "Log group name must be 512 characters or fewer.",
+      "RoleArnRequired": "Role ARN is required.",
+      "RoleArnInvalidFormat": "wrongformat",
+      "RoleArnInvalidFormatError": "ARN value should be in the format arn:aws:iam::123456789012:role/role-name.",
+      "RoleArnWhitespace": "arn:aws:iam: :role/test",
+      "RoleArnWhitespaceError": "Value must not contain whitespaces.",
+      "PrerequisiteAckRequired": "Confirm you have completed the prerequisites to continue.",
+      "SelectedItemsRequired": "Select at least one group or application.",
+      "ValidRoleArn": "arn:aws:iam::123456789012:role/my-cw-log-role",
+      "ValidLogGroupName": "rosa-cw-log-group"
+    }
   }
 }

--- a/playwright/page-objects/cluster-details-page.ts
+++ b/playwright/page-objects/cluster-details-page.ts
@@ -312,6 +312,14 @@ export class ClusterDetailsPage extends BasePage {
     return this.page.getByTestId('etcEncryptionStatus');
   }
 
+  controlPlaneLogForwardingDescription(): Locator {
+    return this.page.getByTestId('controlPlaneLogForwardingDescription');
+  }
+
+  controlPlaneLogForwardingViewDetailsLink(): Locator {
+    return this.page.getByRole('link', { name: 'View details' });
+  }
+
   // Installation screen elements
   clusterInstallationHeader(): Locator {
     return this.page.locator('h2, h3').filter({ hasText: 'Installing cluster' });
@@ -346,7 +354,11 @@ export class ClusterDetailsPage extends BasePage {
     return this.page.getByTestId('wifConfiguration');
   }
 
-  // Settings tab functionality
+  // Tab navigation
+  overviewTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Overview' });
+  }
+
   settingsTab(): Locator {
     return this.page.getByRole('tab', { name: 'Settings' });
   }
@@ -401,11 +413,9 @@ export class ClusterDetailsPage extends BasePage {
   }
 
   editAutoNodeModal(): Locator {
-    return this.page
-      .getByRole('dialog')
-      .filter({
-        has: this.page.getByRole('heading', { name: 'Edit Autonode settings', level: 1 }),
-      });
+    return this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', { name: 'Edit Autonode settings', level: 1 }),
+    });
   }
 
   editAutoNodeModalHeading(): Locator {
@@ -621,19 +631,24 @@ export class ClusterDetailsPage extends BasePage {
   }
 
   logForwardingGroupLabel(category: string, label: string): Locator {
-    return this.logForwardingGroupCategory(category).getByRole('listitem').filter({ hasText: label });
+    return this.logForwardingGroupCategory(category)
+      .getByRole('listitem')
+      .filter({ hasText: label });
   }
 
-  logForwardingPropertyValue(label: string, value: string): Locator {
+  logForwardingPropertyValue(cardTitle: string, label: string, value: string): Locator {
     return this.page
-      .getByText(label, { exact: true })
-      .locator('..')
-      .getByText(value, { exact: true })
-      .first();
+      .getByRole('group', { name: `${cardTitle} ${label}` })
+      .getByText(value, { exact: true });
   }
 
   async isLogForwardingSectionVisible(): Promise<void> {
     await expect(this.logForwardingSectionHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  async navigateToOverviewTab(): Promise<void> {
+    await this.overviewTab().click();
+    await expect(this.clusterNameTitle()).toBeVisible({ timeout: 30000 });
   }
 
   async navigateToSettingsTab(): Promise<void> {

--- a/playwright/page-objects/cluster-details-page.ts
+++ b/playwright/page-objects/cluster-details-page.ts
@@ -530,5 +530,193 @@ export class ClusterDetailsPage extends BasePage {
     await this.page.keyboard.press('Escape');
     await expect(this.deleteClusterDropdownItem()).toBeHidden({ timeout: 5000 });
   }
-  
+
+  // ── Day 2 Log Forwarding (Settings tab) ──────────────────────────────────
+
+  logForwardingSectionHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Control plane log forwarding', level: 2 });
+  }
+
+  logForwardingEmptyState(): Locator {
+    return this.page.getByText('No log forwarding configured.');
+  }
+
+  addConfigurationButton(): Locator {
+    return this.page.getByRole('button', { name: 'Add configuration' });
+  }
+
+  async hoverAddConfigurationButton(): Promise<Locator> {
+    await this.addConfigurationButton().hover({ force: true });
+    return this.page.getByRole('tooltip');
+  }
+
+  addConfigurationMenuItem(destination: 'Amazon S3' | 'CloudWatch'): Locator {
+    return this.page.getByRole('menuitem', { name: destination });
+  }
+
+  logForwardingCardTitle(title: 'Amazon S3' | 'CloudWatch'): Locator {
+    return this.page.getByRole('heading', { name: title, level: 3 });
+  }
+
+  logForwardingCardKebab(title: 'Amazon S3' | 'CloudWatch'): Locator {
+    return this.page.getByRole('button', { name: `${title} configuration actions` });
+  }
+
+  editConfigurationMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Edit configuration' });
+  }
+
+  deleteConfigurationMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Delete configuration' });
+  }
+
+  logForwardingModalHeading(action: 'Add' | 'Edit' | 'Delete', destination: string): Locator {
+    return this.page.getByText(`${action} ${destination} configuration`);
+  }
+
+  logForwardingBucketNameInput(): Locator {
+    return this.page.getByRole('textbox', { name: /Bucket name/i });
+  }
+
+  logForwardingBucketPrefixInput(): Locator {
+    return this.page.getByRole('textbox', { name: /Bucket prefix/i });
+  }
+
+  logForwardingLogGroupNameInput(): Locator {
+    return this.page.getByRole('textbox', { name: /Log group name/i });
+  }
+
+  logForwardingRoleArnInput(): Locator {
+    return this.page.getByRole('textbox', { name: /Role ARN/i });
+  }
+
+  logForwardingPrerequisiteCheckbox(): Locator {
+    return this.page.getByLabel(
+      "I've read and completed all the prerequisites and am ready to continue.",
+    );
+  }
+
+  logForwardingSubmitButton(): Locator {
+    return this.page.getByTestId('log-forwarding-submit-btn');
+  }
+
+  logForwardingModalCancelButton(): Locator {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  deleteLogForwardingConfirmButton(): Locator {
+    return this.page.getByRole('button', { name: 'Delete configuration' });
+  }
+
+  logForwardingDeleteDescription(): Locator {
+    return this.page.getByRole('dialog').getByRole('paragraph');
+  }
+
+  logForwardingSelectedGroupsHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Selected groups and applications' });
+  }
+
+  logForwardingGroupCategory(category: string): Locator {
+    return this.page.getByRole('list', { name: category });
+  }
+
+  logForwardingGroupLabel(category: string, label: string): Locator {
+    return this.logForwardingGroupCategory(category).getByRole('listitem').filter({ hasText: label });
+  }
+
+  logForwardingPropertyValue(label: string, value: string): Locator {
+    return this.page
+      .getByText(label, { exact: true })
+      .locator('..')
+      .getByText(value, { exact: true })
+      .first();
+  }
+
+  async isLogForwardingSectionVisible(): Promise<void> {
+    await expect(this.logForwardingSectionHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  async navigateToSettingsTab(): Promise<void> {
+    await this.settingsTab().click();
+    await expect(this.page.getByText('Update strategy')).toBeVisible({ timeout: 30000 });
+  }
+
+  async scrollToLogForwardingSection(): Promise<void> {
+    await this.logForwardingSectionHeading().scrollIntoViewIfNeeded();
+    await expect(this.logForwardingSectionHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  async openAddConfigurationMenu(destination: 'Amazon S3' | 'CloudWatch'): Promise<void> {
+    await this.addConfigurationButton().click();
+    await this.addConfigurationMenuItem(destination).click();
+  }
+
+  async fillS3Configuration(bucketName: string, bucketPrefix: string): Promise<void> {
+    await this.logForwardingBucketNameInput().fill(bucketName);
+    await this.logForwardingBucketPrefixInput().fill(bucketPrefix);
+  }
+
+  async fillCloudWatchConfiguration(logGroupName: string, roleArn: string): Promise<void> {
+    await this.logForwardingLogGroupNameInput().clear();
+    await this.logForwardingLogGroupNameInput().fill(logGroupName);
+    await this.logForwardingRoleArnInput().fill(roleArn);
+  }
+
+  async deleteLogForwardingIfExists(destination: 'Amazon S3' | 'CloudWatch'): Promise<void> {
+    const card = this.logForwardingCardTitle(destination);
+    try {
+      await card.waitFor({ state: 'visible', timeout: 5000 });
+    } catch {
+      return;
+    }
+    await this.openCardKebabAction(destination, 'Delete configuration');
+    await this.confirmDeleteLogForwarding();
+    await expect(card).toBeHidden({ timeout: 30000 });
+  }
+
+  async selectLogForwardingGroup(groupName: string): Promise<void> {
+    const tree = this.page.getByRole('tree', { name: 'Select groups and applications' });
+    await tree.waitFor({ state: 'visible', timeout: 30000 });
+    const item = tree.getByRole('treeitem', { name: groupName });
+    const checkbox = item.getByRole('checkbox');
+    if (!(await checkbox.isChecked())) {
+      await checkbox.check();
+    }
+  }
+
+  async selectAllLogForwardingGroups(): Promise<void> {
+    const tree = this.page.getByRole('tree', { name: 'Select groups and applications' });
+    await tree.getByRole('checkbox').first().waitFor({ state: 'visible', timeout: 30000 });
+
+    const checkboxes = tree.getByRole('checkbox');
+    const count = await checkboxes.count();
+    for (let i = 0; i < count; i++) {
+      const cb = checkboxes.nth(i);
+      if (!(await cb.isChecked())) {
+        await cb.check();
+      }
+    }
+  }
+
+  async submitLogForwardingModal(): Promise<void> {
+    await this.logForwardingSubmitButton().click();
+    await expect(this.logForwardingSubmitButton()).toBeHidden({ timeout: 30000 });
+  }
+
+  async openCardKebabAction(
+    cardTitle: 'Amazon S3' | 'CloudWatch',
+    action: 'Edit configuration' | 'Delete configuration',
+  ): Promise<void> {
+    await this.logForwardingCardKebab(cardTitle).click();
+    if (action === 'Edit configuration') {
+      await this.editConfigurationMenuItem().click();
+    } else {
+      await this.deleteConfigurationMenuItem().click();
+    }
+  }
+
+  async confirmDeleteLogForwarding(): Promise<void> {
+    await this.deleteLogForwardingConfirmButton().click();
+    await expect(this.deleteLogForwardingConfirmButton()).toBeHidden({ timeout: 30000 });
+  }
 }

--- a/playwright/page-objects/create-rosa-wizard-page.ts
+++ b/playwright/page-objects/create-rosa-wizard-page.ts
@@ -1108,10 +1108,6 @@ export class CreateRosaWizardPage extends BasePage {
     return this.logForwardingReviewSection().getByRole('heading', { name: 'CloudWatch' });
   }
 
-  logForwardingReviewConfigurationValues(): Locator {
-    return this.logForwardingReviewSection().getByText('Disabled', { exact: true });
-  }
-
   logForwardingS3BucketNameInput(): Locator {
     return this.page.getByRole('textbox', { name: 'Bucket name' });
   }
@@ -1169,7 +1165,6 @@ export class CreateRosaWizardPage extends BasePage {
     }
   }
 
-
   // Additional validation method for compute node range
   computeNodeRangeValue(): Locator {
     return this.page.getByTestId('Compute-node-range').locator('div');
@@ -1191,7 +1186,30 @@ export class CreateRosaWizardPage extends BasePage {
     return this.page.getByLabel('Copyable ROSA create operator-roles');
   }
 
-  logForwardingReviewText(text: string): Locator {
-    return this.logForwardingReviewSection().getByText(text);
+  /**
+   * Returns the description (value) cell of a specific log forwarding property in the review
+   * screen. Scopes to the data-testid set on each DescriptionListGroup in
+   * LogForwardingReviewDetails, then returns the <dd> (definition) within it.
+   *
+   * Testid format: review-lf-{provider}-{label}
+   *   provider: 's3' | 'cw'
+   *   label:    'configuration' | 'bucket-name' | 'bucket-prefix' |
+   *             'log-group-name' | 'role-arn' | 'selected-groups'
+   *
+   * Example:
+   *   logForwardingReviewPropertyValue('s3', 'configuration')  → "Enabled" / "Disabled"
+   *   logForwardingReviewPropertyValue('cw', 'role-arn')        → the ARN string
+   */
+  logForwardingReviewPropertyValue(
+    provider: 's3' | 'cw',
+    label:
+      | 'configuration'
+      | 'bucket-name'
+      | 'bucket-prefix'
+      | 'log-group-name'
+      | 'role-arn'
+      | 'selected-groups',
+  ): Locator {
+    return this.page.getByTestId(`review-lf-${provider}-${label}`).getByRole('definition');
   }
 }

--- a/playwright/page-objects/create-rosa-wizard-page.ts
+++ b/playwright/page-objects/create-rosa-wizard-page.ts
@@ -1112,6 +1112,64 @@ export class CreateRosaWizardPage extends BasePage {
     return this.logForwardingReviewSection().getByText('Disabled', { exact: true });
   }
 
+  logForwardingS3BucketNameInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Bucket name' });
+  }
+
+  logForwardingS3BucketPrefixInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Bucket prefix' });
+  }
+
+  logForwardingCloudWatchLogGroupNameInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Log group name' });
+  }
+
+  logForwardingCloudWatchRoleArnInput(): Locator {
+    return this.page.getByRole('textbox', { name: 'Role ARN' });
+  }
+
+  logForwardingCloudWatchPrerequisiteCheckbox(): Locator {
+    return this.page.getByRole('checkbox', {
+      name: "I've read and completed all the prerequisites",
+    });
+  }
+
+  /**
+   * Selects a group by name in the log forwarding available groups/applications tree.
+   * S3 tree is at index 0, CloudWatch tree is at index 1.
+   */
+  async selectLogForwardingGroup(groupName: string, section: 'S3' | 'CloudWatch'): Promise<void> {
+    const treeIndex = section === 'S3' ? 0 : 1;
+    await this.page
+      .getByRole('tree', { name: 'Select groups and applications' })
+      .nth(treeIndex)
+      .getByRole('checkbox', { name: `Select ${groupName}` })
+      .check();
+  }
+
+  /**
+   * Selects all available groups in a log forwarding tree section.
+   * Waits for the tree to load, then checks every unchecked checkbox.
+   */
+  async selectAllLogForwardingGroups(section: 'S3' | 'CloudWatch'): Promise<void> {
+    const treeIndex = section === 'S3' ? 0 : 1;
+    const tree = this.page
+      .getByRole('tree', { name: 'Select groups and applications' })
+      .nth(treeIndex);
+
+    await tree.getByRole('checkbox').first().waitFor({ state: 'visible', timeout: 30000 });
+
+    const checkboxes = tree.getByRole('checkbox');
+    const count = await checkboxes.count();
+    for (let i = 0; i < count; i++) {
+      const cb = checkboxes.nth(i);
+      if (!(await cb.isChecked())) {
+        await cb.check();
+      }
+    }
+  }
+
+
   // Additional validation method for compute node range
   computeNodeRangeValue(): Locator {
     return this.page.getByTestId('Compute-node-range').locator('div');
@@ -1131,5 +1189,9 @@ export class CreateRosaWizardPage extends BasePage {
 
   operatorRoleCommandInput(): Locator {
     return this.page.getByLabel('Copyable ROSA create operator-roles');
+  }
+
+  logForwardingReviewText(text: string): Locator {
+    return this.logForwardingReviewSection().getByText(text);
   }
 }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/logForwardingSectionComponents.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/UpgradeSettings/logForwardingSectionComponents.tsx
@@ -116,9 +116,11 @@ function ForwarderConfigDescription({ description }: { description: React.ReactN
 }
 
 function ForwarderConfigColumns({
+  title,
   columns,
   forwarder,
 }: {
+  title: string;
   columns: LogForwardingConfigColumn[];
   forwarder: LogForwarder;
 }) {
@@ -133,7 +135,13 @@ function ForwarderConfigColumns({
       gap={{ default: 'gapXl' }}
     >
       {columns.map((col) => (
-        <FlexItem key={col.term} flex={{ default: 'flex_1' }} className="pf-v6-u-min-width-0">
+        <FlexItem
+          key={col.term}
+          flex={{ default: 'flex_1' }}
+          className="pf-v6-u-min-width-0"
+          role="group"
+          aria-label={`${title} ${col.term}`}
+        >
           <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
             <span className="pf-v6-u-font-weight-bold">{col.term}</span>
             <div className="pf-v6-u-min-width-0">
@@ -265,7 +273,7 @@ export function LogDestinationCard({
       </CardTitle>
       <CardBody>
         <Stack hasGutter>
-          <ForwarderConfigColumns columns={columns} forwarder={forwarder} />
+          <ForwarderConfigColumns title={title} columns={columns} forwarder={forwarder} />
           <div>
             <Title headingLevel="h5" size="md" className="pf-v6-u-mb-sm">
               Selected groups and applications

--- a/src/components/clusters/wizards/rosa/LogForwarding/LogForwardingReviewDetails.tsx
+++ b/src/components/clusters/wizards/rosa/LogForwarding/LogForwardingReviewDetails.tsx
@@ -70,25 +70,25 @@ export function LogForwardingReviewDetails({ formValues }: { formValues: FormVal
           <span className="pf-v6-u-screen-reader">Amazon S3 log forwarding</span>
         </DescriptionListDescription>
       </DescriptionListGroup>
-      <DescriptionListGroup>
+      <DescriptionListGroup data-testid="review-lf-s3-configuration">
         <DescriptionListTerm>Configuration</DescriptionListTerm>
         <DescriptionListDescription>{s3On ? 'Enabled' : 'Disabled'}</DescriptionListDescription>
       </DescriptionListGroup>
       {s3On ? (
         <>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-s3-bucket-name">
             <DescriptionListTerm>Bucket name</DescriptionListTerm>
             <DescriptionListDescription>
               {formValues[FieldId.LogForwardingS3BucketName]?.trim() || logForwardingNoneLabel}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-s3-bucket-prefix">
             <DescriptionListTerm>Bucket prefix</DescriptionListTerm>
             <DescriptionListDescription>
               {s3BucketPrefixTrimmed || logForwardingNoneLabel}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-s3-selected-groups">
             <DescriptionListTerm>Selected groups and applications</DescriptionListTerm>
             <DescriptionListDescription>
               <LogForwardingSelectedAppsDescription
@@ -109,26 +109,26 @@ export function LogForwardingReviewDetails({ formValues }: { formValues: FormVal
           <span className="pf-v6-u-screen-reader">CloudWatch log forwarding</span>
         </DescriptionListDescription>
       </DescriptionListGroup>
-      <DescriptionListGroup>
+      <DescriptionListGroup data-testid="review-lf-cw-configuration">
         <DescriptionListTerm>Configuration</DescriptionListTerm>
         <DescriptionListDescription>{cwOn ? 'Enabled' : 'Disabled'}</DescriptionListDescription>
       </DescriptionListGroup>
       {cwOn ? (
         <>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-cw-log-group-name">
             <DescriptionListTerm>Log group name</DescriptionListTerm>
             <DescriptionListDescription>
               {formValues[FieldId.LogForwardingCloudWatchLogGroupName]?.trim() ||
                 logForwardingNoneLabel}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-cw-role-arn">
             <DescriptionListTerm>Role ARN</DescriptionListTerm>
             <DescriptionListDescription>
               {formValues[FieldId.LogForwardingCloudWatchRoleArn]?.trim() || logForwardingNoneLabel}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <DescriptionListGroup>
+          <DescriptionListGroup data-testid="review-lf-cw-selected-groups">
             <DescriptionListTerm>Selected groups and applications</DescriptionListTerm>
             <DescriptionListDescription>
               <LogForwardingSelectedAppsDescription


### PR DESCRIPTION
# Summary

E2e test case spec(day1) updates for log forwarding features.

# Jira

 Fixes [OCMUI-3880](https://issues.redhat.com/browse/OCMUI-3880)

# Additional information

1. Updated existing e2e day1 test spec to accommodate the ROSA HCP log forwarding feature
2. Created a new e2e day2 test spec to cover the log forwarding feature
3. Updated related to page object definition and fixture files.

# How to Test

1. Open a terminal and download this PR.
2. Start the local server.
3. Open another terminal and navigate to the source code directory(place you downloaded from step 1)
5. Create a [playwright.env.json](https://github.com/RedHatInsights/uhc-portal/pull/558/changes#diff-c965fc0a1aae58b7cdd9aa60904ee51ecc5732ff358db4174f41936378510826R76) file under repo root with all required AWS, ROSA definition 
6. Run the following test case specs.

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts
```

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts
```

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts
```


# Screen Captures
```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-wizard-validation.spec.ts

🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 12 tests using 1 worker
…luster wizard validations › Step - Accounts and roles - widget validations @smoke @rosa-hosted @wizard-validation @rosa
  12 passed (1.3m)

To open last HTML report run:

npx playwright show-report playwright-artifacts/reports
 ```
 ```
 % BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.ts

🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 17 tests using 1 worker
…ec.ts:55:9 › Rosa hosted cluster (hypershift) - create public advanced cluster with properties › Step - Accounts and roles - Select Accounts and roles for ply-rosa-hosted-public-advanced @day1 @hcp @rosa-hosted @public @hosted @advanced
17 passed (1.9m)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
 ```

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts 

> cloud.openshift.com@0.0.0 playwright-headless
> playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-log-forwarding.spec.ts

🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: *****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 30 tests using 1 worker
  30 passed (59.8s)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-3880]: https://redhat.atlassian.net/browse/OCMUI-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ