### PR TITLE
OCMUI-4407: Update cluster wizard - white background in dark mode

### DIFF
--- a/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeWizard.scss
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/UpgradeWizard.scss
@@ -51,11 +51,6 @@
   .wizard-step-title {
     padding: 24px 24px 0 24px;
   }
-  
-  .version-select-step-title {
-    padding: 24px;
-    background-color: #ffffff;
-  }
 
   .card-footer-button {
     padding-left: 0px !important;

--- a/src/components/clusters/common/Upgrades/UpgradeWizard/VersionSelectionGrid/VersionSelectionGrid.tsx
+++ b/src/components/clusters/common/Upgrades/UpgradeWizard/VersionSelectionGrid/VersionSelectionGrid.tsx
@@ -105,7 +105,7 @@ const VersionSelectionGrid = ({
   );
   return (
     <>
-      <Title className="version-select-step-title" size="lg" headingLevel="h3">
+      <Title className="wizard-step-title" size="lg" headingLevel="h3">
         Select version
       </Title>
       <div id="version-grid-wrapper">


### PR DESCRIPTION
# Summary

In the cluster update wizard (ROSA\OSD), the version selection step title bar renders with a hardcoded background-color: #ffffff - a bright white strip appears behind the title text. Since PF dark theme sets foreground text to white, the result is white text on a white background (unreadable).

Assisted by: Cursor/Auto

# Jira

Fixes [OCMUI-4407](https://redhat.atlassian.net/browse/OCMUI-4407)

# Additional information

`.version-select-step-title` background-color is redundant in this case and causes the bug. 
We have the styling `wizard-step-title` for the other titles that gives us the correct padding, so we will use it for the version select title too.

# How to Test

1. Toggle dark mode via toggling on Preview mode (top of page) and then clicking on the masthead Settings gear, and selecting ‘Color scheme’ of ‘Dark’.
2. Navigate to any ROSA Classic, ROSA HCP, or OSD cluster with version upgrades available in a Ready state
3. Open the Settings tab
4. Click the Update cluster button to open the Upgrade Wizard modal
5. Observe the version selection step title bar

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="640" height="363" alt="image" src="https://github.com/user-attachments/assets/34e29fc9-246c-41e5-9811-1b1afa0cf6f9" /> |<img width="1123" height="469" alt="Screenshot From 2026-05-31 16-17-51" src="https://github.com/user-attachments/assets/a9bf372f-eac5-4257-b12d-ac06c3a115c7" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4407]: https://redhat.atlassian.net/browse/OCMUI-4407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ