### PR TITLE
OCMUI-4290 :E2e test case specs for autonode feature coverage on rosa hosted clusters

### DIFF
--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-autonode.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-autonode.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '../../fixtures/pages';
+
+const autonodeFixtureData = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-autonode.spec.json');
+const clusterProfileFixture = require('../../fixtures/rosa-hosted/rosa-cluster-hosted-public-advanced-creation.spec.json');
+const creationProfile = clusterProfileFixture['rosa-hosted-public-advanced']['day1-profile'];
+
+test.describe.serial(
+  'ROSA HCP Autonode (Red Hat build of Karpenter) - Overview management(OCP-89243)',
+  { tag: ['@day2', '@rosa-hosted', '@rosa', '@hcp', '@autonode', '@advanced'] },
+  () => {
+    const clusterName = process.env.CLUSTER_NAME || creationProfile.ClusterName;
+    const iamRoleArn = process.env.QE_AUTONODE_ROLE_ARN;
+    const updatedIamRoleArn = process.env.QE_AUTONODE_ROLE_ARN_SECONDARY;
+
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      if (!iamRoleArn) {
+        throw new Error(
+          'QE_AUTONODE_ROLE_ARN environment variable is required to run this test suite',
+        );
+      }
+      await navigateTo('cluster-list');
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.isClusterListScreen();
+    });
+
+    test('Navigate to ROSA HCP cluster Overview tab', async ({
+      clusterListPage,
+      clusterDetailsPage,
+    }) => {
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterDetailsPage.isAutoNodeSectionVisible();
+    });
+
+    test('Verify Autonode default status is Disabled', async ({ clusterDetailsPage }) => {
+      await expect(clusterDetailsPage.autoNodeStatus()).toHaveText('Disabled');
+    });
+
+    test('Open the Edit Autonode modal and verify all modal elements are present', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openEditAutoNodeModal();
+      await expect(clusterDetailsPage.editAutoNodeModalHeading()).toBeVisible();
+      await expect(clusterDetailsPage.enableAutoNodeSwitch()).toBeVisible();
+      await expect(clusterDetailsPage.autoNodeIamRoleArnInput()).toBeVisible();
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeVisible();
+      await expect(clusterDetailsPage.cancelAutoNodeButton()).toBeVisible();
+    });
+
+    test('Verify IAM role ARN input and Save button are disabled when Autonode switch is off', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.autoNodeIamRoleArnInput()).toBeDisabled();
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeDisabled();
+    });
+
+    test('Verify enabling the switch shows the irreversible-action warning alert', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.irreversibleWarning);
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.irreversibleWarning, false);
+    });
+
+    test('Verify IAM role ARN input becomes enabled after toggling the Autonode switch on', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await expect(clusterDetailsPage.autoNodeIamRoleArnInput()).toBeEnabled();
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+    });
+
+    test('Verify Save is disabled when Autonode is toggled on but ARN is empty', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().clear();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().blur();
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeDisabled();
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+    });
+
+    test('Verify an invalid ARN format shows a validation error and disables Save', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().fill(autonodeFixtureData.invalidArn);
+      await clusterDetailsPage.autoNodeIamRoleArnInput().blur();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.invalidArnError);
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeDisabled();
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+    });
+
+    test('Verify a valid ARN with Autonode enabled activates the Save button', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().fill(iamRoleArn);
+      await clusterDetailsPage.autoNodeIamRoleArnInput().blur();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.invalidArnError, false);
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeEnabled();
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+    });
+
+    test('Verify an ARN with leading/trailing whitespace shows a validation error and disables Save', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.checkAutoNodeSwitch();
+      await clusterDetailsPage
+        .autoNodeIamRoleArnInput()
+        .fill(autonodeFixtureData.arnWithWhitespace);
+      await clusterDetailsPage.autoNodeIamRoleArnInput().blur();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.arnWithWhitespaceError);
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeDisabled();
+      await clusterDetailsPage.uncheckAutoNodeSwitch();
+    });
+
+    test('Enable Autonode with a valid ARN and save', async ({ clusterDetailsPage }) => {
+      await clusterDetailsPage.enableAutoNodeWithArn(iamRoleArn!);
+      await expect(clusterDetailsPage.editAutoNodeModal()).toBeHidden();
+    });
+
+    test('Verify Autonode status shows Enabled and IAM role ARN is displayed on Overview', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.autoNodeStatus()).toHaveText('Enabled', { timeout: 30000 });
+      await expect(clusterDetailsPage.autoNodeIamRoleArnText()).toBeVisible();
+      await expect(clusterDetailsPage.autoNodeIamRoleArnText()).toContainText(iamRoleArn!);
+    });
+
+    test('Verify post-enable edit behavior: switch disabled, ARN editable, Save disabled with no changes', async ({
+      clusterDetailsPage,
+    }) => {
+      await clusterDetailsPage.openEditAutoNodeModal();
+      await expect(clusterDetailsPage.editAutoNodeModalHeading()).toBeVisible();
+      await expect(clusterDetailsPage.enableAutoNodeSwitch()).toBeChecked();
+      await expect(clusterDetailsPage.enableAutoNodeSwitch()).toBeDisabled();
+      await expect(clusterDetailsPage.autoNodeIamRoleArnInput()).toBeEnabled();
+      await expect(clusterDetailsPage.autoNodeIamRoleArnInput()).toHaveValue(iamRoleArn);
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeDisabled();
+      await clusterDetailsPage.closeEditAutoNodeModal();
+      await expect(clusterDetailsPage.editAutoNodeModal()).toBeHidden();
+    });
+
+    test('Verify Karpenter node reference with tooltip', async ({
+      clusterDetailsPage,
+    }) => {
+      await expect(clusterDetailsPage.autoNodeKarpenterCountContainer()).toBeVisible({
+        timeout: 60000,
+      });
+      await expect(clusterDetailsPage.autoNodeKarpenterCount()).toBeVisible();
+      await expect(clusterDetailsPage.autoNodeKarpenterTooltipButton()).toBeVisible();
+      await clusterDetailsPage.autoNodeKarpenterTooltipButton().click();
+      await clusterDetailsPage.isTextContainsInPage(autonodeFixtureData.karpenterTooltipHint);
+    });
+
+    test('Edit Autonode ARN to a new value and verify updated ARN on Overview', async ({
+      clusterDetailsPage,
+    }) => {
+      test.skip(!updatedIamRoleArn, 'QE_AUTONODE_ROLE_ARN_SECONDARY env var is required');
+      await clusterDetailsPage.openEditAutoNodeModal();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().clear();
+      await clusterDetailsPage.autoNodeIamRoleArnInput().fill(updatedIamRoleArn!);
+      await clusterDetailsPage.autoNodeIamRoleArnInput().blur();
+      await expect(clusterDetailsPage.saveAutoNodeButton()).toBeEnabled();
+      await clusterDetailsPage.saveAutoNodeButton().click();
+      await expect(clusterDetailsPage.editAutoNodeModal()).toBeHidden({ timeout: 30000 });
+      await expect(clusterDetailsPage.autoNodeIamRoleArnText()).toContainText(updatedIamRoleArn!, {
+        timeout: 30000,
+      });
+    });
+  },
+);

--- a/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-autonode.spec.json
+++ b/playwright/fixtures/rosa-hosted/rosa-cluster-hosted-autonode.spec.json
@@ -1,0 +1,9 @@
+{
+  "Description": "ROSA HCP cluster definition used for Autonode Day 2 tests",
+  "irreversibleWarning": "Enabling Autonode cannot be undone",
+  "karpenterTooltipHint": "These nodes are automatically provisioned and managed by Karpenter based on workload demands. These nodes are not managed through machine pools.",
+  "invalidArn": "not-a-valid-arn",
+  "arnWithWhitespace": "  arn:aws:iam::123456789012:role/dummy  ",
+  "arnWithWhitespaceError": "Value must not contain whitespaces",
+  "invalidArnError": "ARN value should be in the format arn:aws:iam::123456789012:role/role-name."
+}

--- a/playwright/page-objects/base-page.ts
+++ b/playwright/page-objects/base-page.ts
@@ -148,4 +148,13 @@ export class BasePage {
       throw error; // Re-throw original error, not screenshot error
     }
   }
+
+  async isTextContainsInPage(text: string, present: boolean = true): Promise<void> {
+    const locator = this.page.locator('body').filter({ hasText: text });
+    if (present) {
+      await expect(locator).toBeVisible();
+    } else {
+      await expect(locator).not.toBeVisible();
+    }
+  }
 }

--- a/playwright/page-objects/cluster-details-page.ts
+++ b/playwright/page-objects/cluster-details-page.ts
@@ -367,4 +367,93 @@ export class ClusterDetailsPage extends BasePage {
   clusterPersistentStorageLabelValue(): Locator {
     return this.page.getByTestId('persistent-storage');
   }
+
+  // ── Autonode (Red Hat build of Karpenter) ────────────────────────────────
+
+  autoNodeStatus(): Locator {
+    return this.page.getByTestId('autoNodeStatus');
+  }
+
+  editAutoNodeButton(): Locator {
+    return this.page.getByRole('button', { name: 'Edit Autonode settings' });
+  }
+
+  autoNodeIamRoleArnText(): Locator {
+    return this.page.getByText('Autonode IAM role ARN:', { exact: false });
+  }
+
+  autoNodeKarpenterCountContainer(): Locator {
+    return this.page.getByTestId('autoNodeKarpenterCountContainer');
+  }
+
+  autoNodeKarpenterCount(): Locator {
+    return this.page.getByTestId('autoNodeKarpenterCount');
+  }
+
+  autoNodeKarpenterTooltipButton(): Locator {
+    return this.page.getByRole('button', {
+      name: 'More information about Autonode Karpenter nodes',
+    });
+  }
+
+  autoNodeStatusAlert(): Locator {
+    return this.page.getByRole('alert').filter({ hasText: 'Autonode status' });
+  }
+
+  editAutoNodeModal(): Locator {
+    return this.page
+      .getByRole('dialog')
+      .filter({
+        has: this.page.getByRole('heading', { name: 'Edit Autonode settings', level: 1 }),
+      });
+  }
+
+  editAutoNodeModalHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Edit Autonode settings', level: 1 });
+  }
+
+  enableAutoNodeSwitch(): Locator {
+    return this.page.getByRole('switch', { name: 'Enable Autonode' });
+  }
+
+  autoNodeIamRoleArnInput(): Locator {
+    return this.editAutoNodeModal().getByRole('textbox');
+  }
+
+  saveAutoNodeButton(): Locator {
+    return this.editAutoNodeModal().getByRole('button', { name: 'Save' });
+  }
+
+  cancelAutoNodeButton(): Locator {
+    return this.editAutoNodeModal().getByRole('button', { name: 'Cancel' });
+  }
+
+  async isAutoNodeSectionVisible(): Promise<void> {
+    await expect(this.autoNodeStatus()).toBeVisible({ timeout: 30000 });
+  }
+
+  async checkAutoNodeSwitch(): Promise<void> {
+    await this.enableAutoNodeSwitch().check({ force: true });
+  }
+
+  async uncheckAutoNodeSwitch(): Promise<void> {
+    await this.enableAutoNodeSwitch().uncheck({ force: true });
+  }
+
+  async openEditAutoNodeModal(): Promise<void> {
+    await this.editAutoNodeButton().click();
+    await expect(this.editAutoNodeModalHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  async closeEditAutoNodeModal(): Promise<void> {
+    await this.cancelAutoNodeButton().click();
+    await expect(this.editAutoNodeModalHeading()).toBeHidden({ timeout: 30000 });
+  }
+
+  async enableAutoNodeWithArn(iamRoleArn: string): Promise<void> {
+    await this.checkAutoNodeSwitch();
+    await this.autoNodeIamRoleArnInput().fill(iamRoleArn);
+    await this.saveAutoNodeButton().click();
+    await expect(this.editAutoNodeModalHeading()).toBeHidden({ timeout: 30000 });
+  }
 }


### PR DESCRIPTION
# Summary
E2e test case specs for autonode feature coverage on rosa hosted clusters

# Jira

Fixes [OCMUI-4290](https://issues.redhat.com/browse/OCMUI-4290)

# Additional information

1. Created new test case spec for covering autonode(day2) feature on rosa hosted cluster.
2. Updated the page object and fixture definition to support the test spec.
  

# How to Test
Pre conditions
1. Create a ROSA HCP cluster, or use an existing one. Ensure the cluster is in a ready state and that the AutoNode feature is not enabled
2. Create autonode supported ARN role (Refer the "How to test" section from  parent [PR](https://github.com/RedHatInsights/uhc-portal/pull/536) ) 

Steps

1. Open a terminal and download this test case spec PR.
2. Export the cluster name and ARN value as below
```
export CLUSTER_NAME=<your cluster name>
export  QE_AUTONODE_ROLE_ARN=< your autonode arn and format is arn:aws:iam::1235678646:role/role-name >
```
3. Keep the required definition under playwright.env.json.
```
{
  "TEST_WITHQUOTA_USER": "<your username>",
  "TEST_WITHQUOTA_PASSWORD": "<your password>",
```
4. Use the below command and  run the test case 
```
BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/rosa-hosted/rosa-cluster-hosted-autonode.spec.ts
```
 
# Screen Captures

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npx playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-autonode.spec.ts
🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 14 tests using 1 worker
  14 passed (1.7m)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
```


[OCMUI-4290]: https://redhat.atlassian.net/browse/OCMUI-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ