### PR TITLE
fix: disable refetchOnWindowFocus for subscription and cluster queries

### DIFF
--- a/src/queries/ClusterDetailsQueries/useFetchCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.ts
@@ -29,6 +29,7 @@ export const useFetchCluster = (
       return response;
     },
     retry: false,
+    refetchOnWindowFocus: false,
     enabled:
       !!subscription &&
       subscription.status !== SubscriptionCommonFieldsStatus.Deprovisioned &&

--- a/src/queries/common/useFetchSubscription.ts
+++ b/src/queries/common/useFetchSubscription.ts
@@ -32,6 +32,7 @@ export const useFetchSubscription = (subscriptionID: string, mainQueryKey: strin
         isOSDCluster,
       };
     },
+    refetchOnWindowFocus: false,
   });
 
   return {


### PR DESCRIPTION
Switching browser tabs triggered a window-focus refetch of useFetchSubscription. When any field in the subscription object had changed server-side, the new object produced a different query key in useFetchCluster, causing a cache miss and a full cluster re-fetch that reloaded the page. Disabling refetchOnWindowFocus on both queries stops the cascade; explicit invalidation via invalidateClusterDetailsQueries (timer and manual refresh) is unaffected.

# Summary

<!-- add a summarized description of the PR content -->

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
