### PR TITLE
OCMUI-4623 - Temp hot fix to extend 60 second refresh timer to 5 minutes for large customer trying to make changes in machine pools modal

### DIFF
--- a/src/components/common/RefreshButton/RefreshButton.test.tsx
+++ b/src/components/common/RefreshButton/RefreshButton.test.tsx
@@ -14,7 +14,7 @@ jest.spyOn(global, 'setInterval');
 
 // Times set for refresh, change here if the corresponding var are changed within the component file
 const shortTimerSeconds = 10;
-const longTimerSeconds = 60;
+const longTimerSeconds = 300;
 
 describe('<RefreshButton />', () => {
   const onClickFunc = jest.fn();

--- a/src/components/common/RefreshButton/RefreshButton.tsx
+++ b/src/components/common/RefreshButton/RefreshButton.tsx
@@ -14,7 +14,8 @@ type Props = {
 };
 
 const shortTimerSeconds = 10;
-const longTimerSeconds = 60;
+// Temporary fix to replace longTimerSeconds to 5 minutes instead of 60 seconds
+const longTimerSeconds = 300;
 const numberOfShortTries = 3;
 
 // See https://overreacted.io/making-setinterval-declarative-with-react-hooks/

--- a/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
+++ b/src/queries/ClusterDetailsQueries/ClusterTransferOwnership/useFetchClusterTransfer.tsx
@@ -61,7 +61,8 @@ export const useFetchClusterTransfer = ({
       return response;
     },
     enabled: !!clusterExternalID || !!transferID || !!filter,
-    refetchInterval: queryConstants.STALE_TIME_60_SEC,
+    // Temporary fix to replace queryConstants.STALE_TIME_60_SEC with 5 minute timer
+    refetchInterval: 300000,
   });
 
   // Recalculate totalPages when pageSize changes or new data arrives (list/search only).


### PR DESCRIPTION
# Summary

This PR adds a temporary fix to increase the cluster details interval refresh timer to 5 minutes instead of 1. Bug is related to https://redhat.atlassian.net/browse/OCMUI-4611

# Jira

Fixes [OCMUI-4623](https://issues.redhat.com/browse/OCMUI-4623) 


# How to Test

1. Navigate to the cluster details of any cluster --> Machine pools tab
2. Open the Add Machine pool modal
3. Begin editing fields and notice how long it takes for the cluster details to refresh, compare directly against doing the same test in console.dev.redhat.com

# Screen Captures



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4623]: https://redhat.atlassian.net/browse/OCMUI-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ