### PR TITLE
OCMUI-4624:Update playwright version to latest(1.60) to fix the blocking issue in CI execution

### DIFF
--- a/.github/workflows/e2e-ci-playwright.yml
+++ b/.github/workflows/e2e-ci-playwright.yml
@@ -63,6 +63,7 @@ jobs:
             sudo apt-get update && sudo apt-get install -y jq
           fi
       - name: Install Playwright Browsers
+        timeout-minutes: 15
         # Explicitly specify all browsers including chrome since Playwright 1.44+ no longer installs Chrome by default
         run: npm exec playwright install chromium chrome firefox webkit --with-deps
       - name: Get browser version

--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -142,6 +142,7 @@ jobs:
           rosa version
 
       - name: Install Playwright Browsers
+        timeout-minutes: 15
         # Explicitly specify all browsers including chrome since Playwright 1.44+ no longer installs Chrome by default
         run: npm exec playwright install chromium chrome firefox webkit --with-deps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "@chromatic-com/storybook": "3.2.2",
         "@cypress/code-coverage": "^3.12.39",
         "@cypress/grep": "^4.0.1",
-        "@playwright/test": "1.59.0",
+        "@playwright/test": "1.60.0",
         "@redhat-cloud-services/frontend-components-config": "^6.8.4",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.58",
         "@redhat-cloud-services/types": "^3.4.2",
@@ -6318,13 +6318,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.0.tgz",
-      "integrity": "sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24387,13 +24387,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
-      "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -24406,9 +24406,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
-      "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@chromatic-com/storybook": "3.2.2",
     "@cypress/code-coverage": "^3.12.39",
     "@cypress/grep": "^4.0.1",
-    "@playwright/test": "1.59.0",
+    "@playwright/test": "1.60.0",
     "@redhat-cloud-services/frontend-components-config": "^6.8.4",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.58",
     "@redhat-cloud-services/types": "^3.4.2",


### PR DESCRIPTION
# Summary

Update playwright version to latest(1.60) to fix the blocking issue in CI execution

# Jira

 Fixes [OCMUI-4624](https://issues.redhat.com/browse/OCMUI-4624)

# Additional information
Latest Node.js version 24.16.0 used in the CI/Smoke execution environment triggers the issue described in microsoft/playwright#40724, which blocks CI and Smoke E2E executions.
To resolve this issue, Playwright needs to be upgraded from v1.59 to v1.60. This PR implements that upgrade.
Additionally, a timeout has been added to the browser installation step in the GitHub workflow to prevent jobs from hanging for up to six hours and to ensure failures are surfaced more quickly when browser installation becomes unresponsive.


# How to Test
These changes cannot be fully validated until the PR is merged

# Screen Captures

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).


[OCMUI-4624]: https://redhat.atlassian.net/browse/OCMUI-4624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ