### PR TITLE
OCMUI-4592: fix and move broken OCM doc links

### DIFF
--- a/playwright/e2e/subscriptions/subscriptions.spec.ts
+++ b/playwright/e2e/subscriptions/subscriptions.spec.ts
@@ -161,7 +161,7 @@ test.describe.serial('Subscription page (OCP-25171)', { tag: ['@smoke'] }, () =>
     const learnMoreLink = subscriptionsPage.learnMoreLink();
     await expect(learnMoreLink).toHaveAttribute(
       'href',
-      /https:\/\/access\.redhat\.com\/documentation\/en-us\/openshift_cluster_manager\/2023\/html\/managing_clusters\/assembly-cluster-subscriptions/,
+      /https:\/\/docs\.redhat\.com\/en\/documentation\/openshift_cluster_manager\/1-latest\/html\/managing_clusters\/assembly-cluster-subscriptions_assembly-cluster-subscriptions/,
     );
   });
 });

--- a/src/common/docLinks.mjs
+++ b/src/common/docLinks.mjs
@@ -182,7 +182,7 @@ const docLinks = {
   // OCM
   OCM_DOCS_PULL_SECRETS: `${OCM_DOCS_BASE}/assembly-managing-clusters_assembly-cluster-subscriptions#managing-pull-secrets-intro_assembly-managing-clusters`,
   OCM_DOCS_SUBSCRIPTIONS: `${OCM_DOCS_BASE}/assembly-cluster-subscriptions_assembly-cluster-subscriptions`,
-  OCM_DOCS_UPGRADING_OSD_TRIAL: `${OSD_DOCS_BASE}/upgrading/osd-upgrades`,
+  OCM_DOCS_UPGRADING_OSD_TRIAL: `${OCM_DOCS_BASE}/assembly-cluster-subscriptions_assembly-cluster-subscriptions#upgrading-osd-trial-cluster_assembly-cluster-subscriptions`,
 
   // Telemetry
   TELEMETRY_INFORMATION: `${OCP_DOCS_BASE}/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring`,

--- a/src/common/docLinks.mjs
+++ b/src/common/docLinks.mjs
@@ -13,6 +13,8 @@ const OSD_DOCS_BASE = 'https://docs.redhat.com/en/documentation/openshift_dedica
 const ROSA_DOCS_BASE =
   'https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html';
 const RH_BASE = 'https://www.redhat.com/en';
+const OCM_DOCS_BASE =
+  'https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters';
 const COSTMGMT_DOCS_BASE =
   'https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html';
 
@@ -176,6 +178,15 @@ const docLinks = {
   RH_ROSA_LEARN: `${RH_BASE}/technologies/cloud-computing/openshift/aws/learn`,
   RH_ROSA_INSTALL: `${RH_BASE}/products/interactive-walkthrough/install-rosa`,
   RH_ROSA_LIGHTBOARD: `${RH_BASE}/about/videos/rosa-lightboard`,
+
+  // OCM
+  OCM_DOCS_PULL_SECRETS: `${OCM_DOCS_BASE}/assembly-managing-clusters_assembly-cluster-subscriptions#managing-pull-secrets-intro_assembly-managing-clusters`,
+  OCM_DOCS_SUBSCRIPTIONS: `${OCM_DOCS_BASE}/assembly-cluster-subscriptions_assembly-cluster-subscriptions`,
+  OCM_DOCS_UPGRADING_OSD_TRIAL: `${OSD_DOCS_BASE}/upgrading/osd-upgrades`,
+
+  // Telemetry
+  TELEMETRY_INFORMATION: `${OCP_DOCS_BASE}/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring`,
+  REMOTE_HEALTH_INSIGHTS: `${OCP_DOCS_BASE}/support/remote-health-monitoring-with-connected-clusters#insights-operator-advisor-overview_using-insights-to-identify-issues-with-your-cluster`,
 
   // Misc
   LEARN_MORE_SSO:

--- a/src/common/supportLinks.mjs
+++ b/src/common/supportLinks.mjs
@@ -13,9 +13,6 @@ const SOLUTIONS_URL = `${BASE_URL}solutions/`;
 const SECURITY_URL = `${BASE_URL}security/`;
 const DOCUMENTATION_URL = `${BASE_URL}documentation/`;
 const ROSA_CP_DOCS_BASE = `${BASE_URL}documentation/en-us/red_hat_openshift_service_on_aws/4/html`;
-const OCM_DOCS_BASE = `${BASE_URL}documentation/en-us/openshift_cluster_manager/2023`;
-const OCP_DOCS_BASE =
-  'https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html';
 
 const supportLinks = {
   // Support Case Management
@@ -51,12 +48,6 @@ const supportLinks = {
   ROSA_CLI_DOCS: `${ROSA_CP_DOCS_BASE}/rosa_cli/rosa-get-started-cli`,
   ROSA_HCP_EXT_AUTH: `${ROSA_CP_DOCS_BASE}/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-ext-auth`,
   ROSA_HCP_BREAK_GLASS: `${ROSA_CP_DOCS_BASE}/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-ext-auth#rosa-hcp-sts-accessing-a-break-glass-cred-cli_rosa-hcp-sts-creating-a-cluster-ext-auth`,
-  OCM_DOCS_PULL_SECRETS: `${OCM_DOCS_BASE}/html/managing_clusters/assembly-managing-clusters#downloading_and_updating_pull_secrets`,
-  OCM_DOCS_ROLES_AND_ACCESS: `${OCM_DOCS_BASE}/html/managing_clusters/assembly-user-management-ocm`,
-  OCM_DOCS_SUBSCRIPTIONS: `${OCM_DOCS_BASE}/html/managing_clusters/assembly-cluster-subscriptions`,
-  OCM_DOCS_UPGRADING_OSD_TRIAL: `${OCM_DOCS_BASE}/html/managing_clusters/assembly-cluster-subscriptions#upgrading-osd-trial-cluster_assembly-cluster-subscriptions`,
-  TELEMETRY_INFORMATION: `${OCP_DOCS_BASE}/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring`,
-  REMOTE_HEALTH_INSIGHTS: `${OCP_DOCS_BASE}/support/remote-health-monitoring-with-connected-clusters#insights-operator-advisor-overview_using-insights-to-identify-issues-with-your-cluster`,
 
   // Support Offerings
   INSTALL_PRE_RELEASE_SUPPORT_KCS: `${SUPPORT_URL}offerings/devpreview`,

--- a/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsFields/components/BillingModelAlert.tsx
+++ b/src/components/clusters/common/EditSubscriptionSettingsDialog/EditSubscriptionSettingsFields/components/BillingModelAlert.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Alert, Icon } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
-import supportLinks from '~/common/supportLinks.mjs';
+import docLinks from '~/common/docLinks.mjs';
 
 type BillingModelAlertProps = {
   title: string;
@@ -16,7 +16,7 @@ const BillingModelAlert = ({ title }: BillingModelAlertProps) => (
     isInline
     title={title}
   >
-    <a href={supportLinks.OCM_DOCS_SUBSCRIPTIONS} target="_blank" rel="noreferrer noopener">
+    <a href={docLinks.OCM_DOCS_SUBSCRIPTIONS} target="_blank" rel="noreferrer noopener">
       Learn more about subscriptions{' '}
       <Icon size="sm" isInline>
         <ExternalLinkAltIcon />

--- a/src/components/clusters/install/instructions/components/TelemetryDisclaimer.jsx
+++ b/src/components/clusters/install/instructions/components/TelemetryDisclaimer.jsx
@@ -4,13 +4,13 @@ import { Content } from '@patternfly/react-core';
 
 import ExternalLink from '~/components/common/ExternalLink';
 
-import supportLinks from '../../../../../common/supportLinks.mjs';
+import docLinks from '../../../../../common/docLinks.mjs';
 
 const TelemetryDisclaimer = () => (
   <Content component="small">
     Red Hat collects a limited amount of telemetry data. By installing OpenShift Container Platform
     4, you accept our data collection policy.{' '}
-    <ExternalLink href={supportLinks.TELEMETRY_INFORMATION} noIcon>
+    <ExternalLink href={docLinks.TELEMETRY_INFORMATION} noIcon>
       Learn more
     </ExternalLink>{' '}
     about the data we collect.

--- a/src/components/dashboard/InsightsAdvisorCard/AdvisorEmptyState.jsx
+++ b/src/components/dashboard/InsightsAdvisorCard/AdvisorEmptyState.jsx
@@ -6,7 +6,7 @@ import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { PLATFORM_LIGHTSPEED_REBRAND } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 
-import supportLinks from '../../../common/supportLinks.mjs';
+import docLinks from '../../../common/docLinks.mjs';
 import ExternalLink from '../../common/ExternalLink';
 
 const AdvisorEmptyState = () => {
@@ -24,10 +24,7 @@ const AdvisorEmptyState = () => {
         This feature uses the Remote Health functionality of OpenShift Container Platform. For
         further details about Red Hat {allowPlatformLightspeedRebrand ? 'Lightspeed' : 'Insights'},
         see the{' '}
-        <ExternalLink href={supportLinks.REMOTE_HEALTH_INSIGHTS}>
-          OpenShift documentation
-        </ExternalLink>
-        .
+        <ExternalLink href={docLinks.REMOTE_HEALTH_INSIGHTS}>OpenShift documentation</ExternalLink>.
       </EmptyStateBody>
     </EmptyState>
   );

--- a/src/components/dashboard/InsightsAdvisorCard/AdvisorEmptyState.test.jsx
+++ b/src/components/dashboard/InsightsAdvisorCard/AdvisorEmptyState.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PLATFORM_LIGHTSPEED_REBRAND } from '~/queries/featureGates/featureConstants';
 import { checkAccessibility, mockUseFeatureGate, render, screen } from '~/testUtils';
 
-import supportLinks from '../../../common/supportLinks.mjs';
+import docLinks from '../../../common/docLinks.mjs';
 
 import AdvisorEmptyState from './AdvisorEmptyState';
 
@@ -13,7 +13,7 @@ describe('<AdvisorEmptyState />', () => {
 
     expect(screen.getByText('OpenShift documentation')).toHaveAttribute(
       'href',
-      supportLinks.REMOTE_HEALTH_INSIGHTS,
+      docLinks.REMOTE_HEALTH_INSIGHTS,
     );
   });
 

--- a/src/components/dashboard/InsightsAdvisorCard/InfoPopover.test.tsx
+++ b/src/components/dashboard/InsightsAdvisorCard/InfoPopover.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PLATFORM_LIGHTSPEED_REBRAND } from '~/queries/featureGates/featureConstants';
 import { checkAccessibility, mockUseFeatureGate, render, screen } from '~/testUtils';
 
-import supportLinks from '../../../common/supportLinks.mjs';
+import docLinks from '../../../common/docLinks.mjs';
 
 import InfoPopover from './InfoPopover';
 
@@ -21,7 +21,7 @@ describe('<InfoPopover />', () => {
     // Assert
     expect(screen.getByText('OpenShift documentation')).toHaveAttribute(
       'href',
-      supportLinks.REMOTE_HEALTH_INSIGHTS,
+      docLinks.REMOTE_HEALTH_INSIGHTS,
     );
   });
 

--- a/src/components/dashboard/InsightsAdvisorCard/InfoPopover.tsx
+++ b/src/components/dashboard/InsightsAdvisorCard/InfoPopover.tsx
@@ -6,7 +6,7 @@ import { HelpIcon } from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { PLATFORM_LIGHTSPEED_REBRAND } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 
-import supportLinks from '../../../common/supportLinks.mjs';
+import docLinks from '../../../common/docLinks.mjs';
 import ExternalLink from '../../common/ExternalLink';
 
 const InfoPopover = () => {
@@ -30,7 +30,7 @@ const InfoPopover = () => {
           <p>{informationText[0]}</p>
           <p>
             {informationText[1]}
-            <ExternalLink href={supportLinks.REMOTE_HEALTH_INSIGHTS}>
+            <ExternalLink href={docLinks.REMOTE_HEALTH_INSIGHTS}>
               OpenShift documentation
             </ExternalLink>
           </p>

--- a/src/components/downloads/DownloadsPage/components/rows/TokenRows.tsx
+++ b/src/components/downloads/DownloadsPage/components/rows/TokenRows.tsx
@@ -9,7 +9,7 @@ import { Link } from '~/common/routing';
 import { AccessTokenCfg } from '~/types/accounts_mgmt.v1';
 import { ErrorState } from '~/types/types';
 
-import supportLinks from '../../../../../common/supportLinks.mjs';
+import docLinks from '../../../../../common/docLinks.mjs';
 import AlignRight from '../../../../common/AlignRight';
 import ExternalLink from '../../../../common/ExternalLink';
 import CopyPullSecret from '../../../CopyPullSecret';
@@ -58,7 +58,7 @@ const PullSecretRow = ({ expanded, setExpanded, toolRefs, token }: PullSecretRow
         </Content>
         <Content component="p">
           Learn how to <Link to="/create">create a cluster</Link> or{' '}
-          <ExternalLink href={supportLinks.OCM_DOCS_PULL_SECRETS}>
+          <ExternalLink href={docLinks.OCM_DOCS_PULL_SECRETS}>
             learn more about pull secrets
           </ExternalLink>
           .

--- a/src/components/quota/SubscriptionNotFulfilled.tsx
+++ b/src/components/quota/SubscriptionNotFulfilled.tsx
@@ -12,7 +12,7 @@ import {
 import { Link } from '~/common/routing';
 
 import { BANNED_USER_CODE, overrideErrorMessage } from '../../common/errors';
-import supportLinks from '../../common/supportLinks.mjs';
+import docLinks from '../../common/docLinks.mjs';
 import ExternalLink from '../common/ExternalLink';
 
 type Props = {
@@ -125,7 +125,7 @@ const SubscriptionNotFulfilled = ({ data, refresh, marketplace }: Props) => {
             </Button>
           </p>
           <br />
-          <ExternalLink href={supportLinks.OCM_DOCS_SUBSCRIPTIONS}>Learn more</ExternalLink>
+          <ExternalLink href={docLinks.OCM_DOCS_SUBSCRIPTIONS}>Learn more</ExternalLink>
         </div>
       ),
       emptyButton: undefined,

--- a/src/components/quota/SubscriptionNotFulfilled.tsx
+++ b/src/components/quota/SubscriptionNotFulfilled.tsx
@@ -11,8 +11,8 @@ import {
 
 import { Link } from '~/common/routing';
 
-import { BANNED_USER_CODE, overrideErrorMessage } from '../../common/errors';
 import docLinks from '../../common/docLinks.mjs';
+import { BANNED_USER_CODE, overrideErrorMessage } from '../../common/errors';
 import ExternalLink from '../common/ExternalLink';
 
 type Props = {


### PR DESCRIPTION
# Summary

As part of the continued migration off of `access.redhat.com` to `docs.redhat.com`, this PR updates three broken OCM documentation links that were returning 404 via a 301 redirect chain (`access.redhat.com` → `docs.redhat.com` → 404).

The corrected URLs were provided by the HCCDOC docs team in [HCCDOC-5174](https://redhat.atlassian.net/browse/HCCDOC-5174). Since these links now point to `docs.redhat.com`, they are moved from `supportLinks.mjs` (which holds `access.redhat.com` URLs) to `docLinks.mjs` (which holds `docs.redhat.com` URLs). Two additional `docs.redhat.com` constants (`TELEMETRY_INFORMATION`, `REMOTE_HEALTH_INSIGHTS`) that were already in `supportLinks.mjs` are moved to `docLinks.mjs` for consistency.

Assisted by: Cursor/claude-4.6-opus

# Jira

Fixes [OCMUI-4592](https://redhat.atlassian.net/browse/OCMUI-4592)

# Additional information

- `OCM_DOCS_ROLES_AND_ACCESS` was also a broken link but is not rendered in any UI component (only referenced in TODO comments). It was removed from `supportLinks.mjs`; the TODO comments are preserved so it can be re-added to `docLinks.mjs` with a corrected URL when the OCM RBAC feature is implemented.

# How to Test

**Link 1 — Pull secrets:**
1. Navigate to https://prod.foo.redhat.com:1337/openshift/downloads
2. Scroll to the Tokens section and expand the "Pull secret" row
3. Click "learn more about pull secrets"
4. Verify the documentation page loads successfully

**Link 2 — Subscriptions:**

The "Learn more" link appears in the marketplace empty state on the quota page. This state requires an account with no OSD marketplace subscriptions. The link uses the same `docLinks.OCM_DOCS_SUBSCRIPTIONS` constant as Link 3.

To verify:
1. Open the external URL directly: https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-cluster-subscriptions_assembly-cluster-subscriptions
2. Verify the documentation page loads successfully.

The same URL is also used in the "Edit Subscription Settings" dialog (`BillingModelAlert.tsx`) which is only available on self-managed OCP clusters.

**Link 3 — Upgrading OSD trial:**
1. On a trial OSD cluster details page, click "Upgrade from trial" in the expiration alert or cluster actions menu
2. In the dialog, click "Learn more"
3. Verify the documentation page loads successfully

Alternatively, verify the direct URL: https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-cluster-subscriptions_assembly-cluster-subscriptions#upgrading-osd-trial-cluster_assembly-cluster-subscriptions

**Link 4 — Telemetry disclaimer:**
1. Navigate to https://prod.foo.redhat.com:1337/openshift/install/aws/multi/installer-provisioned
2. In the install instructions, find the telemetry disclaimer: "Red Hat collects a limited amount of telemetry data..."
4. Click "Learn more" and verify the documentation page loads successfully

**Link 5 — Insights Advisor:**
1. Navigate to https://prod.foo.redhat.com:1337/openshift/dashboard
2. Find the "Advisor recommendations by severity" card
3. Click the info (i) icon next to the card title
4. In the popover, click "OpenShift documentation"
5. Verify the documentation page loads successfully

**E2E Playwright test:**

The `subscriptions.spec.ts` E2E test has been updated to assert the new `docs.redhat.com` URL. To run:

    npx playwright test playwright/e2e/subscriptions/subscriptions.spec.ts

Ensure `BASE_URL` in `playwright.env.json` points to your local dev server (e.g. `https://prod.foo.redhat.com:1337/openshift/`).

**Corrected URLs:**
- https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters_assembly-cluster-subscriptions#managing-pull-secrets-intro_assembly-managing-clusters
- https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-cluster-subscriptions_assembly-cluster-subscriptions
- https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-cluster-subscriptions_assembly-cluster-subscriptions#upgrading-osd-trial-cluster_assembly-cluster-subscriptions

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation

[HCCDOC-5174]: https://redhat.atlassian.net/browse/HCCDOC-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCMUI-4592]: https://redhat.atlassian.net/browse/OCMUI-4592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
