### PR TITLE
OCMUI-4679 - Update Autonode permission

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -492,7 +492,8 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
                 ariaLabel="Edit Autonode settings"
                 disableReason={
                   // Update to !cluster?.canUpdateClusterResource once https://redhat.atlassian.net/browse/ROSAENG-8210 is resolved
-                  (!cluster?.canEdit && 'You do not have permission to edit Autonode settings.') ||
+                  (!cluster?.canUpdateClusterResource &&
+                    'You do not have permission to edit Autonode settings.') ||
                   (!isAutoNodeVersionValid &&
                     `Autonode requires OpenShift version ${AUTO_NODE_MIN_VERSION} or above.`) ||
                   (cluster?.state !== clusterStates.ready &&

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -491,7 +491,6 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
                 data-testid="editAutoNodeButton"
                 ariaLabel="Edit Autonode settings"
                 disableReason={
-                  // Update to !cluster?.canUpdateClusterResource once https://redhat.atlassian.net/browse/ROSAENG-8210 is resolved
                   (!cluster?.canUpdateClusterResource &&
                     'You do not have permission to edit Autonode settings.') ||
                   (!isAutoNodeVersionValid &&

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -1816,7 +1816,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };
@@ -1836,7 +1836,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.21.3',
         },
       };
@@ -1856,7 +1856,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: false,
+          canUpdateClusterResource: false,
           openshift_version: '4.22.0',
         },
       };
@@ -1876,7 +1876,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: undefined,
         },
       };
@@ -1896,7 +1896,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
           state: 'installing',
         },
@@ -1917,7 +1917,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
           state: 'waiting',
         },
@@ -1938,7 +1938,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
           state: 'ready',
         },
@@ -1959,7 +1959,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'disabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0-0.nightly-2026-05-19-113338',
         },
       };
@@ -1982,7 +1982,7 @@ describe('<DetailsRight />', () => {
             mode: 'enabled',
             status: { message: 'AutoNode installation failed' },
           },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };
@@ -2001,7 +2001,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };
@@ -2020,7 +2020,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };
@@ -2042,7 +2042,7 @@ describe('<DetailsRight />', () => {
           ...clusterFixture,
           hypershift: { enabled: true },
           auto_node: { mode: 'disabled' },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };
@@ -2064,7 +2064,7 @@ describe('<DetailsRight />', () => {
           hypershift: { enabled: true },
           auto_node: { mode: 'enabled' },
           aws: { ...clusterFixture.aws, auto_node: { role_arn: '' } },
-          canEdit: true,
+          canUpdateClusterResource: true,
           openshift_version: '4.22.0',
         },
       };


### PR DESCRIPTION
# Summary

This PR fixes a permission issue for the Autonode feature where users with permission cluster.canEdit were allowed to enable Autonode when it should only be users with the permission cluster.canUpdateClusterResource (more details in the JIRA)

# Additional information
Relates to PR https://github.com/RedHatInsights/uhc-portal/pull/536
# Jira

Fixes [OCMUI-4679](https://issues.redhat.com/browse/OCMUI-4679) 



# How to Test
Follow the initial setup testing instructions from PR https://github.com/RedHatInsights/uhc-portal/pull/536

As the permissions are fetched from the backend.. I'm not sure of a realistic way to fully test this.. As a cluster owner or for a cluster where you have the Cluster editor role, you should be able to update the Autonode settings



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4679]: https://redhat.atlassian.net/browse/OCMUI-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ