### PR TITLE
OCMUI-4690: Update file extensions

### DIFF
--- a/src/common/installLinks.mjs
+++ b/src/common/installLinks.mjs
@@ -352,8 +352,8 @@ const urls = {
   [tools.OCM]: {
     [channels.STABLE]: {
       [architectures.x86]: {
-        [operatingSystems.linux]: `${links.OCM_CLI_RELEASES_LATEST}/ocm_linux_amd64.zip`,
-        [operatingSystems.mac]: `${links.OCM_CLI_RELEASES_LATEST}/ocm_darwin_amd64.zip`,
+        [operatingSystems.linux]: `${links.OCM_CLI_RELEASES_LATEST}/ocm_linux_amd64.tar.gz`,
+        [operatingSystems.mac]: `${links.OCM_CLI_RELEASES_LATEST}/ocm_darwin_amd64.tar.gz`,
         [operatingSystems.windows]: `${links.OCM_CLI_RELEASES_LATEST}/ocm_windows_amd64.zip`,
       },
     },


### PR DESCRIPTION
# Summary

This PR fixes broken links. The changes fixes the file extensions for OCM CLI MacOS and Linux downloads to match what's in https://developers.redhat.com/content-gateway/rest/browse/pub/cgw/ocm/latest.

# Jira

Fixes [OCMUI-4690](https://issues.redhat.com/browse/OCMUI-4690)

# How to Test

1. Go to https://console.redhat.com/openshift/downloads or https://console.dev.redhat.com/openshift/downloads
2. Click on the download button for OCM CLI with OS type MacOS and Linux
  a. Verify the links are broken
3. Pull down this PR and follow steps 1 and 2 on the local environment
  a. Verify the links are fixed


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4690]: https://redhat.atlassian.net/browse/OCMUI-4690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ