### PR TITLE
[OCMUI-4677] Fixed failures in the recent smoke test runs

### DIFF
--- a/playwright/e2e/clusters/cluster-types-cloud.spec.ts
+++ b/playwright/e2e/clusters/cluster-types-cloud.spec.ts
@@ -12,30 +12,39 @@ test.describe(
     test('Checks cluster installation types for cloud provider Alibaba Cloud', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/alibaba';
+
       await clusterTypesPage.clickCloudProvider('Alibaba Cloud', true);
-      await clusterTypesPage.isClusterTypesUrl('/install/alibaba');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Alibaba Cloud');
-      await clusterTypesPage.isInteractive(true, true, 'install/alibaba');
+      await clusterTypesPage.isInteractive(true, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('any x86_64 platform', '', true);
     });
 
     test('Checks cluster installation types for cloud provider AWS (x86_64)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/aws';
+
       await clusterTypesPage.clickCloudProvider('AWS (x86_64)');
-      await clusterTypesPage.isClusterTypesUrl('/install/aws');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('AWS');
       await clusterTypesPage.isAutomated('aws', 'AWS', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('aws', 'AWS', '');
     });
 
     test('Checks cluster installation types for cloud provider AWS (ARM)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/aws/arm';
+
       await clusterTypesPage.clickCloudProvider('AWS (ARM)');
-      await clusterTypesPage.isClusterTypesUrl('/install/aws/arm');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('AWS (ARM)');
       await clusterTypesPage.isAutomated('aws', 'AWS', 'ARM');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('aws', 'AWS', 'ARM');
     });
 
@@ -55,10 +64,13 @@ test.describe(
     test('Checks cluster installation types for cloud provider Azure (x86_64)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/azure';
+
       await clusterTypesPage.clickCloudProvider('Azure (x86_64)');
-      await clusterTypesPage.isClusterTypesUrl('/install/azure');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Azure');
       await clusterTypesPage.isAutomated('azure', 'Azure', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('azure', 'Azure', '');
     });
 
@@ -91,10 +103,13 @@ test.describe(
     test('Checks cluster installation types for cloud provider Google Cloud', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/gcp';
+
       await clusterTypesPage.clickCloudProvider('Google Cloud');
-      await clusterTypesPage.isClusterTypesUrl('/install/gcp');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Google Cloud');
       await clusterTypesPage.isAutomated('gcp', 'Google Cloud', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('gcp', 'Google Cloud', '');
     });
 
@@ -141,21 +156,28 @@ test.describe(
     test('Checks cluster installation types for cloud provider Platform Agnostic', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/platform-agnostic';
+
       await clusterTypesPage.clickCloudProvider('Platform agnostic (x86_64)');
-      await clusterTypesPage.isClusterTypesUrl('/install/platform-agnostic');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Platform agnostic (x86_64)');
-      await clusterTypesPage.isInteractive(true, true, 'install/platform-agnostic');
+      await clusterTypesPage.isInteractive(true, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('any x86_64 platform', '', true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('platform-agnostic', 'any x86_64 platform', '', true);
     });
 
     test('Checks cluster installation types for cloud provider Oracle Cloud Infrastructure', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/oracle-cloud';
+
       await clusterTypesPage.clickCloudProvider('Oracle Cloud Infrastructure');
-      await clusterTypesPage.isClusterTypesUrl('/install/oracle-cloud');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Oracle Cloud Infrastructure');
-      await clusterTypesPage.isInteractive(true, true, 'install/oracle-cloud');
+      await clusterTypesPage.isInteractive(true, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('any x86_64 platform', '', true);
     });
   },

--- a/playwright/e2e/clusters/cluster-types-datacenter.spec.ts
+++ b/playwright/e2e/clusters/cluster-types-datacenter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../fixtures/pages';
+import { test } from '../../fixtures/pages';
 
 test.describe(
   'OCP-56051-User interface layout checks for create cluster installation types in Datacenter tab',
@@ -13,111 +13,147 @@ test.describe(
     test('Checks cluster installation types for infrastructure provider Bare Metal (X86_64)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/metal';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Bare Metal (x86_64)');
-      await clusterTypesPage.isClusterTypesUrl('/install/metal');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Bare Metal');
-      await clusterTypesPage.isInteractive(false, true, 'install/metal');
+      await clusterTypesPage.isInteractive(false, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('Bare Metal', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isAutomated('bare_metal', 'Bare Metal', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('bare-metal', 'Bare Metal', '');
     });
 
     test('Checks cluster installation types for infrastructure provider Bare Metal (ARM)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/arm';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Bare Metal (ARM)');
-      await clusterTypesPage.isClusterTypesUrl('/install/arm');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('ARM Bare Metal');
-      await clusterTypesPage.isInteractive(false, true, 'install/arm');
+      await clusterTypesPage.isInteractive(false, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('ARM Bare Metal');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isAutomated('bare_metal', 'ARM Bare Metal');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('bare-metal', 'ARM Bare Metal');
     });
 
     test('Checks cluster installation types for infrastructure provider Azure stack hub', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/azure-stack-hub';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Azure Stack Hub');
-      await clusterTypesPage.isClusterTypesUrl('/install/azure-stack-hub');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Azure Stack Hub');
       await clusterTypesPage.isAutomated('azure_stack_hub', 'Azure Stack Hub', '');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('azure_stack_hub', 'Azure Stack Hub');
     });
 
     test('Checks cluster installation types for infrastructure provider IBM Z (s390x)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/ibmz';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('IBM Z (s390x)');
-      await clusterTypesPage.isClusterTypesUrl('/install/ibmz');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('IBM Z (s390x)');
-      await clusterTypesPage.isInteractive(false, true, 'install/ibmz');
+      await clusterTypesPage.isInteractive(false, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('IBM Z (s390x)');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('ibm-z', 'IBM Z (s390x)');
     });
 
     test('Checks cluster installation types for infrastructure provider IBM Power (ppc64le)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/power';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('IBM Power (ppc64le)');
-      await clusterTypesPage.isClusterTypesUrl('/install/power');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('IBM Power (ppc64le)');
-      await clusterTypesPage.isInteractive(false, true, 'install/power');
+      await clusterTypesPage.isInteractive(false, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('IBM Power (ppc64le)');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('ibm-power', 'IBM Power (ppc64le)');
     });
 
     test('Checks cluster installation types for infrastructure provider Nutanix AOS', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/nutanix';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Nutanix AOS');
-      await clusterTypesPage.isClusterTypesUrl('/install/nutanix');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Nutanix AOS');
-      await clusterTypesPage.isInteractive(false, false, 'install/nutanix');
+      await clusterTypesPage.isInteractive(false, false);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isAutomated('nutanix', 'Nutanix AOS', '', true);
     });
 
     test('Checks cluster installation types for infrastructure provider Red Hat OpenStack', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/openstack';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Red Hat OpenStack');
-      await clusterTypesPage.isClusterTypesUrl('/install/openstack');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('OpenStack');
       await clusterTypesPage.isAutomated(
         'openstack-installer-custom',
         'Red Hat OpenStack Platform',
       );
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('openstack-user', 'Red Hat OpenStack Platform');
     });
 
     test('Checks cluster installation types for infrastructure provider vSphere', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/vsphere';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('vSphere');
-      await clusterTypesPage.isClusterTypesUrl('/install/vsphere');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('VMware vSphere');
-      await clusterTypesPage.isInteractive(false, true, 'install/vsphere');
+      await clusterTypesPage.isInteractive(false, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('vSphere');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isAutomated('vsphere-installer-provisioned', 'vSphere');
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('vsphere', 'vSphere');
     });
 
     test('Checks cluster installation types for infrastructure provider Platform agnostic (x86_64)', async ({
       clusterTypesPage,
     }) => {
+      const installPath = 'install/platform-agnostic';
+
       await clusterTypesPage.clickDatacenter();
       await clusterTypesPage.clickInfrastructureProvider('Platform agnostic (x86_64)');
-      await clusterTypesPage.isClusterTypesUrl('/install/platform-agnostic');
+      await clusterTypesPage.isClusterTypesUrl(`/${installPath}`);
       await clusterTypesPage.isClusterTypesHeader('Platform agnostic (x86_64)');
-      await clusterTypesPage.isInteractive(true, true, 'install/platform-agnostic');
+      await clusterTypesPage.isInteractive(true, true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isLocalAgentBased('any x86_64 platform', '', true);
+      await clusterTypesPage.returnToProvider(installPath);
       await clusterTypesPage.isFullControl('platform-agnostic', 'any x86_64 platform', '', true);
     });
   },

--- a/playwright/page-objects/cluster-types-page.ts
+++ b/playwright/page-objects/cluster-types-page.ts
@@ -92,6 +92,11 @@ export class ClusterTypesPage extends BasePage {
     ).toBeVisible({ timeout: 60000 });
   }
 
+  /** Navigate back to a provider install-type page after a section check navigates away. */
+  async returnToProvider(installPath: string): Promise<void> {
+    await this.goto(installPath);
+  }
+
   async isAutomated(
     clusterType: string,
     clusterHeader: string,
@@ -131,8 +136,6 @@ export class ClusterTypesPage extends BasePage {
     );
     await expect(this.page.locator('h1')).toHaveText(expectedHeaderRegex, { timeout: 30000 });
     await expect(this.page).toHaveURL(new RegExp('installer-provisioned'));
-
-    await this.page.goBack();
   }
 
   async isFullControl(
@@ -186,15 +189,9 @@ export class ClusterTypesPage extends BasePage {
     await expect(this.page.locator('h1')).toHaveText(expectedHeader.trim(), { timeout: 30000 });
 
     await expect(this.page).toHaveURL(new RegExp('user-provisioned'));
-
-    await this.page.goBack();
   }
 
-  async isInteractive(
-    nonTested?: boolean,
-    recommended?: boolean,
-    previousPage?: string,
-  ): Promise<void> {
+  async isInteractive(nonTested?: boolean, recommended?: boolean): Promise<void> {
     await this.interactiveSection.scrollIntoViewIfNeeded();
 
     // Check section elements
@@ -233,12 +230,6 @@ export class ClusterTypesPage extends BasePage {
     await expect(
       this.page.locator('h1').filter({ hasText: 'Install OpenShift with the Assisted Installer' }),
     ).toBeVisible({ timeout: 30000 });
-
-    if (previousPage) {
-      await this.page.goto(previousPage);
-    } else {
-      await this.page.goBack();
-    }
   }
 
   async isLocalAgentBased(
@@ -283,7 +274,5 @@ export class ClusterTypesPage extends BasePage {
     const archText = clusterArch && clusterArch.length > 0 ? `${clusterArch} ` : '';
     const expectedHeader = `Install OpenShift on ${clusterHeader} locally ${archText}with Agent`;
     await expect(this.page.locator('h1')).toHaveText(expectedHeader, { timeout: 30000 });
-
-    await this.page.goBack();
   }
 }


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->

Related job run:  https://github.com/RedHatInsights/uhc-portal/actions/runs/27056772546/job/79862504964

More details about the failure can be found [here](https://github.com/RedHatInsights/uhc-portal/pull/574#issuecomment-4669314916)

**Summary of Findings**
Root cause: WAF blocking (infrastructure, not app bugs)
Daily smoke failures on staging (console.dev.redhat.com) were traced to Akamai/WAF rate limiting, not broken Playwright tests or application regressions.

**Evidence**:

Failure screenshots show raw "Access Denied" HTML, not the app UI
errors.edgesuite.net references and #18.936bdc17.* IDs are Akamai edge denial signatures
Requests were blocked at the CDN before reaching the app
Same commits passed on some days and failed on others; slow runs with retries failed more often
Primary traffic amplifier: cluster-types-* specs
cluster-types-cloud.spec.ts (13 tests) and cluster-types-datacenter.spec.ts (9 tests) were the main contributors to request volume.

**Why**:

Each test navigates to a provider page and runs multiple section checks (isAutomated, isFullControl, isInteractive, isLocalAgentBased)
page.goBack() in the page object triggered full page reloads through the CDN on every return trip
One cluster-types test could produce 8+ full navigations (forward → back → forward → back…)
Rough estimate: 22 tests × ~8 navigations ≈ 176 HTTP round-trips, multiplied by 4 parallel CI workers
goBack() vs navigateTo(): navigateTo() reuses the session and is more predictable; goBack() depends on browser history and still hits the CDN as a new request.

**Work completed/recommended next steps**
Done:

Replaced goBack() with direct navigation in cluster-types flows
Added returnToProvider(installPath) page-object helper to reduce duplicated navigateTo() noise in specs

# Jira


Fixes [OCMUI-4677](https://redhat.atlassian.net/browse/OCMUI-4677)


# How to Test

<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

Export the definitions [playwright.env.json](https://github.com/RedHatInsights/uhc-portal/tree/main/playwright#example-playwrightenvjson-structure) and execute the below commands

```
BROWSER=chromium npm run playwright-headless -- playwright/e2e/clusters/cluster-types-cloud.spec.ts
BROWSER=chromium npm run playwright-headless -- playwright/e2e/clusters/cluster-types-datacenter.spec.ts


```
# Screen Captures

<img width="1117" height="773" alt="Screenshot 2026-06-15 at 2 29 18 PM" src="https://github.com/user-attachments/assets/7fcffc0a-231f-4515-aed7-a827de74b921" />




# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).



[OCMUI-4677]: https://redhat.atlassian.net/browse/OCMUI-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ