### PR TITLE
OCMUI-4556: Hide PrivateLink field in network tab for hcp clusters

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.jsx
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core';
 
 import { stringToArray } from '~/common/helpers';
-import { isHibernating } from '~/components/clusters/common/clusterStates';
+import { isHibernating, isHypershiftCluster } from '~/components/clusters/common/clusterStates';
 import { CloudProviderType } from '~/components/clusters/wizards/common';
 import ButtonWithTooltip from '~/components/common/ButtonWithTooltip';
 import { modalActions } from '~/components/common/Modal/ModalActions';
@@ -58,6 +58,7 @@ const VPCDetailsCard = ({ cluster }) => {
   const region = cluster.subscription?.rh_region_id;
 
   const isPrivateLinkInitialized = typeof privateLink !== 'undefined';
+  const showPrivateLink = isPrivateLinkInitialized && !isHypershiftCluster(cluster);
   const isGcpDnsZoneEnabled = useFeatureGate(GCP_DNS_ZONE);
 
   const { data: dnsZone } = useFetchGcpDnsZone(cluster.dns?.base_domain, isGCP);
@@ -95,7 +96,7 @@ const VPCDetailsCard = ({ cluster }) => {
         </Title>
       </CardTitle>
       <CardBody className="ocm-c-networking-vpc-details__card--body pf-v6-l-stack pf-m-gutter">
-        {gcpVPCName || isPrivateLinkInitialized || gcpPrivateServiceConnect ? (
+        {gcpVPCName || showPrivateLink || gcpPrivateServiceConnect ? (
           <>
             <Title headingLevel="h3" className="pf-v6-l-stack__item">
               VPC Details
@@ -110,7 +111,7 @@ const VPCDetailsCard = ({ cluster }) => {
                   <DescriptionListDescription>{gcpVPCName}</DescriptionListDescription>
                 </DescriptionListGroup>
               ) : null}
-              {isPrivateLinkInitialized ? (
+              {showPrivateLink ? (
                 <DescriptionListGroup>
                   <DescriptionListTerm>PrivateLink</DescriptionListTerm>
                   <DescriptionListDescription>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Networking/components/VPCDetailsCard/VPCDetailsCard.test.tsx
@@ -63,6 +63,44 @@ describe('<VPCDetailsCard />', () => {
     });
   });
 
+  describe('PrivateLink', () => {
+    it.each([
+      ['Enabled', true],
+      ['Disabled', false],
+    ])('renders PrivateLink as %s for classic ROSA clusters', (label, privateLink) => {
+      render(
+        <VPCDetailsCard
+          cluster={{
+            aws: {
+              subnet_ids: ['subnet-05281fa2678b6d8cd'],
+              private_link: privateLink,
+            },
+            hypershift: { enabled: false },
+          }}
+        />,
+      );
+
+      expect(screen.getByText('PrivateLink')).toBeInTheDocument();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    });
+
+    it('does not render PrivateLink for HCP clusters', () => {
+      render(
+        <VPCDetailsCard
+          cluster={{
+            aws: {
+              subnet_ids: ['subnet-05281fa2678b6d8cd'],
+              private_link: false,
+            },
+            hypershift: { enabled: true },
+          }}
+        />,
+      );
+
+      expect(screen.queryByText('PrivateLink')).not.toBeInTheDocument();
+    });
+  });
+
   describe('When Private Service Connect Subnet is provided', () => {
     const props = {
       cluster: {


### PR DESCRIPTION
# Summary

This PR hides the PrivateLink field on the cluster details Networking tab for ROSA HCP clusters.
ROSA HCP uses PrivateLink as an integrated component. PrivateLink is not visible to the customers when creating a ROSA HCP cluster, so this should not be in the UI for ROSA HCP.  
On the other hand, in the Classic wizard, choosing 'Private' for Cluster privacy auto selects PrivateLink (visible to the user) and opens the VPC settings step, so the PrivateLink field in the Networking tab remains.

Assisted by: Cursor/Auto

# Jira

Fixes [OCMUI-4556](https://redhat.atlassian.net/browse/OCMUI-4556)

# How to Test

1. Create (or use existing ones) HCP and Classic clusters with Cluster Privacy - 'Private'
2. Go to cluster details -> Networking tab
3. HCP - the VPC card should not have PrivateLink field
4. Classic -  the VPC card should have PrivateLink field

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="495" height="434" alt="image" src="https://github.com/user-attachments/assets/aeec295f-9960-4851-8fc1-b13a094f0df2" />| <img width="531" height="391" alt="image" src="https://github.com/user-attachments/assets/d6430d26-cca2-4b02-8a70-b52f619914cb" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4556]: https://redhat.atlassian.net/browse/OCMUI-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ