### PR TITLE
Added E2E automation tests for GCP application ingress attributes

### DIFF
--- a/playwright/e2e/osd-gcp/osd-ccs-gcp-wizard-validation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-ccs-gcp-wizard-validation.spec.ts
@@ -23,7 +23,7 @@ Clusters.forEach((clusterProperties) => {
         await navigateTo('create');
       });
       test(`Launch OSD cluster wizard`, async ({ createOSDWizardPage }) => {
-        await createOSDWizardPage.waitAndClick(createOSDWizardPage.osdCreateClusterButton());
+        await createOSDWizardPage.openOsdCreateClusterWizard();
         await createOSDWizardPage.isCreateOSDPage();
       });
 
@@ -758,7 +758,6 @@ Clusters.forEach((clusterProperties) => {
           ClustersValidation.ClusterSettings.Machinepool.Common.NodeLabel[2].KeyError,
           false,
         );
-
         await createOSDWizardPage.wizardNextButton().click();
       });
 
@@ -863,6 +862,158 @@ Clusters.forEach((clusterProperties) => {
             .ExcludedNamespaces[1].Error,
           false,
         );
+
+        const excludeNamespaceSelectors =
+          ClustersValidation.Networking.Configuration.Common.IngressSettings.CustomSettings
+            .ExcludeNamespaceSelectors;
+
+        await expect(createOSDWizardPage.excludeNamespaceSelectorsSection()).toBeVisible();
+        await expect(page.getByText(excludeNamespaceSelectors.HelpText)).toBeVisible();
+
+        await createOSDWizardPage.excludeNamespaceSelectorsMoreInfoButton().click();
+        await expect(
+          page.getByRole('dialog').getByText(excludeNamespaceSelectors.PopoverTitle),
+        ).toBeVisible();
+        await createOSDWizardPage.closePopoverDialogs();
+
+        // Key exceeds 63 characters
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.UpperCharacterLimitValue);
+        await createOSDWizardPage.excludeNamespaceSelectorValuesInput(0).fill('prod');
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.KeyUpperCharacterLimitError,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Each comma-separated value segment exceeds 63 characters
+        await createOSDWizardPage.excludeNamespaceSelectorKeyInput(0).fill('env');
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.UpperCharacterLimitValue);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.ValueUpperCharacterLimitError,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.ValueUpperCharacterLimitInList.Key);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.ValueUpperCharacterLimitInList.Value);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.ValueUpperCharacterLimitError,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Unsupported characters in key field
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.UnsupportedKeyCharacters.Value);
+        await createOSDWizardPage.excludeNamespaceSelectorValuesInput(0).fill('prod');
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.UnsupportedKeyCharacters.Error,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Missing key — values entered without a key
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.MissingKey.Value);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.MissingKey.Error,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Missing values — key entered without values
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.MissingValues.Key);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.MissingValues.Value);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.MissingValues.Error,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Unsupported characters in value field (invalid comma-separated segment)
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.UnsupportedValueCharacters.Key);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.UnsupportedValueCharacters.Value);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorErrorContaining(
+          excludeNamespaceSelectors.UnsupportedValueCharacters.ErrorContains,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Reserved namespace values in value field
+        for (const reserved of excludeNamespaceSelectors.ReservedNamespaces) {
+          await createOSDWizardPage.excludeNamespaceSelectorKeyInput(0).fill(reserved.Key);
+          await createOSDWizardPage.excludeNamespaceSelectorValuesInput(0).fill(reserved.Value);
+          await createOSDWizardPage.expectExcludeNamespaceSelectorError(reserved.Error);
+          await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+        }
+
+        // Duplicate key across selector rows
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(0)
+          .fill(excludeNamespaceSelectors.DuplicateKey.Key);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.DuplicateKey.FirstValue);
+        await createOSDWizardPage.addExcludeNamespaceSelectorRow();
+        await createOSDWizardPage
+          .excludeNamespaceSelectorKeyInput(1)
+          .fill(excludeNamespaceSelectors.DuplicateKey.Key);
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(1)
+          .fill(excludeNamespaceSelectors.DuplicateKey.SecondValue);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.DuplicateKey.Error,
+        );
+
+        await createOSDWizardPage
+          .excludeNamespaceSelectorsSection()
+          .getByRole('button', { name: 'Remove item' })
+          .nth(1)
+          .click();
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Erasing a previously entered key leaves values and shows missing-key error
+        await createOSDWizardPage.fillExcludeNamespaceSelector(
+          0,
+          excludeNamespaceSelectors.ClearedKey.Key,
+          excludeNamespaceSelectors.ClearedKey.Value,
+        );
+        await createOSDWizardPage.excludeNamespaceSelectorKeyInput(0).clear();
+        await createOSDWizardPage
+          .excludeNamespaceSelectorValuesInput(0)
+          .fill(excludeNamespaceSelectors.ClearedKey.Value);
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.ClearedKey.ErrorAfterClear,
+        );
+        await createOSDWizardPage.clearExcludeNamespaceSelectorRow(0);
+
+        // Valid key and values clear validation errors
+        await createOSDWizardPage.fillExcludeNamespaceSelector(
+          0,
+          excludeNamespaceSelectors.Valid.Key,
+          excludeNamespaceSelectors.Valid.Value,
+        );
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.ReservedNamespaces[0].Error,
+          false,
+        );
+        await createOSDWizardPage.expectExcludeNamespaceSelectorError(
+          excludeNamespaceSelectors.DuplicateKey.Error,
+          false,
+        );
+
         if (clusterProperties.AuthenticationType?.includes('Workload Identity Federation')) {
           await createOSDWizardPage.installIntoExistingVpcCheckBox().check();
           await createOSDWizardPage.wizardNextButton().click();

--- a/playwright/e2e/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.ts
@@ -11,13 +11,12 @@ const region = PSC_INFRA.REGION || clusterProperties.Region.split(',')[0];
 
 test.describe.serial(
   'OSD GCP Curated Marketplace WIF cluster creation tests (OCMUI-3888)',
-  { tag: ['@smoke', '@osd', '@curated'] },
+  { tag: ['@smoke', '@osd', '@curated', '@custom-ingress'] },
   () => {
-    test.beforeAll(async ({ navigateTo }) => {
+    test.beforeAll(async ({ page, navigateTo }) => {
       if (!QE_GCP_WIF_CONFIG?.trim()) {
         throw new Error('QE_GCP_WIF_CONFIG must be set for curated GCP WIF tests');
       }
-      // Navigate directly to curated OSD GCP wizard
       await navigateTo('create/osdgcp');
     });
 
@@ -82,11 +81,30 @@ test.describe.serial(
       await page.locator(createOSDWizardPage.primaryButton).click();
     });
 
-    test(`OSD GCP curated wizard - ${clusterProperties.CloudProvider} -${clusterProperties.AuthenticationType} -${clusterProperties.Marketplace} : Networking configuration - cluster privacy definitions`, async ({
+    test(`OSD GCP curated wizard - ${clusterProperties.CloudProvider} -${clusterProperties.AuthenticationType} -${clusterProperties.Marketplace} : Networking configuration - cluster privacy and application ingress definitions`, async ({
       page,
       createOSDWizardPage,
     }) => {
       await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.applicationIngressCustomSettingsRadio().check();
+      await expect(createOSDWizardPage.excludeNamespaceSelectorsSection()).toBeVisible();
+      await expect(
+        page.getByText(clusterProperties.ExcludeNamespaceSelectorsHelpText),
+      ).toBeVisible();
+
+      const selectors = clusterProperties.ExcludeNamespaceSelectors;
+      await createOSDWizardPage.fillExcludeNamespaceSelector(
+        0,
+        selectors[0].Key,
+        selectors[0].Values,
+      );
+      await createOSDWizardPage.addExcludeNamespaceSelectorRow();
+      await createOSDWizardPage.fillExcludeNamespaceSelector(
+        1,
+        selectors[1].Key,
+        selectors[1].Values,
+      );
+
       await createOSDWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
       await expect(createOSDWizardPage.installIntoExistingVpcCheckBox()).toBeChecked();
       await page.locator(createOSDWizardPage.primaryButton).click();
@@ -204,6 +222,11 @@ test.describe.serial(
       await expect(createOSDWizardPage.applicationIngressValue()).toContainText(
         clusterProperties.ApplicationIngress,
       );
+      const excludeNamespaceSelectorsReview =
+        createOSDWizardPage.excludeNamespaceSelectorsReviewValue();
+      for (const selector of clusterProperties.ExcludeNamespaceSelectors) {
+        await expect(excludeNamespaceSelectorsReview).toContainText(selector.ReviewDisplay);
+      }
       await expect(createOSDWizardPage.updateStratergyValue()).toContainText(
         clusterProperties.UpdateStrategy,
       );

--- a/playwright/e2e/osd-gcp/osd-gcp-custom-ingress-day1.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-gcp-custom-ingress-day1.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test } from '../../fixtures/pages';
+import { CreateOSDWizardPage } from '../../page-objects/create-osd-wizard-page';
+
+const clusterProperties = require('../../fixtures/osd-gcp/osd-ccs-gcp-custom-ingress.spec.json');
+
+const clusterName = `${clusterProperties.ClusterName}-${Math.random().toString(36).substring(7)}`;
+const clusterDomainPrefix = `osd${Math.random().toString(36).substring(2, 13)}`;
+const authType = clusterProperties.AuthenticationType;
+const isWif = authType.includes('Workload Identity Federation');
+const QE_GCP_WIF_CONFIG = process.env.QE_GCP_WIF_CONFIG || '';
+const QE_GCP = process.env.QE_GCP_OSDCCSADMIN_JSON;
+
+async function fillAllExcludeNamespaceSelectors(
+  createOSDWizardPage: CreateOSDWizardPage,
+  selectors: { Key: string; Values: string }[],
+): Promise<void> {
+  for (let i = 0; i < selectors.length; i++) {
+    if (i > 0) {
+      await createOSDWizardPage.addExcludeNamespaceSelectorRow();
+    }
+    await createOSDWizardPage.fillExcludeNamespaceSelector(
+      i,
+      selectors[i].Key,
+      selectors[i].Values,
+    );
+  }
+}
+test.describe.serial(
+  'OSD GCP WIF networking day-1 – exclude namespace selectors',
+  { tag: ['@day1', '@smoke', '@osd', '@gcp', '@networking', '@custom-ingress'] },
+  () => {
+    test.beforeAll(async ({ navigateTo }) => {
+      if (isWif && !QE_GCP_WIF_CONFIG?.trim()) {
+        throw new Error('QE_GCP_WIF_CONFIG must be set for WIF authentication');
+      }
+      if (!isWif && !QE_GCP?.trim()) {
+        throw new Error('QE_GCP_OSDCCSADMIN_JSON must be set for Service Account authentication');
+      }
+
+      await navigateTo('create');
+    });
+
+    test('Launch OSD GCP wizard', async ({ createOSDWizardPage }) => {
+      await createOSDWizardPage.waitAndClick(createOSDWizardPage.osdCreateClusterButton());
+      await createOSDWizardPage.isCreateOSDPage();
+    });
+
+    test('Billing model – Annual fixed capacity and customer cloud subscription', async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isBillingModelScreen();
+      await createOSDWizardPage.selectSubscriptionType(clusterProperties.SubscriptionType);
+      await createOSDWizardPage.selectInfrastructureType(clusterProperties.InfrastructureType);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test(`Cloud provider – GCP ${authType}`, async ({ page, createOSDWizardPage }) => {
+      await createOSDWizardPage.isCloudProviderSelectionScreen();
+      await createOSDWizardPage.selectCloudProvider(clusterProperties.CloudProvider);
+
+      if (isWif) {
+        await createOSDWizardPage.workloadIdentityFederationButton().click();
+        await createOSDWizardPage.selectWorkloadIdentityConfiguration(QE_GCP_WIF_CONFIG);
+      } else {
+        await createOSDWizardPage.serviceAccountButton().click();
+        await createOSDWizardPage.uploadGCPServiceAccountJSON(QE_GCP || '{}');
+      }
+
+      await createOSDWizardPage.acknowlegePrerequisitesCheckbox().check();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('Cluster details', async ({ page, createOSDWizardPage }) => {
+      await createOSDWizardPage.isClusterDetailsScreen();
+      await createOSDWizardPage.createCustomDomainPrefixCheckbox().scrollIntoViewIfNeeded();
+      await createOSDWizardPage.createCustomDomainPrefixCheckbox().check();
+      await createOSDWizardPage.setClusterName(clusterName);
+      await createOSDWizardPage.closePopoverDialogs();
+      await createOSDWizardPage.setDomainPrefix(clusterDomainPrefix);
+      await createOSDWizardPage.closePopoverDialogs();
+      await createOSDWizardPage.selectRegion(clusterProperties.Region);
+      await createOSDWizardPage.selectVersion(
+        clusterProperties.Version || process.env.VERSION || '',
+      );
+      await createOSDWizardPage.enableSecureBootSupportForSchieldedVMs(true);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('Machine pool', async ({ page, createOSDWizardPage }) => {
+      await createOSDWizardPage.isMachinePoolScreen();
+      await createOSDWizardPage.selectComputeNodeType(
+        clusterProperties.MachinePools[0].InstanceType,
+      );
+      await createOSDWizardPage.selectComputeNodeCount(clusterProperties.MachinePools[0].NodeCount);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('Networking – empty exclude namespace selector validations', async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.selectApplicationIngressCustomSettings();
+      await createOSDWizardPage.ensureExcludeNamespaceSelectorsSectionVisible();
+
+      // Route selector and excluded namespaces are always shown with custom ingress.
+      // Exclude namespace selectors default to empty
+      await createOSDWizardPage.expectApplicationIngressRouteFieldsEmpty();
+
+      await page.locator(createOSDWizardPage.primaryButton).click();
+      await createOSDWizardPage.isCIDRScreen();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+      await createOSDWizardPage.isClusterUpdatesScreen();
+      await page.locator(createOSDWizardPage.primaryButton).click();
+      await createOSDWizardPage.isReviewScreen();
+
+      await expect(createOSDWizardPage.routeSelectorsReviewValue()).toHaveText(
+        clusterProperties.RouteSelectorEmptyReviewDisplay,
+      );
+      await expect(createOSDWizardPage.excludedNamespacesReviewValue()).toHaveText(
+        clusterProperties.ExcludedNamespacesEmptyReviewDisplay,
+      );
+      await expect(createOSDWizardPage.excludeNamespaceSelectorsReviewValue()).toHaveText(
+        clusterProperties.ExcludeNamespaceSelectorsEmptyReviewDisplay,
+      );
+      await expect(createOSDWizardPage.namespaceOwnershipPolicyReviewValue()).toHaveText(
+        clusterProperties.NamespaceOwnershipPolicyReviewDisplay,
+      );
+      await expect(createOSDWizardPage.wildcardPolicyReviewValue()).toHaveText(
+        clusterProperties.WildcardPolicyReviewDisplay,
+      );
+
+      await createOSDWizardPage.wizardBackButton().click();
+      await createOSDWizardPage.isClusterUpdatesScreen();
+      await createOSDWizardPage.wizardBackButton().click();
+      await createOSDWizardPage.isCIDRScreen();
+      await createOSDWizardPage.wizardBackButton().click();
+      await createOSDWizardPage.isNetworkingScreen();
+    });
+
+    test('Networking – enter valid custom ingress controller settings', async ({
+      page,
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isNetworkingScreen();
+      await createOSDWizardPage.ensureExcludeNamespaceSelectorsSectionVisible();
+
+      await createOSDWizardPage
+        .applicationIngressRouterSelectorsInput()
+        .fill(clusterProperties.RouteSelector.Value);
+      await createOSDWizardPage
+        .applicationIngressExcludedNamespacesInput()
+        .fill(clusterProperties.ExcludedNamespaces.Value);
+
+      if (clusterProperties.NamespaceOwnershipPolicy === 'Strict') {
+        await expect(createOSDWizardPage.namespaceOwnershipPolicySwitch()).toBeChecked();
+      } else {
+        await createOSDWizardPage.namespaceOwnershipPolicySwitch().click();
+        await expect(createOSDWizardPage.namespaceOwnershipPolicySwitch()).not.toBeChecked();
+      }
+      if (clusterProperties.WildcardPolicy === 'Allowed') {
+        await createOSDWizardPage.wildcardPolicySwitch().click();
+        await expect(page.getByRole('switch', { name: 'Allowed' })).toBeChecked();
+      } else {
+        await expect(createOSDWizardPage.wildcardPolicySwitch()).not.toBeChecked();
+      }
+
+      await expect(createOSDWizardPage.applicationIngressRouterSelectorsInput()).toHaveValue(
+        clusterProperties.RouteSelector.Value,
+      );
+      await expect(createOSDWizardPage.applicationIngressExcludedNamespacesInput()).toHaveValue(
+        clusterProperties.ExcludedNamespaces.Value,
+      );
+
+      await fillAllExcludeNamespaceSelectors(
+        createOSDWizardPage,
+        clusterProperties.ExcludeNamespaceSelectors,
+      );
+
+      await createOSDWizardPage.selectClusterPrivacy(clusterProperties.ClusterPrivacy);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('CIDR ranges', async ({ page, createOSDWizardPage }) => {
+      await createOSDWizardPage.isCIDRScreen();
+      await expect(createOSDWizardPage.machineCIDRInput()).toHaveValue(
+        clusterProperties.MachineCIDR,
+      );
+      await expect(createOSDWizardPage.serviceCIDRInput()).toHaveValue(
+        clusterProperties.ServiceCIDR,
+      );
+      await expect(createOSDWizardPage.podCIDRInput()).toHaveValue(clusterProperties.PodCIDR);
+      await expect(createOSDWizardPage.hostPrefixInput()).toHaveValue(clusterProperties.HostPrefix);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('Cluster updates', async ({ page, createOSDWizardPage }) => {
+      await createOSDWizardPage.isClusterUpdatesScreen();
+      await createOSDWizardPage.selectNodeDraining(clusterProperties.NodeDraining);
+      await page.locator(createOSDWizardPage.primaryButton).click();
+    });
+
+    test('Review and create – exclude namespace selectors definitions', async ({
+      createOSDWizardPage,
+    }) => {
+      await createOSDWizardPage.isReviewScreen();
+
+      await expect(createOSDWizardPage.applicationIngressValue()).toContainText(
+        clusterProperties.ApplicationIngress,
+      );
+      for (const reviewDisplay of clusterProperties.RouteSelector.ReviewDisplays) {
+        await expect(createOSDWizardPage.routeSelectorsReviewValue()).toContainText(reviewDisplay);
+      }
+      for (const reviewDisplay of clusterProperties.ExcludedNamespaces.ReviewDisplays) {
+        await expect(createOSDWizardPage.excludedNamespacesReviewValue()).toContainText(
+          reviewDisplay,
+        );
+      }
+      await expect(createOSDWizardPage.namespaceOwnershipPolicyReviewValue()).toHaveText(
+        clusterProperties.NamespaceOwnershipPolicyReviewDisplay,
+      );
+      await expect(createOSDWizardPage.wildcardPolicyReviewValue()).toHaveText(
+        clusterProperties.WildcardPolicyReviewDisplay,
+      );
+
+      await createOSDWizardPage.expectReviewLabelGroupDisplays(
+        createOSDWizardPage.excludeNamespaceSelectorsReviewValue(),
+        clusterProperties.ExcludeNamespaceSelectors.map((selector) => selector.ReviewDisplay),
+      );
+    });
+
+    test('Cluster submission and installation progress', async ({
+      createOSDWizardPage,
+      clusterDetailsPage,
+    }) => {
+      await createOSDWizardPage.createClusterButton().click();
+      await clusterDetailsPage.waitForInstallerScreenToLoad();
+
+      await expect(clusterDetailsPage.clusterNameTitle()).toContainText(clusterName);
+      await expect(clusterDetailsPage.clusterInstallationHeader()).toContainText(
+        'Installing cluster',
+      );
+
+      await clusterDetailsPage.clusterDetailsPageRefresh();
+      await clusterDetailsPage.checkInstallationStepStatus('Account setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Network settings');
+      await clusterDetailsPage.checkInstallationStepStatus('DNS setup');
+      await clusterDetailsPage.checkInstallationStepStatus('Cluster installation');
+    });
+  },
+);

--- a/playwright/e2e/osd-gcp/osd-gcp-custom-ingress-day2.spec.ts
+++ b/playwright/e2e/osd-gcp/osd-gcp-custom-ingress-day2.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test } from '../../fixtures/pages';
+
+const clusterProfiles = require('../../fixtures/osd-gcp/osd-ccs-gcp-custom-ingress.spec.json');
+const ClustersValidation = require('../../fixtures/osd-gcp/osd-ccs-gcp-wizard-validation.spec.json');
+const day1Profile = clusterProfiles['osd-gcp-ingress-public-advanced']['day1-profile'];
+const clusterProperties = clusterProfiles['osd-gcp-ingress-public-advanced']['day2-profile'];
+const clusterName = day1Profile.ClusterName;
+const cidrRanges = clusterProperties.CIDRRanges;
+const ingressValidation =
+  ClustersValidation.ClustersValidation.Networking.Configuration.Common.IngressSettings
+    .CustomSettings;
+
+test.describe.serial(
+  `OSD GCP WIF custom ingress Networking Day-2 (${clusterName})`,
+  { tag: ['@day2', '@osd', '@curated', '@gcp', '@networking', '@custom-ingress'] },
+  () => {
+    test.beforeAll(async ({ navigateTo, clusterListPage }) => {
+      test.skip(!clusterName, 'Set CLUSTER_NAME or QE_CURATED_GCP_DAY2_CLUSTER_NAME.');
+
+      await navigateTo('clusters/list');
+      await clusterListPage.waitForDataReady();
+    });
+
+    test('Navigate to cluster Networking tab', async ({
+      clusterListPage,
+      clusterDetailsPage,
+      networkingPage,
+    }) => {
+      await clusterListPage.isClusterListScreen();
+      await clusterListPage.filterTxtField().fill(clusterName);
+      await clusterListPage.waitForDataReady();
+      await clusterListPage.openClusterDefinition(clusterName);
+      await clusterDetailsPage.waitForClusterDetailsLoad();
+      await networkingPage.goToNetworkingTab();
+    });
+
+    test('Network configuration card shows CIDR ranges from cluster creation', async ({
+      networkingPage,
+    }) => {
+      const card = networkingPage.networkConfigurationCard();
+      await expect(card.getByText('CIDR ranges')).toBeVisible();
+
+      await expect(networkingPage.descriptionListValue(card, 'Machine CIDR')).toHaveText(
+        cidrRanges.MachineCIDR,
+      );
+      await expect(networkingPage.descriptionListValue(card, 'Service CIDR')).toHaveText(
+        cidrRanges.ServiceCIDR,
+      );
+      await expect(networkingPage.descriptionListValue(card, 'Pod CIDR')).toHaveText(
+        cidrRanges.PodCIDR,
+      );
+      await expect(networkingPage.descriptionListValue(card, 'Host prefix')).toHaveText(
+        cidrRanges.Hostprefix,
+      );
+    });
+
+    test('Application ingress card shows default router and ingress fields', async ({
+      networkingPage,
+    }) => {
+      const card = networkingPage.applicationIngressCard();
+      await expect(card.getByText('Application ingress', { exact: true })).toBeVisible();
+      await expect(networkingPage.defaultApplicationRouterInput()).toBeVisible();
+      await expect(networkingPage.routeSelectorDisplayInput()).toBeVisible();
+      await expect(networkingPage.excludedNamespacesDisplayInput()).toBeVisible();
+      await expect(networkingPage.editApplicationIngressButton()).toBeVisible();
+    });
+
+    test('Edit application ingress modal opens with Save disabled until values change', async ({
+      networkingPage,
+    }) => {
+      await networkingPage.openEditApplicationIngressModal();
+      await expect(networkingPage.editModalSaveButton()).toBeDisabled();
+      await networkingPage.closeEditApplicationIngressModal();
+    });
+
+    test('Application ingress card and edit modal show day-1 custom ingress values', async ({
+      networkingPage,
+    }) => {
+      const expectedIngress = clusterProperties.ApplicationIngress;
+
+      expect(expectedIngress.RouteSelector).toBe(day1Profile.RouteSelector.Value);
+      expect(expectedIngress.ExcludedNamespaces).toBe(day1Profile.ExcludedNamespaces.Value);
+      expect(expectedIngress.NamespaceOwnershipPolicy).toBe(day1Profile.NamespaceOwnershipPolicy);
+      expect(expectedIngress.WildcardPolicy).toBe(day1Profile.WildcardPolicy);
+
+      await expect(networkingPage.routeSelectorDisplayInput()).toHaveValue(
+        expectedIngress.RouteSelector,
+      );
+      await expect(networkingPage.excludedNamespacesDisplayInput()).toHaveValue(
+        expectedIngress.ExcludedNamespaces,
+      );
+
+      const card = networkingPage.applicationIngressCard();
+      if (expectedIngress.NamespaceOwnershipPolicy === 'Strict') {
+        await expect(card.getByRole('switch', { name: 'Strict' })).toBeChecked();
+      } else {
+        await expect(card.getByRole('switch', { name: 'Strict' })).not.toBeChecked();
+      }
+      if (expectedIngress.WildcardPolicy === 'Allowed') {
+        await expect(card.getByRole('switch', { name: 'Allowed' })).toBeChecked();
+      } else {
+        await expect(card.getByRole('switch', { name: 'Disallowed' })).not.toBeChecked();
+      }
+
+      await networkingPage.openEditApplicationIngressModal();
+      await expect(networkingPage.editModalRouteSelectorInput()).toHaveValue(
+        expectedIngress.RouteSelector,
+      );
+      await expect(networkingPage.editModalExcludedNamespacesInput()).toHaveValue(
+        expectedIngress.ExcludedNamespaces,
+      );
+      await networkingPage.closeEditApplicationIngressModal();
+    });
+
+    test('Edit application ingress - route selector field validations', async ({
+      networkingPage,
+    }) => {
+      const routeSelectorValidation = ingressValidation.RouteSelector;
+
+      await networkingPage.openEditApplicationIngressModal();
+
+      await networkingPage.editModalRouteSelectorInput().clear();
+      await networkingPage
+        .editModalRouteSelectorInput()
+        .fill(routeSelectorValidation[0].UpperCharacterLimitValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(routeSelectorValidation[0].Error);
+
+      await networkingPage.editModalRouteSelectorInput().clear();
+      await networkingPage
+        .editModalRouteSelectorInput()
+        .fill(routeSelectorValidation[1].InvalidValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(routeSelectorValidation[1].Error);
+
+      await networkingPage.editModalRouteSelectorInput().clear();
+      await networkingPage
+        .editModalRouteSelectorInput()
+        .fill(routeSelectorValidation[2].InvalidValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(routeSelectorValidation[2].Error);
+
+      await networkingPage.editModalRouteSelectorInput().clear();
+      await networkingPage
+        .editModalRouteSelectorInput()
+        .fill(routeSelectorValidation[3].InvalidValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(routeSelectorValidation[3].Error);
+
+      await networkingPage.editModalRouteSelectorInput().clear();
+      await networkingPage.editModalRouteSelectorInput().fill('valid123-k.com/Hello_world2');
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(routeSelectorValidation[0].Error, false);
+
+      await networkingPage.closeEditApplicationIngressModal();
+    });
+
+    test('Edit application ingress - excluded namespaces field validations', async ({
+      networkingPage,
+    }) => {
+      const excludedNamespacesValidation = ingressValidation.ExcludedNamespaces;
+
+      await networkingPage.openEditApplicationIngressModal();
+
+      await networkingPage.editModalExcludedNamespacesInput().clear();
+      await networkingPage
+        .editModalExcludedNamespacesInput()
+        .fill(excludedNamespacesValidation[0].UpperCharacterLimitValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(excludedNamespacesValidation[0].Error);
+
+      await networkingPage.editModalExcludedNamespacesInput().clear();
+      await networkingPage
+        .editModalExcludedNamespacesInput()
+        .fill(excludedNamespacesValidation[1].InvalidValue);
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(excludedNamespacesValidation[1].Error);
+
+      await networkingPage.editModalExcludedNamespacesInput().clear();
+      await networkingPage.editModalExcludedNamespacesInput().fill('abc-123');
+      await networkingPage.blurRouteSelectorField();
+      await networkingPage.expectTextInPage(excludedNamespacesValidation[1].Error, false);
+
+      await networkingPage.closeEditApplicationIngressModal();
+    });
+  },
+);

--- a/playwright/fixtures/osd-gcp/osd-ccs-gcp-custom-ingress.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ccs-gcp-custom-ingress.spec.json
@@ -1,0 +1,108 @@
+{
+  "osd-gcp-ingress-public-advanced": {
+    "day1-profile": {
+      "ClusterName": "ocmui-playwright-osd-gcp-wif-ingress",
+      "Type": "OSD",
+      "CloudProvider": "Google Cloud",
+      "SubscriptionType": "Annual: Fixed capacity subscription from Red Hat",
+      "SubscriptionBillingModel": "Annual Red Hat subscriptions",
+      "InfrastructureType": "Customer cloud subscription",
+      "AuthenticationType": "Workload Identity Federation",
+      "Region": "us-central1, Council Bluffs, Iowa, USA",
+      "Availability": "Single zone",
+      "SecureBootSupportForShieldedVMs": "Enabled",
+      "UserWorkloadMonitoring": "Enabled",
+      "EncryptVolumesWithCustomerKeys": "Disabled",
+      "FIPSCryptography": "Disabled",
+      "AdditionalEncryption": "Disabled",
+      "ClusterAutoscaling": "Disabled",
+      "InstallIntoExistingVPC": "Disabled",
+      "ClusterPrivacy": "Public",
+      "MachineCIDR": "10.0.0.0/16",
+      "ServiceCIDR": "172.30.0.0/16",
+      "PodCIDR": "10.128.0.0/14",
+      "HostPrefix": "/23",
+      "ApplicationIngress": "Custom settings",
+      "RouteSelectorEmptyReviewDisplay": "None specified",
+      "ExcludedNamespacesEmptyReviewDisplay": "None specified",
+      "ExcludeNamespaceSelectorsEmptyReviewDisplay": "None specified",
+      "RouteSelector": {
+        "Value": "route1=value1,route2=value2",
+        "ReviewDisplays": ["route1 = value1", "route2 = value2"]
+      },
+      "ExcludedNamespaces": {
+        "Value": "test-excluded-ns-1,test-excluded-ns-2",
+        "ReviewDisplays": ["test-excluded-ns-1", "test-excluded-ns-2"]
+      },
+      "NamespaceOwnershipPolicy": "Strict",
+      "NamespaceOwnershipPolicyReviewDisplay": "Strict namespace ownership",
+      "WildcardPolicy": "Disallowed",
+      "WildcardPolicyReviewDisplay": "Disallowed",
+      "UpdateStrategy": "Individual updates",
+      "NodeDraining": "1 hour",
+      "ExcludeNamespaceSelectorsHelpText": "Namespaces matching any of these label selectors will be excluded from the default ingress controller.",
+      "ExcludeNamespaceSelectorsValidation": {
+        "MissingKey": {
+          "Value": "prod",
+          "Error": "Enter a label key before values."
+        },
+        "MissingValues": {
+          "Key": "env",
+          "Error": "Enter at least one value, separated by commas."
+        }
+      },
+      "ExcludeNamespaceSelectors": [
+        {
+          "Key": "env",
+          "Values": "testing",
+          "ReviewDisplay": "env = testing"
+        },
+        {
+          "Key": "longerstringslongerstringslongerstringslongerstringslongerstri",
+          "Values": "longerstringslongerstringslongerstringslongerstringslongerstri",
+          "ReviewDisplay": "longerstringslongerstringslongerstringslongerstringslongerstri = longerstringslongerstringslongerstringslongerstringslongerstri"
+        },
+        {
+          "Key": "example.co.in/app.com",
+          "Values": "exmaples.co.in",
+          "ReviewDisplay": "example.co.in/app.com = exmaples.co.in"
+        },
+        {
+          "Key": "app.kubernetes.io/version",
+          "Values": "v1.2",
+          "ReviewDisplay": "app.kubernetes.io/version = v1.2"
+        },
+        {
+          "Key": "v22-22_t23",
+          "Values": "v22-22_t23.2,ddd",
+          "ReviewDisplay": "v22-22_t23 = v22-22_t23.2, ddd"
+        }
+      ],
+      "MachinePools": [
+        {
+          "Name": "worker",
+          "InstanceType": "e2-standard-4",
+          "NodeCount": 2,
+          "Autoscaling": "Disabled"
+        }
+      ]
+    },
+    "day2-profile": {
+      "ClusterNamePrefix": "ocmui-smoke-osd-gcp-wif-custom-ingress",
+      "ApplicationIngress": {
+        "RouteSelectorLabel": "Route selector",
+        "ExcludedNamespacesLabel": "Excluded namespaces",
+        "RouteSelector": "route1=value1,route2=value2",
+        "ExcludedNamespaces": "test-excluded-ns-1,test-excluded-ns-2",
+        "NamespaceOwnershipPolicy": "Strict",
+        "WildcardPolicy": "Disallowed"
+      },
+      "CIDRRanges": {
+        "MachineCIDR": "10.0.0.0/16",
+        "ServiceCIDR": "172.30.0.0/16",
+        "PodCIDR": "10.128.0.0/14",
+        "Hostprefix": "/23"
+      }
+    }
+  }
+}

--- a/playwright/fixtures/osd-gcp/osd-ccs-gcp-wizard-validation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-ccs-gcp-wizard-validation.spec.json
@@ -152,7 +152,63 @@
                   "InvalidValue": "Invalid-",
                   "Error": "Namespace name 'Invalid-' isn't valid, must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. For example, 'my-name', or 'abc-123'."
                 }
-              ]
+              ],
+              "ExcludeNamespaceSelectors": {
+                "HelpText": "Namespaces matching any of these label selectors will be excluded from the default ingress controller.",
+                "PopoverTitle": "Exclude namespace selectors",
+                "UpperCharacterLimitValue": "characterslimtgreaterthan60testingssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+                "KeyUpperCharacterLimitError": "A valid key name must be 63 characters or less",
+                "ValueUpperCharacterLimitError": "A valid value must be 63 characters or less",
+                "ValueUpperCharacterLimitInList": {
+                  "Key": "env",
+                  "Value": "prod,characterslimtgreaterthan60testingssssssssssssssssssssssssssssssssssssssssssssssssssssssss"
+                },
+                "UnsupportedKeyCharacters": {
+                  "Value": "Invalid_Label_Key!",
+                  "Error": "A valid key name must consist of alphanumeric characters, '-', '.' , '_'  or '/' and must start and end with an alphanumeric character"
+                },
+                "UnsupportedValueCharacters": {
+                  "Key": "department",
+                  "Value": "good,bad value!",
+                  "ErrorContains": "valid value"
+                },
+                "MissingKey": {
+                  "Value": "prod",
+                  "Error": "Enter a label key before values."
+                },
+                "MissingValues": {
+                  "Key": "env",
+                  "Value": "",
+                  "Error": "Enter at least one value, separated by commas."
+                },
+                "DuplicateKey": {
+                  "Key": "env",
+                  "FirstValue": "prod",
+                  "SecondValue": "dev",
+                  "Error": "Each selector must have a different key."
+                },
+                "ReservedNamespaces": [
+                  {
+                    "Key": "kubernetes.io/metadata.name",
+                    "Value": "openshift-console",
+                    "Error": "Do not exclude openshift-console or openshift-authentication namespaces; they are vital to cluster operations."
+                  },
+                  {
+                    "Key": "kubernetes.io/metadata.name",
+                    "Value": "openshift-authentication",
+                    "Error": "Do not exclude openshift-console or openshift-authentication namespaces; they are vital to cluster operations."
+                  }
+                ],
+                "ClearedKey": {
+                  "Key": "department",
+                  "Value": "finance",
+                  "ErrorAfterClear": "Enter a label key before values."
+                },
+                "Valid": {
+                  "Key": "department",
+                  "Value": "finance,hr,legal"
+                }
+              }
             }
           }
         },

--- a/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.json
+++ b/playwright/fixtures/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.json
@@ -31,9 +31,22 @@
   "ServiceCIDR": "172.30.0.0/16",
   "PodCIDR": "10.128.0.0/14",
   "HostPrefix": "/23",
-  "ApplicationIngress": "Use default settings",
+  "ApplicationIngress": "Custom settings",
+  "ExcludeNamespaceSelectorsHelpText": "Namespaces matching any of these label selectors will be excluded from the default ingress controller.",
   "UpdateStrategy": "Individual updates",
   "NodeDraining": "60 minutes",
+  "ExcludeNamespaceSelectors": [
+    {
+      "Key": "department",
+      "Values": "finance,hr",
+      "ReviewDisplay": "department = finance, hr"
+    },
+    {
+      "Key": "kubernetes.io/metadata.name",
+      "Values": "workloads",
+      "ReviewDisplay": "kubernetes.io/metadata.name = workloads"
+    }
+  ],
   "MachinePools": [
     {
       "Name": "worker",
@@ -55,6 +68,13 @@
       "ServiceCIDR": "172.30.0.0/16",
       "PodCIDR": "10.128.0.0/14",
       "Hostprefix": "/23"
+    }
+  },
+  "Day2": {
+    "ClusterNamePrefix": "ocmui-smoke-osd-curated-gcp-wif",
+    "ApplicationIngress": {
+      "RouteSelectorLabel": "Route selector",
+      "ExcludedNamespacesLabel": "Excluded namespaces"
     }
   }
 }

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -7,6 +7,7 @@ import {
 } from '@playwright/test';
 import { ClusterDetailsPage } from '../page-objects/cluster-details-page';
 import { MachinePoolsPage } from '../page-objects/machine-pools-page';
+import { NetworkingPage } from '../page-objects/networking-page';
 import { ClusterListPage } from '../page-objects/cluster-list-page';
 import { ClusterRequestsPage } from '../page-objects/cluster-requests-page';
 import { ClusterTypesPage } from '../page-objects/cluster-types-page';
@@ -38,6 +39,7 @@ type WorkerFixtures = {
   authenticatedPage: Page;
   clusterDetailsPage: ClusterDetailsPage;
   machinePoolsPage: MachinePoolsPage;
+  networkingPage: NetworkingPage;
   clusterListPage: ClusterListPage;
   clusterRequestsPage: ClusterRequestsPage;
   clusterTypesPage: ClusterTypesPage;
@@ -143,6 +145,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   machinePoolsPage: [
     async ({ authenticatedPage }, use) => {
       const pageObject = new MachinePoolsPage(authenticatedPage);
+      await use(pageObject);
+    },
+    { scope: 'worker' },
+  ],
+
+  // Worker-scoped: NetworkingPage instance - created once, reused across all tests in suite
+  networkingPage: [
+    async ({ authenticatedPage }, use) => {
+      const pageObject = new NetworkingPage(authenticatedPage);
       await use(pageObject);
     },
     { scope: 'worker' },

--- a/playwright/page-objects/create-osd-wizard-page.ts
+++ b/playwright/page-objects/create-osd-wizard-page.ts
@@ -1,4 +1,5 @@
 import { Page, Locator, expect } from '@playwright/test';
+import { DEFAULT_NAVIGATION_TIMEOUT } from '../support/playwright-constants';
 import { BasePage } from './base-page';
 
 /**
@@ -28,7 +29,7 @@ export class CreateOSDWizardPage extends BasePage {
   async isBillingModelScreen(): Promise<void> {
     await expect(
       this.page.getByRole('heading', { name: 'Welcome to Red Hat OpenShift Dedicated' }),
-    ).toBeVisible({ timeout: 60000 });
+    ).toBeVisible({ timeout: 100000 });
   }
 
   async isCuratedBillingModelEnabledAndSelected(): Promise<void> {
@@ -80,8 +81,22 @@ export class CreateOSDWizardPage extends BasePage {
 
   async waitAndClick(buttonLocator: Locator, timeout: number = 160000): Promise<void> {
     await buttonLocator.waitFor({ state: 'visible', timeout });
-    await buttonLocator.click();
+    await buttonLocator.click({ timeout });
   }
+
+  /**
+   * Opens the OSD billing step via direct URL navigation (not the create landing button).
+   * Always reloads so parameterized serial suites sharing one page start from a clean wizard.
+   */
+  async openOsdCreateClusterWizard(): Promise<void> {
+    await this.page.goto('create/osd', {
+      waitUntil: 'domcontentloaded',
+      timeout: DEFAULT_NAVIGATION_TIMEOUT,
+    });
+    await this.closePopoverDialogs();
+    await this.isBillingModelScreen();
+  }
+
   // Machine pool selectors
   computeNodeTypeButton(): Locator {
     return this.page.locator('button[aria-label="Machine type select toggle"]');
@@ -214,7 +229,7 @@ export class CreateOSDWizardPage extends BasePage {
     await this.page.locator('input[placeholder="Filter by name / ID"]').clear();
     await this.page.locator('input[placeholder="Filter by name / ID"]').fill(wifConfig);
     await this.page.getByText(wifConfig).scrollIntoViewIfNeeded();
-    await this.page.getByText(wifConfig).click();
+    await this.page.getByText(wifConfig).click({ force: true });
   }
 
   // AWS credentials
@@ -850,12 +865,169 @@ export class CreateOSDWizardPage extends BasePage {
     return this.page.locator('input[id="form-radiobutton-applicationIngress-custom-field"]');
   }
 
+  async selectApplicationIngressCustomSettings(): Promise<void> {
+    const customSettingsRadio = this.page.getByRole('radio', { name: 'Custom settings' });
+    await customSettingsRadio.scrollIntoViewIfNeeded();
+    await customSettingsRadio.check();
+    await expect(customSettingsRadio).toBeChecked();
+  }
+
+  wizardScrollContainer(): Locator {
+    return this.page.locator('.pf-v6-c-wizard__main, .pf-v6-c-wizard__main-body').first();
+  }
+
+  async scrollWizardContentDown(deltaY = 400): Promise<void> {
+    const container = this.wizardScrollContainer();
+    if (await container.isVisible().catch(() => false)) {
+      await container.hover();
+    } else {
+      await this.page.getByText('Application ingress settings').hover();
+    }
+    await this.page.mouse.wheel(0, deltaY);
+  }
+
+  async ensureExcludeNamespaceSelectorsSectionVisible(): Promise<void> {
+    const section = this.excludeNamespaceSelectorsSection();
+
+    await this.page.getByText('Application ingress settings').scrollIntoViewIfNeeded();
+  }
+
+  async expectApplicationIngressRouteFieldsEmpty(): Promise<void> {
+    await expect(this.applicationIngressRouterSelectorsInput()).toHaveValue('');
+    await expect(this.applicationIngressExcludedNamespacesInput()).toHaveValue('');
+  }
+
+  async expectApplicationIngressEmptyOnReview(): Promise<void> {
+    await expect(this.routeSelectorsReviewValue()).toHaveText('None specified');
+    await expect(this.excludedNamespacesReviewValue()).toHaveText('None specified');
+    await expect(this.excludeNamespaceSelectorsReviewValue()).toHaveText('None specified');
+  }
+
   applicationIngressRouterSelectorsInput(): Locator {
     return this.page.locator('input[name="defaultRouterSelectors"]');
   }
 
   applicationIngressExcludedNamespacesInput(): Locator {
     return this.page.locator('input[name="defaultRouterExcludedNamespacesFlag"]');
+  }
+
+  namespaceOwnershipPolicySwitch(): Locator {
+    return this.page.getByRole('switch', { name: 'Strict' });
+  }
+
+  wildcardPolicySwitch(): Locator {
+    return this.page.getByRole('switch', { name: 'Disallowed' });
+  }
+
+  excludeNamespaceSelectorsSection(): Locator {
+    return this.page.getByTestId('default-ingress-exclude-namespace-selectors');
+  }
+
+  excludeNamespaceSelectorsLabel(): Locator {
+    return this.excludeNamespaceSelectorsSection()
+      .locator('.pf-v6-c-form__group-label')
+      .getByText('Exclude namespace selectors', { exact: true });
+  }
+
+  excludeNamespaceSelectorsLabelHelpIcon(): Locator {
+    return this.excludeNamespaceSelectorsSection().locator('.pf-v6-c-form__group-label-help');
+  }
+
+  excludeNamespaceSelectorKeyInput(rowIndex = 0): Locator {
+    return this.excludeNamespaceSelectorsSection()
+      .getByRole('textbox', { name: 'Exclude namespace selector key' })
+      .nth(rowIndex);
+  }
+
+  excludeNamespaceSelectorValuesInput(rowIndex = 0): Locator {
+    return this.excludeNamespaceSelectorsSection()
+      .getByRole('textbox', { name: 'Exclude namespace selector values' })
+      .nth(rowIndex);
+  }
+
+  excludeNamespaceSelectorsAddRowButton(): Locator {
+    return this.excludeNamespaceSelectorsSection().getByRole('button', { name: 'Add selector' });
+  }
+
+  excludeNamespaceSelectorsReviewValue(): Locator {
+    return this.page.getByTestId('Exclude-namespace-selectors');
+  }
+
+  /**
+   * PatternFly LabelGroup shows at most 3 labels inline; additional labels are behind an "N more"
+   * overflow control. Expands when needed, then asserts each label text is visible on the page.
+   */
+  async expectReviewLabelGroupDisplays(
+    reviewValue: Locator,
+    reviewDisplays: string[],
+  ): Promise<void> {
+    await expect(reviewValue).toBeVisible();
+
+    const overflowButton = reviewValue.getByRole('button', { name: /\d+ more/ });
+    if (await overflowButton.isVisible().catch(() => false)) {
+      await overflowButton.click();
+    }
+
+    for (const reviewDisplay of reviewDisplays) {
+      await expect(this.page.getByText(reviewDisplay, { exact: true })).toBeVisible();
+    }
+  }
+
+  routeSelectorsReviewValue(): Locator {
+    return this.page.getByTestId('Route-selectors');
+  }
+
+  excludedNamespacesReviewValue(): Locator {
+    return this.page.getByTestId('Excluded-namespaces');
+  }
+
+  namespaceOwnershipPolicyReviewValue(): Locator {
+    return this.page.getByTestId('Namespace-ownership-policy');
+  }
+
+  wildcardPolicyReviewValue(): Locator {
+    return this.page.getByTestId('Wildcard-policy');
+  }
+
+  excludeNamespaceSelectorsMoreInfoButton(): Locator {
+    return this.excludeNamespaceSelectorsSection().getByRole('button', {
+      name: 'More information',
+    });
+  }
+
+  async fillExcludeNamespaceSelector(rowIndex: number, key: string, values: string): Promise<void> {
+    await this.excludeNamespaceSelectorKeyInput(rowIndex).fill(key);
+    await this.excludeNamespaceSelectorValuesInput(rowIndex).fill(values);
+  }
+
+  async addExcludeNamespaceSelectorRow(): Promise<void> {
+    await this.excludeNamespaceSelectorsAddRowButton().click();
+  }
+
+  async clearExcludeNamespaceSelectorRow(rowIndex = 0): Promise<void> {
+    await this.excludeNamespaceSelectorKeyInput(rowIndex).clear();
+    await this.excludeNamespaceSelectorValuesInput(rowIndex).clear();
+  }
+
+  async expectExcludeNamespaceSelectorError(errorText: string, present = true): Promise<void> {
+    const locator = this.excludeNamespaceSelectorsSection().getByText(errorText);
+    if (present) {
+      await expect(locator.first()).toBeVisible();
+    } else {
+      await expect(locator).toHaveCount(0);
+    }
+  }
+
+  async expectExcludeNamespaceSelectorErrorContaining(
+    errorText: string,
+    present = true,
+  ): Promise<void> {
+    const locator = this.excludeNamespaceSelectorsSection().getByText(errorText, { exact: false });
+    if (present) {
+      await expect(locator.first()).toBeVisible();
+    } else {
+      await expect(locator).toHaveCount(0);
+    }
   }
 
   // Navigation buttons (if not already present)

--- a/playwright/page-objects/networking-page.ts
+++ b/playwright/page-objects/networking-page.ts
@@ -1,0 +1,112 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+/**
+ * Cluster details Networking tab page object for Playwright tests
+ */
+export class NetworkingPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  networkingTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Networking' });
+  }
+
+  async goToNetworkingTab(): Promise<void> {
+    await this.networkingTab().click();
+    await expect(this.networkingTab()).toHaveAttribute('aria-selected', 'true');
+    await expect(this.page.getByText('CIDR ranges')).toBeVisible({ timeout: 30000 });
+  }
+
+  networkConfigurationCard(): Locator {
+    return this.page
+      .locator('.ocm-c-networking-network-configuration__card')
+      .filter({ hasText: 'CIDR ranges' });
+  }
+
+  vpcDetailsCard(): Locator {
+    return this.page.locator('.ocm-c-networking-vpc-details__card');
+  }
+
+  vpcSubnetsCard(): Locator {
+    return this.page
+      .locator('.ocm-c-networking-network-configuration__card')
+      .filter({ hasText: 'VPC subnets' });
+  }
+
+  applicationIngressCard(): Locator {
+    return this.page.locator('.ocm-c-networking-application-ingress__card');
+  }
+
+  descriptionListValue(container: Locator, term: string): Locator {
+    return container
+      .locator('.pf-v6-c-description-list__group')
+      .filter({ hasText: term })
+      .locator('.pf-v6-c-description-list__description');
+  }
+
+  defaultApplicationRouterInput(): Locator {
+    return this.applicationIngressCard().locator('#default_router_address');
+  }
+
+  routeSelectorDisplayInput(): Locator {
+    return this.applicationIngressCard().locator('#defaultRouterSelectors');
+  }
+
+  excludedNamespacesDisplayInput(): Locator {
+    return this.applicationIngressCard().locator('#defaultRouterExcludedNamespacesFlag');
+  }
+
+  editApplicationIngressButton(): Locator {
+    return this.applicationIngressCard().getByRole('button', { name: 'Edit application ingress' });
+  }
+
+  editApplicationIngressModal(): Locator {
+    return this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', { name: 'Edit application ingress' }),
+    });
+  }
+
+  editModalRouteSelectorInput(): Locator {
+    return this.editApplicationIngressModal().locator('input[name="defaultRouterSelectors"]');
+  }
+
+  editModalExcludedNamespacesInput(): Locator {
+    return this.editApplicationIngressModal().locator(
+      'input[name="defaultRouterExcludedNamespacesFlag"]',
+    );
+  }
+
+  editModalSaveButton(): Locator {
+    return this.editApplicationIngressModal().getByRole('button', { name: 'Save' });
+  }
+
+  editModalCancelButton(): Locator {
+    return this.editApplicationIngressModal().getByRole('button', { name: 'Cancel' });
+  }
+
+  async openEditApplicationIngressModal(): Promise<void> {
+    await this.editApplicationIngressButton().click();
+    await expect(this.editApplicationIngressModal()).toBeVisible({ timeout: 30000 });
+  }
+
+  async closeEditApplicationIngressModal(): Promise<void> {
+    await this.editModalCancelButton().click();
+    await expect(this.editApplicationIngressModal()).not.toBeVisible({ timeout: 30000 });
+  }
+
+  async blurRouteSelectorField(): Promise<void> {
+    await this.editApplicationIngressModal().getByText('Route selector', { exact: true }).click();
+  }
+
+  async expectTextInPage(text: string, present = true): Promise<void> {
+    const locator = this.page.locator('body').filter({ hasText: text });
+    if (present) {
+      await expect(locator).toBeVisible();
+    } else {
+      await expect(locator).not.toBeVisible();
+    }
+  }
+}


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

Adds Playwright E2E coverage for OCMUI GCP Clusters: cluster creation (Day-1 wizard) and cluster networking (Day-2 overview + networking). T

# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-4325](https://redhat.atlassian.net/browse/OCMUI-4325) -->

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

Export the definitions from playwright.env.json

Run Day-1 against dev/ staging to create the cluster and wait for it to be ready:
QE_GCP_WIF_CONFIG=<your wif config> BROWSER=chromium npm run playwright-headless -- \\n  playwright/e2e/osd-gcp/osd-gcp-wif-networking-day1.spec.ts

Run Day-2 against an existing cluster from Day-1:

QE_GCP_WIF_CONFIG=<your wif config> BROWSER=chromium npm run playwright-headless -- \\n  playwright/e2e/osd-gcp/osd-gcp-wif-networking-day2.spec.ts

Similarly, execute the tests and validations for the below spec files

BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/osd-gcp/osd-curated-gcp-wif-cluster-creation.spec.ts


BROWSER=chromium BASE_URL=https://console.dev.redhat.com/openshift/ npm run playwright-headless playwright/e2e/osd-gcp/osd-ccs-gcp-wizard-validation.spec.ts

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-4325]: https://redhat.atlassian.net/browse/OCMUI-4325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ