### PR TITLE
OCMUI-4567 - Add "Learn more" link to Autonode tooltip

### DIFF
--- a/src/common/docLinks.mjs
+++ b/src/common/docLinks.mjs
@@ -77,6 +77,7 @@ const docLinks = {
   ROSA_AWS_FEDRAMP: `${ROSA_DOCS_BASE}/getting_started_with_red_hat_openshift_service_on_aws_in_aws_govcloud/index`,
   ROSA_HCP_CLI_URL: `${ROSA_DOCS_BASE}/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly`,
   LEARN_MORE_SSO_ROSA: `${ROSA_DOCS_BASE}/cli_tools/rosa-cli#rosa-login-sso_rosa-getting-started-cli`,
+  ROSA_AUTONODE: `${ROSA_DOCS_BASE}-single/cluster_administration/index#rosa-nodes-autonode-managing`,
 
   // OSD
   OSD_DEDICATED_ADMIN_ROLE: `${OSD_DOCS_BASE}/authentication_and_authorization/osd-admin-roles`,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -483,7 +483,12 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
                 id="autonode-hint"
                 iconClassName="nodes-hint"
                 buttonAriaLabel="More information about Autonode"
-                hint="Enables hosted Karpenter to autoscale nodes."
+                hint={
+                  <>
+                    Enables hosted Karpenter to autoscale nodes.{' '}
+                    <ExternalLink href={docLinks.ROSA_AUTONODE}>Learn more</ExternalLink>
+                  </>
+                }
               />
             </DescriptionListTerm>
             <DescriptionListDescription>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -2074,6 +2074,30 @@ describe('<DetailsRight />', () => {
       expect(screen.getByTestId('autoNodeStatus')).toHaveTextContent('Enabled');
       expect(screen.queryByText('arn:')).not.toBeInTheDocument();
     });
+
+    it('renders Autonode doc link in the popover hint', async () => {
+      mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
+      const clusterFixture = defaultProps.cluster;
+      const newProps = {
+        ...defaultProps,
+        cluster: {
+          ...clusterFixture,
+          hypershift: { enabled: true },
+          auto_node: { mode: 'enabled' },
+        },
+      };
+
+      useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+      const { user } = render(<DetailsRight {...newProps} />);
+
+      const moreInfoBtn = await screen.findByRole('button', {
+        name: 'More information about Autonode',
+      });
+      await user.click(moreInfoBtn);
+
+      const link = screen.getByText('Learn more');
+      expect(link).toHaveAttribute('href', docLinks.ROSA_AUTONODE);
+    });
   });
 
   describe('in restricted env', () => {


### PR DESCRIPTION
# Summary

This PR adds a Learn more link for the recently implemented Red Hat build of Karpenter (Autonode) field

# Jira


Fixes [OCMUI-4567](https://issues.redhat.com/browse/OCMUI-4567) 


# How to Test

1. Create a ROSA hcp cluster or navigate to any existing Rosa hcp cluster
2. On the right side of the cluster details find the Red Hat build of Karpenter (Autonode) field
3. Click the ? popover, check that the Learn more link exists and when navigating to it, it opens to the RH docs `Chapter 5. Manage compute nodes using Red Hat build of Karpenter`

# Screen Captures

| Popover with Learn more added                                   |
| --------------------------------------- |
| <img width="690" height="329" alt="Screenshot 2026-06-10 at 2 07 50 PM" src="https://github.com/user-attachments/assets/f337ab32-56fc-4803-889b-3c46af95f22e" /> |


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4567]: https://redhat.atlassian.net/browse/OCMUI-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ