### PR TITLE
OCMUI-4410: Fix dark mode for update version graph

### DIFF
--- a/src/components/clusters/common/Upgrades/UpdateGraph/UpdateGraph.scss
+++ b/src/components/clusters/common/Upgrades/UpdateGraph/UpdateGraph.scss
@@ -43,7 +43,6 @@
   &:last-child::after {
     background: transparent;
     border: 8px solid transparent;
-    border-left-color: var(--pf-t--global--border--color--default);
     border-width: 8px 12px;
     content: '';
     position: absolute;
@@ -53,7 +52,7 @@
 }
 
 .ocm-upgrade-graph-version {
-  color: var(--pf-t--global--text--color--regular);
+  color: inherit;
   display: flex;
   flex-direction: column;
   height: 35px;

--- a/src/components/clusters/common/Upgrades/UpdateGraph/UpdateGraph.scss
+++ b/src/components/clusters/common/Upgrades/UpdateGraph/UpdateGraph.scss
@@ -33,7 +33,7 @@
   width: 100%;
 
   &::before {
-    background-color: #06c;
+    background-color: var(--pf-t--global--color--brand--default);
     content: '';
     height: 4px;
     position: absolute;
@@ -53,7 +53,7 @@
 }
 
 .ocm-upgrade-graph-version {
-  color: initial;
+  color: var(--pf-t--global--text--color--regular);
   display: flex;
   flex-direction: column;
   height: 35px;
@@ -79,8 +79,8 @@
   }
 
   &::after {
-    background: #fff;
-    border: 2px solid #fff;
+    background: var(--pf-t--global--background--color--primary--default);
+    border: 2px solid var(--pf-t--global--background--color--primary--default);
     border-radius: 12px;
     content: '';
     height: 12px;


### PR DESCRIPTION
# Summary

Replace hardcoded colors in the upgrade path graph with patternfly tokens so version labels, connector line, and dot rings adapt correctly in dark mode.

# Jira

Fixes [OCMUI-4410](https://redhat.atlassian.net/browse/OCMUI-4410)

# How to Test

1. Toggle dark mode via toggling on Preview mode (top of page) and then clicking on the masthead Settings gear, and selecting ‘Color scheme’ of ‘Dark’.
2. Navigate to any ROSA Classic, ROSA HCP, or OSD cluster with available version upgrades in a Ready state
3. Open the Settings tab
4. Scroll to the upgrade path visualization (horizontal dot-and-line graph)
5. Make sure version numbers are readable in dark mode. Connector line and dot rings use PF tokens that adapt to the current theme.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="415" height="335" alt="image" src="https://github.com/user-attachments/assets/3757974a-950b-4f11-a4cc-5f43fee37493" /> | <img width="415" height="335" alt="image" src="https://github.com/user-attachments/assets/037d54de-097e-4a60-9490-16412d3fd107" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4410]: https://redhat.atlassian.net/browse/OCMUI-4410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ