### PR TITLE
OCMUI-4580: Fix edit Application Ingress modal refreshes cluster data on Cancel

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import * as reactRedux from 'react-redux';
+
+import modals from '~/components/common/Modal/modals';
+import * as useEditClusterIngressModule from '~/queries/ClusterDetailsQueries/NetworkingTab/useEditClusterIngress';
+import { screen, withState } from '~/testUtils';
+import { LoadBalancerFlavor } from '~/types/clusters_mgmt.v1/enums';
+
+import EditApplicationIngressDialog from './EditApplicationIngressDialog';
+
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-redux'),
+}));
+
+jest.mock('~/hooks/useAnalytics', () => () => jest.fn());
+
+jest.mock(
+  '~/components/clusters/wizards/common/NetworkingSection/DefaultIngressFieldsFormik',
+  () => ({
+    DefaultIngressFieldsFormik: () => {
+      const { setFieldValue } = useFormikContext();
+      return (
+        <button type="button" onClick={() => setFieldValue('private_default_router', true)}>
+          Make dirty
+        </button>
+      );
+    },
+  }),
+);
+
+const mockedUseEditClusterIngressMutation = jest.spyOn(
+  useEditClusterIngressModule,
+  'useEditClusterIngressMutation',
+);
+
+describe('<EditApplicationIngressDialog />', () => {
+  const refreshCluster = jest.fn();
+  const mutate = jest.fn();
+
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const mockedDispatch = jest.fn();
+
+  const defaultReduxState = {
+    modal: { modalName: modals.EDIT_APPLICATION_INGRESS, data: {} },
+  };
+
+  const defaultProps = {
+    refreshCluster,
+    clusterRouters: {
+      default: {
+        isDefault: true,
+        isPrivate: false,
+        isNamespaceOwnershipPolicyStrict: true,
+        isWildcardPolicyAllowed: false,
+        loadBalancer: LoadBalancerFlavor.nlb,
+        address: 'apps.example.com',
+      },
+    },
+    clusterID: 'cluster-123',
+    provider: 'aws',
+  };
+
+  beforeEach(() => {
+    useDispatchMock.mockReturnValue(mockedDispatch);
+    mockedUseEditClusterIngressMutation.mockReturnValue({
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      mutate,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not call refreshCluster when cancelled', async () => {
+    const { user } = withState(defaultReduxState).render(
+      <EditApplicationIngressDialog {...defaultProps} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(refreshCluster).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+    expect(mockedDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'CLOSE_MODAL' }));
+  });
+
+  it('does not call refreshCluster when closed with the X button', async () => {
+    const { user } = withState(defaultReduxState).render(
+      <EditApplicationIngressDialog {...defaultProps} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(refreshCluster).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
+    expect(mockedDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'CLOSE_MODAL' }));
+  });
+
+  it('calls refreshCluster when save succeeds', async () => {
+    mutate.mockImplementation((_data, { onSuccess }) => {
+      onSuccess?.();
+    });
+
+    const { user } = withState(defaultReduxState).render(
+      <EditApplicationIngressDialog {...defaultProps} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Make dirty' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(refreshCluster).toHaveBeenCalledTimes(1);
+    expect(mockedDispatch).toHaveBeenCalledWith(expect.objectContaining({ type: 'CLOSE_MODAL' }));
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/EditApplicationIngressDialog/EditApplicationIngressDialog.tsx
@@ -77,7 +77,6 @@ const EditApplicationIngressDialog: React.FC<EditApplicationIngressDialogProps> 
   ) : null;
 
   const onClose = () => {
-    refreshCluster();
     dispatch(modalActions.closeModal());
   };
 
@@ -131,6 +130,7 @@ const EditApplicationIngressDialog: React.FC<EditApplicationIngressDialogProps> 
                   customProperties: { cluster_creation: false },
                 });
               }
+              refreshCluster();
               onClose();
             },
           },


### PR DESCRIPTION
# Summary

<!-- add a summarized description of the PR content -->
Moving the refreshClusters() out of the onClose and into the onSuccess similar to the edit cluster ingress modal so that when the user cancels, the refresh is no longer called.
<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->
Code reviewed by cursor locally and inspired by the AI output in the jira details.
# Jira

<!-- link to the corresponding Jira item -->
<!-- for example: Fixes [OCMUI-XXXX](https://issues.redhat.com/browse/OCMUI-XXXX) -->
Fixes [OCMUI-4580](https://redhat.atlassian.net/browse/OCMUI-4580)
# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test
Open the network tab and note that when cancelling the edit application ingress modal, there is no cluster refresh taking place vs the network activity seen on prod with the bug in place.
<!-- add any useful information for local testing, like environment or tooling prerequisites,
specially used CLI options, the user-flow, and so on -->

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |
No visual change before and after.
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4580]: https://redhat.atlassian.net/browse/OCMUI-4580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ