### PR TITLE
OCMUI-4342: Showing Control Plane Log Forwarding info

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/ClusterDetails.jsx
@@ -607,6 +607,7 @@ const ClusterDetails = (props) => {
                 userAccess={userAccess}
                 canSubscribeOCP={canSubscribeOCP}
                 isSubscriptionSettingsRequestPending={isSubscriptionSettingsRequestPending}
+                displayUpgradeSettingsTab={displayUpgradeSettingsTab}
                 wifConfigData={{
                   displayName: wifConfigData?.display_name,
                   isLoading: isWifLoading,

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -14,6 +14,8 @@ import {
   Flex,
   HelperText,
   HelperTextItem,
+  Stack,
+  StackItem,
   Timestamp,
   TimestampFormat,
 } from '@patternfly/react-core';
@@ -22,6 +24,7 @@ import { trackEvents } from '~/common/analytics';
 import { getQueryParam } from '~/common/queryHelpers';
 import { Link } from '~/common/routing';
 import { hasSecurityGroupIds } from '~/common/securityGroupsHelpers';
+import { knownProducts } from '~/common/subscriptionTypes';
 import AIClusterStatus from '~/components/AIComponents/AIClusterStatus';
 import { OverviewBillingAccount } from '~/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccount';
 import clusterStates, {
@@ -71,6 +74,12 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
   const clusterRawVersionID = cluster?.version?.raw_id;
   const isAutoNodeAllowed = useFeatureGate(ENABLE_AUTO_NODE) && isHypershift;
   const isHcpLogForwardingEnabled = useFeatureGate(HCP_LOG_FORWARDING);
+  const isArchived =
+    get(cluster, 'subscription.status', false) === SubscriptionCommonFieldsStatus.Archived ||
+    get(cluster, 'subscription.status', false) === SubscriptionCommonFieldsStatus.Deprovisioned;
+  const isAROCluster = get(cluster, 'subscription.plan.type', '') === knownProducts.ARO;
+  const displayUpgradeSettingsTab =
+    cluster.managed && !isAROCluster && cluster.canEdit && !isArchived;
   const showControlPlaneLogForwarding = isHypershift && isROSACluster && isHcpLogForwardingEnabled;
   const track = useAnalytics();
   const dispatch = useDispatch();
@@ -571,25 +580,31 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
           <DescriptionListTerm>
             <Flex gap={{ default: 'gapSm' }}>
               Control plane log forwarding
-              <Button variant="link" component={Link} to={{ hash: '#updateSettings' }}>
-                View details
-              </Button>
+              {displayUpgradeSettingsTab && (
+                <Button variant="link" component={Link} to={{ hash: '#updateSettings' }}>
+                  View details
+                </Button>
+              )}
             </Flex>
           </DescriptionListTerm>
           <DescriptionListDescription data-testid="controlPlaneLogForwardingDescription">
             {!hasConfiguredLogForwarder ? (
               <span>Disabled</span>
             ) : (
-              <dl className="pf-v6-l-stack">
-                <Flex>
-                  <dt>Amazon S3: </dt>
-                  <dd>{s3LogForwarder ? 'Enabled' : 'Disabled'}</dd>
-                </Flex>
-                <Flex>
-                  <dt>CloudWatch: </dt>
-                  <dd>{cloudWatchLogForwarder ? 'Enabled' : 'Disabled'}</dd>
-                </Flex>
-              </dl>
+              <Stack>
+                <StackItem>
+                  <Flex>
+                    <dt>Amazon S3: </dt>
+                    <dd>{s3LogForwarder ? 'Enabled' : 'Disabled'}</dd>
+                  </Flex>
+                </StackItem>
+                <StackItem>
+                  <Flex>
+                    <dt>CloudWatch: </dt>
+                    <dd>{cloudWatchLogForwarder ? 'Enabled' : 'Disabled'}</dd>
+                  </Flex>
+                </StackItem>
+              </Stack>
             )}
           </DescriptionListDescription>
         </DescriptionListGroup>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -6,7 +6,6 @@ import semver from 'semver';
 
 import {
   Alert,
-  Button,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -14,17 +13,13 @@ import {
   Flex,
   HelperText,
   HelperTextItem,
-  Stack,
-  StackItem,
   Timestamp,
   TimestampFormat,
 } from '@patternfly/react-core';
 
 import { trackEvents } from '~/common/analytics';
 import { getQueryParam } from '~/common/queryHelpers';
-import { Link } from '~/common/routing';
 import { hasSecurityGroupIds } from '~/common/securityGroupsHelpers';
-import { knownProducts } from '~/common/subscriptionTypes';
 import AIClusterStatus from '~/components/AIComponents/AIClusterStatus';
 import { OverviewBillingAccount } from '~/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccount';
 import clusterStates, {
@@ -62,10 +57,17 @@ import EditAutoNodeModal from '../EditAutoNodeModal/EditAutoNodeModal';
 import DeleteProtection from './DeleteProtection/DeleteProtection';
 import AutoNodeKarpenterCount from './AutoNodeKarpenterCount';
 import { ClusterStatus } from './ClusterStatus';
+import LogForwardingConfiguration from './LogForwardingConfiguration';
 
 const AUTO_NODE_MIN_VERSION = '4.22.0';
 
-function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDetailsFetching }) {
+function DetailsRight({
+  cluster,
+  hasAutoscaleCluster,
+  isDeprovisioned,
+  clusterDetailsFetching,
+  displayUpgradeSettingsTab,
+}) {
   const isHypershift = isHypershiftCluster(cluster);
   const isROSACluster = isROSA(cluster);
   const region = cluster?.subscription?.rh_region_id;
@@ -74,13 +76,7 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
   const clusterRawVersionID = cluster?.version?.raw_id;
   const isAutoNodeAllowed = useFeatureGate(ENABLE_AUTO_NODE) && isHypershift;
   const isHcpLogForwardingEnabled = useFeatureGate(HCP_LOG_FORWARDING);
-  const isArchived =
-    get(cluster, 'subscription.status', false) === SubscriptionCommonFieldsStatus.Archived ||
-    get(cluster, 'subscription.status', false) === SubscriptionCommonFieldsStatus.Deprovisioned;
-  const isAROCluster = get(cluster, 'subscription.plan.type', '') === knownProducts.ARO;
-  const displayUpgradeSettingsTab =
-    cluster.managed && !isAROCluster && cluster.canEdit && !isArchived;
-  const showControlPlaneLogForwarding = isHypershift && isROSACluster && isHcpLogForwardingEnabled;
+  const showControlPlaneLogForwarding = isHypershift && isHcpLogForwardingEnabled;
   const track = useAnalytics();
   const dispatch = useDispatch();
 
@@ -99,7 +95,6 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
 
   const s3LogForwarder = logForwarders.find((forwarder) => forwarder.s3);
   const cloudWatchLogForwarder = logForwarders.find((forwarder) => forwarder.cloudwatch);
-  const hasConfiguredLogForwarder = s3LogForwarder || cloudWatchLogForwarder;
 
   const nodesSectionData = totalNodesDataSelector(cluster, machinePools);
 
@@ -576,38 +571,11 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
       )}
       {/* Control plane log forwarding */}
       {showControlPlaneLogForwarding ? (
-        <DescriptionListGroup>
-          <DescriptionListTerm>
-            <Flex gap={{ default: 'gapSm' }}>
-              Control plane log forwarding
-              {displayUpgradeSettingsTab && (
-                <Button variant="link" component={Link} to={{ hash: '#updateSettings' }}>
-                  View details
-                </Button>
-              )}
-            </Flex>
-          </DescriptionListTerm>
-          <DescriptionListDescription data-testid="controlPlaneLogForwardingDescription">
-            {!hasConfiguredLogForwarder ? (
-              <span>Disabled</span>
-            ) : (
-              <Stack>
-                <StackItem>
-                  <Flex>
-                    <dt>Amazon S3: </dt>
-                    <dd>{s3LogForwarder ? 'Enabled' : 'Disabled'}</dd>
-                  </Flex>
-                </StackItem>
-                <StackItem>
-                  <Flex>
-                    <dt>CloudWatch: </dt>
-                    <dd>{cloudWatchLogForwarder ? 'Enabled' : 'Disabled'}</dd>
-                  </Flex>
-                </StackItem>
-              </Stack>
-            )}
-          </DescriptionListDescription>
-        </DescriptionListGroup>
+        <LogForwardingConfiguration
+          displayUpgradeSettingsTab={displayUpgradeSettingsTab}
+          isS3Enabled={!!s3LogForwarder}
+          isCloudWatchEnabled={!!cloudWatchLogForwarder}
+        />
       ) : null}
     </DescriptionList>
   );
@@ -618,6 +586,7 @@ DetailsRight.propTypes = {
   isDeprovisioned: PropTypes.bool,
   hasAutoscaleCluster: PropTypes.bool,
   clusterDetailsFetching: PropTypes.bool,
+  displayUpgradeSettingsTab: PropTypes.bool,
 };
 
 export default DetailsRight;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -6,6 +6,7 @@ import semver from 'semver';
 
 import {
   Alert,
+  Button,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -19,6 +20,7 @@ import {
 
 import { trackEvents } from '~/common/analytics';
 import { getQueryParam } from '~/common/queryHelpers';
+import { Link } from '~/common/routing';
 import { hasSecurityGroupIds } from '~/common/securityGroupsHelpers';
 import AIClusterStatus from '~/components/AIComponents/AIClusterStatus';
 import { OverviewBillingAccount } from '~/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccount';
@@ -36,7 +38,8 @@ import modals from '~/components/common/Modal/modals';
 import useAnalytics from '~/hooks/useAnalytics';
 import useCanClusterAutoscale from '~/hooks/useCanClusterAutoscale';
 import { useFetchMachineOrNodePools } from '~/queries/ClusterDetailsQueries/MachinePoolTab/useFetchMachineOrNodePools';
-import { ENABLE_AUTO_NODE } from '~/queries/featureGates/featureConstants';
+import { useFetchLogForwarders } from '~/queries/ClusterDetailsQueries/useFetchLogForwarders';
+import { ENABLE_AUTO_NODE, HCP_LOG_FORWARDING } from '~/queries/featureGates/featureConstants';
 import { useFeatureGate } from '~/queries/featureGates/useFetchFeatureGate';
 import { isRestrictedEnv } from '~/restrictedEnv';
 import { SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
@@ -61,11 +64,14 @@ const AUTO_NODE_MIN_VERSION = '4.22.0';
 
 function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDetailsFetching }) {
   const isHypershift = isHypershiftCluster(cluster);
+  const isROSACluster = isROSA(cluster);
   const region = cluster?.subscription?.rh_region_id;
   const clusterID = cluster?.id;
   const clusterVersionID = cluster?.version?.id;
   const clusterRawVersionID = cluster?.version?.raw_id;
   const isAutoNodeAllowed = useFeatureGate(ENABLE_AUTO_NODE) && isHypershift;
+  const isHcpLogForwardingEnabled = useFeatureGate(HCP_LOG_FORWARDING);
+  const showControlPlaneLogForwarding = isHypershift && isROSACluster && isHcpLogForwardingEnabled;
   const track = useAnalytics();
   const dispatch = useDispatch();
 
@@ -76,6 +82,15 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
     region,
     clusterRawVersionID,
   );
+
+  const { data: logForwarders = [] } = useFetchLogForwarders(
+    showControlPlaneLogForwarding ? clusterID : undefined,
+    region,
+  );
+
+  const s3LogForwarder = logForwarders.find((forwarder) => forwarder.s3);
+  const cloudWatchLogForwarder = logForwarders.find((forwarder) => forwarder.cloudwatch);
+  const hasConfiguredLogForwarder = s3LogForwarder || cloudWatchLogForwarder;
 
   const nodesSectionData = totalNodesDataSelector(cluster, machinePools);
 
@@ -130,7 +145,6 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
   );
   const isAWS = cluster.subscription?.cloud_provider_id === 'aws';
   const isGCP = cluster.subscription?.cloud_provider_id === 'gcp';
-  const isROSACluster = isROSA(cluster);
   const infraAccount = cluster.subscription?.cloud_account_id || null;
   const hypershiftEtcdEncryptionKey = isHypershift && cluster.aws?.etcd_encryption?.kms_key_arn;
   const { clusterVpc } = useAWSVPCFromCluster(cluster);
@@ -551,6 +565,35 @@ function DetailsRight({ cluster, hasAutoscaleCluster, isDeprovisioned, clusterDe
           </DescriptionListDescription>
         </DescriptionListGroup>
       )}
+      {/* Control plane log forwarding */}
+      {showControlPlaneLogForwarding ? (
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            <Flex gap={{ default: 'gapSm' }}>
+              Control plane log forwarding
+              <Button variant="link" component={Link} to={{ hash: '#updateSettings' }}>
+                View details
+              </Button>
+            </Flex>
+          </DescriptionListTerm>
+          <DescriptionListDescription data-testid="controlPlaneLogForwardingDescription">
+            {!hasConfiguredLogForwarder ? (
+              <span>Disabled</span>
+            ) : (
+              <dl className="pf-v6-l-stack">
+                <Flex>
+                  <dt>Amazon S3: </dt>
+                  <dd>{s3LogForwarder ? 'Enabled' : 'Disabled'}</dd>
+                </Flex>
+                <Flex>
+                  <dt>CloudWatch: </dt>
+                  <dd>{cloudWatchLogForwarder ? 'Enabled' : 'Disabled'}</dd>
+                </Flex>
+              </dl>
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      ) : null}
     </DescriptionList>
   );
 }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -2165,6 +2165,41 @@ describe('<DetailsRight />', () => {
       );
     });
 
+    it('does not show View details link when cluster is archived', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: {
+          ...fixtures.ROSAHypershiftClusterDetails.cluster,
+          subscription: {
+            ...fixtures.ROSAHypershiftClusterDetails.cluster.subscription,
+            status: SubscriptionCommonFieldsStatus.Archived,
+          },
+        },
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.getByText('Control plane log forwarding')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
+    });
+
+    it('does not show View details link when user does not have canEdit', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: {
+          ...fixtures.ROSAHypershiftClusterDetails.cluster,
+          canEdit: false,
+        },
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.getByText('Control plane log forwarding')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
+    });
+
     it('hides section when feature gate is disabled', () => {
       mockUseFeatureGate([[HCP_LOG_FORWARDING, false]]);
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -16,7 +16,6 @@ import {
 } from '~/testUtils';
 
 import { useFetchMachineOrNodePools } from '../../../../../../queries/ClusterDetailsQueries/MachinePoolTab/useFetchMachineOrNodePools';
-import { useFetchLogForwarders } from '../../../../../../queries/ClusterDetailsQueries/useFetchLogForwarders';
 import { SubscriptionCommonFieldsStatus } from '../../../../../../types/accounts_mgmt.v1';
 import fixtures from '../../../__tests__/ClusterDetails.fixtures';
 
@@ -2112,92 +2111,6 @@ describe('<DetailsRight />', () => {
   describe('Control plane log forwarding', () => {
     beforeEach(() => {
       useFetchMachineOrNodePools.mockReturnValue({ data: [] });
-    });
-
-    it('shows Disabled when no forwarders are configured', () => {
-      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
-
-      const newProps = {
-        ...defaultProps,
-        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
-      };
-      render(<DetailsRight {...newProps} />);
-
-      expect(screen.getByTestId('controlPlaneLogForwardingDescription')).toHaveTextContent(
-        'Disabled',
-      );
-      expect(screen.getByTestId('controlPlaneLogForwardingDescription')).not.toHaveTextContent(
-        'Amazon S3:',
-      );
-    });
-
-    it('shows status when at least one forwarder is configured', () => {
-      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
-      useFetchLogForwarders.mockReturnValue({
-        data: [{ s3: { bucket_name: 'my-bucket' } }],
-      });
-
-      const newProps = {
-        ...defaultProps,
-        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
-      };
-      render(<DetailsRight {...newProps} />);
-
-      const description = screen.getByTestId('controlPlaneLogForwardingDescription');
-      expect(description).toHaveTextContent('Amazon S3:');
-      expect(description).toHaveTextContent('Enabled');
-      expect(description).toHaveTextContent('CloudWatch:');
-      expect(description).toHaveTextContent('Disabled');
-    });
-
-    it('View details links to Settings tab', () => {
-      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
-
-      const newProps = {
-        ...defaultProps,
-        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
-      };
-      render(<DetailsRight {...newProps} />);
-
-      expect(screen.getByRole('link', { name: 'View details' })).toHaveAttribute(
-        'href',
-        expect.stringContaining('#updateSettings'),
-      );
-    });
-
-    it('does not show View details link when cluster is archived', () => {
-      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
-
-      const newProps = {
-        ...defaultProps,
-        cluster: {
-          ...fixtures.ROSAHypershiftClusterDetails.cluster,
-          subscription: {
-            ...fixtures.ROSAHypershiftClusterDetails.cluster.subscription,
-            status: SubscriptionCommonFieldsStatus.Archived,
-          },
-        },
-      };
-      render(<DetailsRight {...newProps} />);
-
-      expect(screen.getByText('Control plane log forwarding')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
-    });
-
-    it('does not show View details link when user does not have canEdit', () => {
-      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
-
-      const newProps = {
-        ...defaultProps,
-        cluster: {
-          ...fixtures.ROSAHypershiftClusterDetails.cluster,
-          canEdit: false,
-        },
-      };
-      render(<DetailsRight {...newProps} />);
-
-      expect(screen.getByText('Control plane log forwarding')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
     });
 
     it('hides section when feature gate is disabled', () => {

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 import docLinks from '~/common/docLinks.mjs';
-import { ALLOW_EUS_CHANNEL, ENABLE_AUTO_NODE } from '~/queries/featureGates/featureConstants';
+import {
+  ALLOW_EUS_CHANNEL,
+  ENABLE_AUTO_NODE,
+  HCP_LOG_FORWARDING,
+} from '~/queries/featureGates/featureConstants';
 import {
   checkAccessibility,
   mockRestrictedEnv,
@@ -12,6 +16,7 @@ import {
 } from '~/testUtils';
 
 import { useFetchMachineOrNodePools } from '../../../../../../queries/ClusterDetailsQueries/MachinePoolTab/useFetchMachineOrNodePools';
+import { useFetchLogForwarders } from '../../../../../../queries/ClusterDetailsQueries/useFetchLogForwarders';
 import { SubscriptionCommonFieldsStatus } from '../../../../../../types/accounts_mgmt.v1';
 import fixtures from '../../../__tests__/ClusterDetails.fixtures';
 
@@ -29,6 +34,10 @@ const defaultProps = {
 jest.mock(
   '../../../../../../queries/ClusterDetailsQueries/MachinePoolTab/useFetchMachineOrNodePools',
 );
+
+jest.mock('../../../../../../queries/ClusterDetailsQueries/useFetchLogForwarders', () => ({
+  useFetchLogForwarders: jest.fn(() => ({ data: [] })),
+}));
 
 jest.mock('~/hooks/useAnalytics', () => () => jest.fn());
 
@@ -2097,6 +2106,87 @@ describe('<DetailsRight />', () => {
 
       const link = screen.getByText('Learn more');
       expect(link).toHaveAttribute('href', docLinks.ROSA_AUTONODE);
+    });
+  });
+
+  describe('Control plane log forwarding', () => {
+    beforeEach(() => {
+      useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+    });
+
+    it('shows Disabled when no forwarders are configured', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.getByTestId('controlPlaneLogForwardingDescription')).toHaveTextContent(
+        'Disabled',
+      );
+      expect(screen.getByTestId('controlPlaneLogForwardingDescription')).not.toHaveTextContent(
+        'Amazon S3:',
+      );
+    });
+
+    it('shows status when at least one forwarder is configured', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+      useFetchLogForwarders.mockReturnValue({
+        data: [{ s3: { bucket_name: 'my-bucket' } }],
+      });
+
+      const newProps = {
+        ...defaultProps,
+        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
+      };
+      render(<DetailsRight {...newProps} />);
+
+      const description = screen.getByTestId('controlPlaneLogForwardingDescription');
+      expect(description).toHaveTextContent('Amazon S3:');
+      expect(description).toHaveTextContent('Enabled');
+      expect(description).toHaveTextContent('CloudWatch:');
+      expect(description).toHaveTextContent('Disabled');
+    });
+
+    it('View details links to Settings tab', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.getByRole('link', { name: 'View details' })).toHaveAttribute(
+        'href',
+        expect.stringContaining('#updateSettings'),
+      );
+    });
+
+    it('hides section when feature gate is disabled', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, false]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: fixtures.ROSAHypershiftClusterDetails.cluster,
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.queryByText('Control plane log forwarding')).not.toBeInTheDocument();
+    });
+
+    it('hides section for non hypershift clusters', () => {
+      mockUseFeatureGate([[HCP_LOG_FORWARDING, true]]);
+
+      const newProps = {
+        ...defaultProps,
+        cluster: fixtures.ROSAClusterDetails.cluster,
+      };
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.queryByText('Control plane log forwarding')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/LogForwardingConfiguration.test.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/LogForwardingConfiguration.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { render, screen } from '~/testUtils';
+
+import { ClusterTabsId } from '../../common/ClusterTabIds';
+
+import LogForwardingConfiguration from './LogForwardingConfiguration';
+
+describe('<LogForwardingConfiguration />', () => {
+  it('shows Disabled when no forwarders are configured', () => {
+    render(
+      <LogForwardingConfiguration
+        displayUpgradeSettingsTab
+        isS3Enabled={false}
+        isCloudWatchEnabled={false}
+      />,
+    );
+
+    expect(screen.getByTestId('controlPlaneLogForwardingDescription')).toHaveTextContent(
+      'Disabled',
+    );
+    expect(screen.getByTestId('controlPlaneLogForwardingDescription')).not.toHaveTextContent(
+      'Amazon S3:',
+    );
+  });
+
+  it('shows status when at least one forwarder is configured', () => {
+    render(
+      <LogForwardingConfiguration
+        displayUpgradeSettingsTab
+        isS3Enabled
+        isCloudWatchEnabled={false}
+      />,
+    );
+
+    const description = screen.getByTestId('controlPlaneLogForwardingDescription');
+    expect(description).toHaveTextContent('Amazon S3:');
+    expect(description).toHaveTextContent('Enabled');
+    expect(description).toHaveTextContent('CloudWatch:');
+    expect(description).toHaveTextContent('Disabled');
+  });
+
+  it('shows View details link when displayUpgradeSettingsTab is true', () => {
+    render(
+      <LogForwardingConfiguration
+        displayUpgradeSettingsTab
+        isS3Enabled={false}
+        isCloudWatchEnabled={false}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'View details' })).toHaveAttribute(
+      'href',
+      expect.stringContaining(`#${ClusterTabsId.UPDATE_SETTINGS}`),
+    );
+  });
+
+  it('hides View details link when displayUpgradeSettingsTab is false', () => {
+    render(
+      <LogForwardingConfiguration
+        displayUpgradeSettingsTab={false}
+        isS3Enabled={false}
+        isCloudWatchEnabled={false}
+      />,
+    );
+
+    expect(screen.getByText('Control plane log forwarding')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'View details' })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/LogForwardingConfiguration.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/LogForwardingConfiguration.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+import {
+  Button,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Flex,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+
+import { Link } from '~/common/routing';
+
+import { ClusterTabsId } from '../../common/ClusterTabIds';
+
+type LogForwardingConfigurationProps = {
+  displayUpgradeSettingsTab: boolean;
+  isS3Enabled: boolean;
+  isCloudWatchEnabled: boolean;
+};
+
+const UpdateSettingsLink = (props: any) => (
+  <Link {...props} to={{ hash: `#${ClusterTabsId.UPDATE_SETTINGS}` }} />
+);
+
+const LogForwardingConfiguration = ({
+  displayUpgradeSettingsTab,
+  isS3Enabled,
+  isCloudWatchEnabled,
+}: LogForwardingConfigurationProps) => {
+  const hasConfiguredLogForwarder = isS3Enabled || isCloudWatchEnabled;
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>
+        <Flex gap={{ default: 'gapSm' }}>
+          Control plane log forwarding
+          {displayUpgradeSettingsTab && (
+            <Button variant="link" component={UpdateSettingsLink}>
+              View details
+            </Button>
+          )}
+        </Flex>
+      </DescriptionListTerm>
+      <DescriptionListDescription data-testid="controlPlaneLogForwardingDescription">
+        {!hasConfiguredLogForwarder ? (
+          <span>Disabled</span>
+        ) : (
+          <Stack>
+            <StackItem>
+              <Flex>
+                <dt>Amazon S3: </dt>
+                <dd>{isS3Enabled ? 'Enabled' : 'Disabled'}</dd>
+              </Flex>
+            </StackItem>
+            <StackItem>
+              <Flex>
+                <dt>CloudWatch: </dt>
+                <dd>{isCloudWatchEnabled ? 'Enabled' : 'Disabled'}</dd>
+              </Flex>
+            </StackItem>
+          </Stack>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default LogForwardingConfiguration;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Overview.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/Overview.jsx
@@ -54,6 +54,7 @@ const Overview = (props) => {
     clusterDetailsLoading,
     isSubscriptionSettingsRequestPending,
     clusterDetailsFetching,
+    displayUpgradeSettingsTab,
     wifConfigData,
   } = props;
 
@@ -233,6 +234,7 @@ const Overview = (props) => {
                       isDeprovisioned={isDeprovisioned}
                       hasAutoscaleCluster={!!cluster?.autoscaler}
                       clusterDetailsFetching={clusterDetailsFetching}
+                      displayUpgradeSettingsTab={displayUpgradeSettingsTab}
                     />
                   </GridItem>
                 </Grid>
@@ -300,6 +302,7 @@ Overview.propTypes = {
     fulfilled: PropTypes.bool,
   }).isRequired,
   clusterDetailsFetching: PropTypes.bool,
+  displayUpgradeSettingsTab: PropTypes.bool,
   wifConfigData: PropTypes.shape({
     displayName: PropTypes.string,
     isLoading: PropTypes.bool,


### PR DESCRIPTION
# Summary

**This PR is built on top of PR-515 (https://github.com/RedHatInsights/uhc-portal/pull/515) and will merge after PR-515 merges. 
Only the [last commit](https://github.com/RedHatInsights/uhc-portal/commit/935229d26810edd728aed9f05e775964032f133a) changes should be checked.
All other commits were reviewed in the day 1 and day 2 PRs.**

This PR adds control plane log forwarding field to the details in the Overview tab of cluster details.
The field states whether each config tab is enabled or disabled.
If control plane log forwarding is not configured, only ‘Disabled’ is shown.
The ‘View details’ link navigates the user to the settings tab where they can view the full configurations.

Assisted by Cursor/Auto

# Jira

Fixes [OCMUI-4342](https://redhat.atlassian.net/browse/OCMUI-4342)

# How to Test

1. Build an HCP cluster without log forwarding. 
2. Go to cluster details -> Overview tab.
3. Log forwarding field should display only 'Disabled' text
4. click on 'View details'
5. Make sure you are navigated to the settings tab.
6. Add a new log forwarder (like S3)
7. Go back to overview and make sure the log forwarding field now shows Amazon S3 as 'Enabled' and CloudWatch as 'Disabled'
8. Go to Overview page on a non rosa hcp cluster and make sure this field doesn't exist at all.

# Screen Captures

<img width="381" height="101" alt="Screenshot From 2026-06-18 14-43-48" src="https://github.com/user-attachments/assets/5b44e2c5-a345-4371-8c7a-260d27e72b8b" />

<img width="376" height="106" alt="Screenshot From 2026-06-18 17-20-44" src="https://github.com/user-attachments/assets/7ad2e593-1f85-4f48-9545-a16dabe043fd" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4342]: https://redhat.atlassian.net/browse/OCMUI-4342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ