### PR TITLE
OCMUI-4611: Suppress auto-refresh when Add/Edit Machine Pool (local-state) modals are open on cluster details

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
@@ -87,7 +87,6 @@ import { canTransferClusterOwnershipMultiRegion } from '../common/TransferCluste
 import CancelUpgradeModal from '../common/Upgrades/CancelUpgradeModal/CancelUpgradeModal';
 import { getSchedules } from '../common/Upgrades/clusterUpgradeActions';
 
-import { ModalPresenceProvider, useModalPresence } from './ModalPresenceContext';
 import AccessControl from './components/AccessControl/AccessControl';
 import usersActions from './components/AccessControl/UsersSection/UsersActions';
 import { AccessRequest } from './components/AccessRequest/AccessRequest';
@@ -109,6 +108,7 @@ import AddNotificationContactDialog from './components/Support/components/AddNot
 import TabsRow from './components/TabsRow/TabsRow';
 import UpgradeSettingsTab from './components/UpgradeSettings';
 import { eventTypes } from './clusterDetailsHelper';
+import { ModalPresenceProvider, useModalPresence } from './ModalPresenceContext';
 
 const PAGE_TITLE = 'Red Hat OpenShift Cluster Manager';
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
@@ -87,6 +87,7 @@ import { canTransferClusterOwnershipMultiRegion } from '../common/TransferCluste
 import CancelUpgradeModal from '../common/Upgrades/CancelUpgradeModal/CancelUpgradeModal';
 import { getSchedules } from '../common/Upgrades/clusterUpgradeActions';
 
+import { ModalPresenceProvider, useModalPresence } from './ModalPresenceContext';
 import AccessControl from './components/AccessControl/AccessControl';
 import usersActions from './components/AccessControl/UsersSection/UsersActions';
 import { AccessRequest } from './components/AccessRequest/AccessRequest';
@@ -111,7 +112,7 @@ import { eventTypes } from './clusterDetailsHelper';
 
 const PAGE_TITLE = 'Red Hat OpenShift Cluster Manager';
 
-const ClusterDetails = (props) => {
+const ClusterDetailsInner = (props) => {
   const location = useLocation();
   const clusterListPath = useClusterListPath();
   const { toggleSubscriptionReleased } = props;
@@ -119,7 +120,9 @@ const ClusterDetails = (props) => {
   const monitoring = useGlobalState((state) => state.monitoring);
 
   const canHibernateCluster = useGlobalState((state) => userCanHibernateClustersSelector(state));
-  const anyModalOpen = useGlobalState((state) => !!state.modal.modalName);
+  const anyReduxModalOpen = useGlobalState((state) => !!state.modal.modalName);
+  const { isAnyLocalModalOpen } = useModalPresence();
+  const anyModalOpen = anyReduxModalOpen || isAnyLocalModalOpen;
   const userAccess = useGlobalState((state) => state.cost.userAccess);
 
   const { organization } = useGlobalState((state) => state.userProfile);
@@ -809,8 +812,16 @@ const ClusterDetails = (props) => {
   );
 };
 
-ClusterDetails.propTypes = {
+ClusterDetailsInner.propTypes = {
   toggleSubscriptionReleased: PropTypes.func.isRequired,
 };
+
+const ClusterDetails = (props) => (
+  <ModalPresenceProvider>
+    <ClusterDetailsInner {...props} />
+  </ModalPresenceProvider>
+);
+
+ClusterDetails.propTypes = ClusterDetailsInner.propTypes;
 
 export default ClusterDetails;

--- a/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.test.tsx
@@ -10,10 +10,10 @@ const TestConsumer = () => {
   return (
     <div>
       <span data-testid="modal-status">{isAnyLocalModalOpen ? 'open' : 'closed'}</span>
-      <button data-testid="register" onClick={registerModal}>
+      <button type="button" data-testid="register" onClick={registerModal}>
         Register
       </button>
-      <button data-testid="unregister" onClick={unregisterModal}>
+      <button type="button" data-testid="unregister" onClick={unregisterModal}>
         Unregister
       </button>
     </div>

--- a/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { render, screen, waitFor } from '~/testUtils';
+
+import { ModalPresenceProvider, useModalPresence } from './ModalPresenceContext';
+
+const TestConsumer = () => {
+  const { isAnyLocalModalOpen, registerModal, unregisterModal } = useModalPresence();
+
+  return (
+    <div>
+      <span data-testid="modal-status">{isAnyLocalModalOpen ? 'open' : 'closed'}</span>
+      <button data-testid="register" onClick={registerModal}>
+        Register
+      </button>
+      <button data-testid="unregister" onClick={unregisterModal}>
+        Unregister
+      </button>
+    </div>
+  );
+};
+
+const renderWithProvider = () =>
+  render(
+    <ModalPresenceProvider>
+      <TestConsumer />
+    </ModalPresenceProvider>,
+  );
+
+describe('ModalPresenceContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts with no modals open', () => {
+    // Arrange & Act
+    renderWithProvider();
+
+    // Assert
+    expect(screen.getByTestId('modal-status')).toHaveTextContent('closed');
+  });
+
+  it('reports modal open after registerModal is called', async () => {
+    // Arrange
+    const { user } = renderWithProvider();
+
+    // Act
+    await user.click(screen.getByTestId('register'));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('open');
+    });
+  });
+
+  it('reports closed after unregisterModal is called', async () => {
+    // Arrange
+    const { user } = renderWithProvider();
+    await user.click(screen.getByTestId('register'));
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('open');
+    });
+
+    // Act
+    await user.click(screen.getByTestId('unregister'));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('closed');
+    });
+  });
+
+  it('supports multiple simultaneous modals', async () => {
+    // Arrange
+    const { user } = renderWithProvider();
+
+    // Act - register two modals
+    await user.click(screen.getByTestId('register'));
+    await user.click(screen.getByTestId('register'));
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('open');
+    });
+
+    // Assert - still open after first unregister
+    await user.click(screen.getByTestId('unregister'));
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('open');
+    });
+
+    // Assert - closed after second unregister
+    await user.click(screen.getByTestId('unregister'));
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('closed');
+    });
+  });
+
+  it('does not go below zero when unregisterModal is called without a matching register', async () => {
+    // Arrange
+    const { user } = renderWithProvider();
+
+    // Act - unregister with nothing registered
+    await user.click(screen.getByTestId('unregister'));
+
+    // Assert - still closed
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('closed');
+    });
+
+    // Verify a subsequent register still works
+    await user.click(screen.getByTestId('register'));
+    await waitFor(() => {
+      expect(screen.getByTestId('modal-status')).toHaveTextContent('open');
+    });
+  });
+
+  it('returns default values when used outside the provider', () => {
+    // Arrange & Act
+    render(<TestConsumer />);
+
+    // Assert
+    expect(screen.getByTestId('modal-status')).toHaveTextContent('closed');
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+type ModalPresenceContextType = {
+  isAnyLocalModalOpen: boolean;
+  registerModal: () => void;
+  unregisterModal: () => void;
+};
+
+const ModalPresenceContext = React.createContext<ModalPresenceContextType>({
+  isAnyLocalModalOpen: false,
+  registerModal: () => {},
+  unregisterModal: () => {},
+});
+
+export const ModalPresenceProvider = ({ children }: { children: React.ReactNode }) => {
+  const countRef = React.useRef(0);
+  const [isAnyLocalModalOpen, setIsAnyLocalModalOpen] = React.useState(false);
+
+  const registerModal = React.useCallback(() => {
+    countRef.current += 1;
+    setIsAnyLocalModalOpen(true);
+  }, []);
+
+  const unregisterModal = React.useCallback(() => {
+    countRef.current = Math.max(0, countRef.current - 1);
+    setIsAnyLocalModalOpen(countRef.current > 0);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({ isAnyLocalModalOpen, registerModal, unregisterModal }),
+    [isAnyLocalModalOpen, registerModal, unregisterModal],
+  );
+
+  return <ModalPresenceContext.Provider value={value}>{children}</ModalPresenceContext.Provider>;
+};
+
+export const useModalPresence = () => React.useContext(ModalPresenceContext);

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ClusterTransferOwnership/ClusterTransferSection.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/ClusterTransferOwnership/ClusterTransferSection.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { Alert, Card, CardBody, Flex, FlexItem, Title } from '@patternfly/react-core';
 
+import { useModalPresence } from '~/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext';
 import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
 import ErrorBox from '~/components/common/ErrorBox';
 import { openModal } from '~/components/common/Modal/ModalActions';
@@ -27,9 +28,11 @@ export const ClusterTransferSection = ({
   subscription,
   canEdit,
 }: ClusterTransferSectionProps) => {
+  const { isAnyLocalModalOpen } = useModalPresence();
   const { data, isLoading, isError, error } = useFetchClusterTransfer({
     clusterExternalID,
     showPendingTransfer: true,
+    suppressRefetch: isAnyLocalModalOpen,
   });
   const dispatch = useDispatch();
   const transfer = data?.items?.[0] || {};

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePools.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePools.jsx
@@ -13,10 +13,10 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 
-import { useModalPresence } from '~/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext';
 import { getOCMResourceType } from '~/common/analytics';
 import { noQuotaTooltip } from '~/common/helpers';
 import { normalizedProducts } from '~/common/subscriptionTypes';
+import { useModalPresence } from '~/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext';
 import { getDefaultClusterAutoScaling } from '~/components/clusters/common/clusterAutoScalingValues';
 import { LoadingSkeletonCard } from '~/components/clusters/common/LoadingSkeletonCard/LoadingSkeletonCard';
 import { MachineConfiguration } from '~/components/clusters/common/MachineConfiguration';

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePools.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/MachinePools/MachinePools.jsx
@@ -13,6 +13,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 
+import { useModalPresence } from '~/components/clusters/ClusterDetailsMultiRegion/ModalPresenceContext';
 import { getOCMResourceType } from '~/common/analytics';
 import { noQuotaTooltip } from '~/common/helpers';
 import { normalizedProducts } from '~/common/subscriptionTypes';
@@ -67,6 +68,7 @@ import './MachinePools.scss';
 
 const MachinePools = ({ cluster }) => {
   const dispatch = useDispatch();
+  const { registerModal, unregisterModal } = useModalPresence();
   const allow249NodesOSDCCSROSA = useFeatureGate(MAX_NODES_TOTAL_249);
 
   const isDeleteMachinePoolModalOpen = useGlobalState((state) =>
@@ -275,7 +277,10 @@ const MachinePools = ({ cluster }) => {
                         quotaReason
                       }
                       id="add-machine-pool"
-                      onClick={() => setAddMachinePool(true)}
+                      onClick={() => {
+                        setAddMachinePool(true);
+                        registerModal();
+                      }}
                       variant={ButtonVariant.secondary}
                     >
                       Add machine pool
@@ -299,7 +304,10 @@ const MachinePools = ({ cluster }) => {
                     <ToolbarItem>
                       <ButtonWithTooltip
                         disableReason={isMachineConfigurationActionDisabledReason}
-                        onClick={() => setShowMachinePoolsConfigModal(true)}
+                        onClick={() => {
+                          setShowMachinePoolsConfigModal(true);
+                          registerModal();
+                        }}
                         variant={ButtonVariant.secondary}
                       >
                         Edit machine configuration
@@ -326,7 +334,10 @@ const MachinePools = ({ cluster }) => {
                   isDeleteMachinePoolPending={isDeleteMachinePoolPending}
                   isDeleteMachinePoolSuccess={isDeleteMachinePoolSuccess}
                   isDeleteMachinePoolError={isDeleteMachinePoolError}
-                  setEditMachinePoolId={setEditMachinePoolId}
+                  setEditMachinePoolId={(id) => {
+                    setEditMachinePoolId(id);
+                    registerModal();
+                  }}
                   setHideDeleteMachinePoolError={setHideDeleteMachinePoolError}
                   cluster={cluster}
                   isMachinePoolError={isMachinePoolError}
@@ -349,6 +360,7 @@ const MachinePools = ({ cluster }) => {
           onClose={() => {
             setEditMachinePoolId(undefined);
             setAddMachinePool(false);
+            unregisterModal();
           }}
           isHypershift={isHypershift}
           machinePoolId={editMachinePoolId}
@@ -400,7 +412,10 @@ const MachinePools = ({ cluster }) => {
               ? getClusterServiceForRegion(region).patchKubeletConfiguration
               : clusterService.patchKubeletConfiguration
           }
-          onClose={() => setShowMachinePoolsConfigModal(false)}
+          onClose={() => {
+            setShowMachinePoolsConfigModal(false);
+            unregisterModal();
+          }}
           canBypassPIDsLimit={canBypassPIDsLimit}
         />
       )}

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.test.tsx
@@ -313,6 +313,26 @@ describe('useFetchClusterTransfer', () => {
     expect(result.current.data).toEqual({ items: [] });
   });
 
+  it('fetches data but disables automatic polling when suppressRefetch is true', async () => {
+    // Arrange
+    getClusterTransferByExternalIDSpy.mockResolvedValueOnce({
+      data: { items: [], total: 0 },
+    });
+
+    // Act
+    const { result } = renderHook(() =>
+      useFetchClusterTransfer({ clusterExternalID: 'ext-suppress', suppressRefetch: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Assert
+    expect(getClusterTransferByExternalIDSpy).toHaveBeenCalledWith('ext-suppress');
+    expect(result.current.isError).toBe(false);
+  });
+
   it('returns formatted error when the request fails', async () => {
     getClusterTransferByExternalIDSpy.mockRejectedValueOnce({
       name: 403,

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
@@ -23,11 +23,13 @@ export const useFetchClusterTransfer = ({
   clusterExternalID,
   filter,
   showPendingTransfer,
+  suppressRefetch,
 }: {
   transferID?: string;
   clusterExternalID?: string;
   filter?: string;
   showPendingTransfer?: boolean;
+  suppressRefetch?: boolean;
 }) => {
   const viewType = viewConstants.CLUSTER_TRANSFER_VIEW;
   const viewOptions = useGlobalState((state) => state.viewOptions[viewType]);
@@ -61,7 +63,7 @@ export const useFetchClusterTransfer = ({
       return response;
     },
     enabled: !!clusterExternalID || !!transferID || !!filter,
-    refetchInterval: queryConstants.STALE_TIME_60_SEC,
+    refetchInterval: suppressRefetch ? false : queryConstants.STALE_TIME_60_SEC,
   });
 
   // Recalculate totalPages when pageSize changes or new data arrives (list/search only).


### PR DESCRIPTION
# Summary

Suppress auto-refresh on cluster details when local-state modals (Add/Edit Machine Pool, Machine Configuration) are open. The existing auto-refresh guard only detected Redux-managed modals, leaving local-state modals unprotected. This caused background refreshes to clear form state every 60 seconds while users were filling out forms.

Introduces a `ModalPresenceContext` using the React shared state pattern to track open modals, and gates both the RefreshButton timer and the cluster transfer ownership polling on this context.

Assisted by: Cursor

# Jira

Fixes [OCMUI-4611](https://redhat.atlassian.net/browse/OCMUI-4611)

# Additional information

- This fix uses the [Sharing State Between Components](https://react.dev/learn/sharing-state-between-components) pattern from the official React documentation. It lifts modal-open state to a common ancestor via React Context — no new libraries or dependencies are introduced. This is a standard React pattern for coordinating state across sibling and descendant components without relying on Redux or external state management.
- Cluster details has two independent 60-second auto-refresh timers: the RefreshButton and the cluster transfer ownership query's `refetchInterval`. Because they are unsynchronized, users could see refreshes as frequently as every ~30 seconds.
- The RefreshButton was already gated by `anyModalOpen`, but that only checked the Redux modal registry (`state.modal.modalName`). The Add/Edit Machine Pool and Machine Configuration modals use local React state and were invisible to this guard.
- This fix adds a `ModalPresenceContext` that uses a counter to support multiple simultaneous modals. The `anyModalOpen` flag in `ClusterDetails` now combines both Redux modal state and the context state.
- The transfer ownership query now accepts a `suppressRefetch` flag to disable its independent polling when a modal is open.
- The `MachineConfiguration` modal is behind the `enable-machine-configuration` feature flag, which is not enabled in production. Its registration with the context is included proactively for when/if that feature is released.

# How to Test

1. Navigate to a ROSA cluster's Machine Pools tab
2. Click "Add machine pool"
3. Verify the modal stays open and form fields are not cleared after 60+ seconds
4. Close the modal and verify the auto-refresh resumes (typically 60s, the refresh icon in the top-right will spin periodically)
5. Click the edit (pencil) icon on an existing machine pool
6. Verify the same behavior — form fields are preserved while editing

**Note:** The "Edit machine configuration" button is behind the `enable-machine-configuration` feature flag, which is not enabled in production. Its integration with the modal guard is included to keep it up to date, but is not testable in production.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| Form fields reset every 60s while modal is open | Form fields persist — auto-refresh pauses while modal is open |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation

[OCMUI-4611]: https://redhat.atlassian.net/browse/OCMUI-4611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ