### PR TITLE
OCMUI-4408:  [PF Dark mode] Installation log viewer: top row has white background

### DIFF
--- a/src/styles/log-window.scss
+++ b/src/styles/log-window.scss
@@ -5,7 +5,7 @@ $font-family-log-window-body: var(--pf-t--global--font--family--mono);
 $log-window-container-min-height: 25em;
 
 .log-window-container {
-  background-color: #fff;
+  background-color: var(--pf-t--global--background--color--primary--default);
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
# Summary

This PR fixes a bug from the log window container's fixed background color to a PatternFly token, so it can adapt to the dark theme.
 
Investigated with Cursor/Auto

# Jira

Fixes [OCMUI-4408](https://issues.redhat.com/browse/OCMUI-4408)


# How to Test

1. Toggle dark mode via toggling on Preview mode (top of page) and then clicking on the master header `Settings` gear, and selecting ‘**Color scheme**’ of ‘**Dark’**.
2. Navigate to a cluster in an installing, uninstalling, or error state (or create a new cluster and observe mid-provisioning)
3. Open the Overview tab — the log viewer renders during these lifecycle phases only
4. Observe the log viewer container

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="2250" height="1151" alt="Screenshot 2026-06-08 at 2 59 53 PM" src="https://github.com/user-attachments/assets/3a48143b-152c-4a23-8614-772016dad41a" /> | <img width="2257" height="1152" alt="Screenshot 2026-06-08 at 3 02 59 PM" src="https://github.com/user-attachments/assets/d691869b-b275-4dad-9903-ed2c9bf3f936" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4408]: https://redhat.atlassian.net/browse/OCMUI-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ