### PR TITLE
[NO-JIRA] Add minimumReleaseAge to renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,7 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "reviewersFromCodeOwners": true,
+  "minimumReleaseAge": "7 days",
   "baseBranchPatterns": ["main"],
   "tekton": {
     "schedule": ["at any time"]


### PR DESCRIPTION
# Summary

Protecting renovate from supply chain attacks

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

Not sure if there is way to test this beside double checking the configuration is applied properly [according to docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/)

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
