### PR TITLE
OCMUI-4689 : updates on e2e rosa hosted specs to align log forwarding features

### DIFF
--- a/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
+++ b/playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
@@ -160,6 +160,17 @@ test.describe.serial(
       await createRosaWizardPage.rosaNextButton().click();
     });
 
+    test('Step - Additional set up - Control plane log forwarding options', async ({
+      createRosaWizardPage,
+    }) => {
+      await createRosaWizardPage.isLogForwardingScreen();
+      await expect(createRosaWizardPage.amazonS3Heading()).toBeVisible();
+      await expect(createRosaWizardPage.cloudWatchHeading()).toBeVisible();
+      await expect(createRosaWizardPage.amazonS3EnableCheckbox()).not.toBeChecked();
+      await expect(createRosaWizardPage.cloudWatchEnableCheckbox()).not.toBeChecked();
+      await createRosaWizardPage.rosaNextButton().click();
+    });
+
     test('Step - Review and create : Accounts and roles definitions', async ({
       createRosaWizardPage,
     }) => {
@@ -277,6 +288,15 @@ test.describe.serial(
         'OIDC Configuration ID',
         oidcConfigId,
       );
+    });
+
+    test('Step - Review and create : Control plane log forwarding definitions', async ({
+      createRosaWizardPage,
+    }) => {
+      await expect(createRosaWizardPage.logForwardingReviewSection()).toBeVisible();
+      await expect(createRosaWizardPage.logForwardingReviewS3Heading()).toBeVisible();
+      await expect(createRosaWizardPage.logForwardingReviewCloudWatchHeading()).toBeVisible();
+      await expect(createRosaWizardPage.logForwardingReviewConfigurationValues()).toHaveCount(2);
     });
 
     test('Create cluster and check the installation progress', async ({

--- a/playwright/page-objects/create-rosa-wizard-page.ts
+++ b/playwright/page-objects/create-rosa-wizard-page.ts
@@ -1048,6 +1048,48 @@ export class CreateRosaWizardPage extends BasePage {
     });
   }
 
+  // Log forwarding screen selectors
+  logForwardingHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Control plane log forwarding' });
+  }
+
+  amazonS3EnableCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: 'Enable Amazon S3' });
+  }
+
+  cloudWatchEnableCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: 'Enable CloudWatch' });
+  }
+
+  amazonS3Heading(): Locator {
+    return this.page.getByRole('heading', { name: 'Amazon S3' });
+  }
+
+  cloudWatchHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'CloudWatch' });
+  }
+
+  async isLogForwardingScreen(): Promise<void> {
+    await expect(this.logForwardingHeading()).toBeVisible({ timeout: 30000 });
+  }
+
+  // Log forwarding review section selectors
+  logForwardingReviewSection(): Locator {
+    return this.page.getByRole('region', { name: 'Control plane log forwarding' });
+  }
+
+  logForwardingReviewS3Heading(): Locator {
+    return this.logForwardingReviewSection().getByRole('heading', { name: 'Amazon S3' });
+  }
+
+  logForwardingReviewCloudWatchHeading(): Locator {
+    return this.logForwardingReviewSection().getByRole('heading', { name: 'CloudWatch' });
+  }
+
+  logForwardingReviewConfigurationValues(): Locator {
+    return this.logForwardingReviewSection().getByText('Disabled', { exact: true });
+  }
+
   // Additional validation method for compute node range
   computeNodeRangeValue(): Locator {
     return this.page.getByTestId('Compute-node-range').locator('div');


### PR DESCRIPTION
# Summary

Updates on e2e rosa hosted specs to align log forwarding features

# Jira

Fixes [OCMUI-4689](https://issues.redhat.com/browse/OCMUI-4689)

# Additional information

The changes introduced by this feature in the [PR](https://github.com/RedHatInsights/uhc-portal/pull/454) have caused failures in the existing ROSA Hosted Wizard specs that run as part of the daily smoke tests. This PR updates the affected spec definitions to align with the new behavior and prevent those failures.

Out of scope :  
E2e  test case coverage for the feature and  the same task will be covered in dedicated story [OCMUI-3880](https://redhat.atlassian.net/browse/OCMUI-3880)


# How to Test
Pre-condition

1. Create ROSA hosted account roles with prefix : cypress-account-roles
2. Create a VPC in us-west-2 region with 3 public and private subnets.
3. Create AWS KMS key or Use existing one from here : https://us-west-2.console.aws.amazon.com/kms/home?region=us-west-2#/kms/keys
4. Open a terminal and Download feature code from PR
5. Start the local server

Steps
1. Open another terminal
2. Download current PR
3. Create playwright.env.json file and populate inline user, VPC definitions and keep it in repo root folder.
```
  "TEST_WITHQUOTA_USER": "your username",
  "TEST_WITHQUOTA_PASSWORD": "your password",
  "QE_AWS_ID": "your aws id",
  "QE_AWS_REGION" : "us-west-2"
  "QE_AWS_BILLING_ID": "your aws billing id",
  "QE_OIDC_CONFIG_ID" : "your oidc config id",
  "QE_AWS_KMS_KEY" : "your kms key arn", 
  "QE_ACCOUNT_ROLE_PREFIX": "cypress-account-roles",
  "QE_INFRA_REGIONS": {
    "us-west-2": [
      {
        "VPC-ID": "vpc-0be37398ae6399822",
        "VPC_NAME": "vpc name",
        "SUBNETS": {
          "ZONES": {
            "us-west-2a": {
              "PUBLIC_SUBNET_NAME": "your public-subnet-1 name",
              "PUBLIC_SUBNET_ID": "your public-subnet-1 id",
              "PRIVATE_SUBNET_NAME": "your private-subnet-1 name",
              "PRIVATE_SUBNET_ID": "your private-subnet-1 id"
            },
            "us-west-2b": {
              "PUBLIC_SUBNET_NAME": "your public-subnet-2 name",
              "PUBLIC_SUBNET_ID": "your public-subnet-2 id,
              "PRIVATE_SUBNET_NAME": "your private-subnet-2 name",
              "PRIVATE_SUBNET_ID": "your private-subnet-2 id"
            },
            "us-west-2c": {
              "PUBLIC_SUBNET_NAME": "your public-subnet-3 name",
              "PUBLIC_SUBNET_ID": "your public-subnet-3 id",
              "PRIVATE_SUBNET_NAME": "your private-subnet-2 name",
              "PRIVATE_SUBNET_ID": "your private-subnet-3 id"
            }
          }
        }
      }
    ]
  }
```
4. Run the following test against the local server(feature branch)
```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npm run playwright-headless -- playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
```

# Screen Captures

```
BROWSER=chromium BASE_URL=https://prod.foo.redhat.com:1337/openshift/ npx playwright test playwright/e2e/rosa-hosted/rosa-cluster-hosted-creation.spec.ts
🔍 Base URL from config: https://prod.foo.redhat.com:1337/openshift/
🔒 Ignore HTTPS errors: true
🔐 Starting GLOBAL authentication setup (ONCE for all tests)...
🍪 Set session cookies to disable cookie consent dialog
🌐 Navigating to: https://prod.foo.redhat.com:1337/openshift/
🔑 Starting login process for user: ****
🔐 Login page detected, proceeding with authentication...
✅ Username entered
✅ Password entered
✅ Authentication completed, redirected to console
✅ Verified console page navigation for non-GOV_CLOUD environment
✅ GLOBAL authentication state saved - will be reused by ALL tests

Running 18 tests using 1 worker
…osa-hosted/rosa-cluster-hosted-creation.spec.ts:49:9 › Rosa hosted cluster (hypershift) - wizard checks and cluster creation tests (OCP-57641) › Step - Accounts and roles - Select Account roles, ARN definitions @smoke @rosa-hosted @rosa
  18 passed (1.3m)

To open last HTML report run:

  npx playwright show-report playwright-artifacts/reports
  
```
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).




[OCMUI-4689]: https://redhat.atlassian.net/browse/OCMUI-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCMUI-3880]: https://redhat.atlassian.net/browse/OCMUI-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ