### PR TITLE
OCMUI-4669: Change the queryKey for useFetchCluster to prevent extra reloads of data

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/BillingAccount/OverviewBillingAccountModal.tsx
@@ -66,7 +66,6 @@ export function OverviewBillingAccountModal(props: OverviewBillingAccountModalPr
                 queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
                 'clusterService',
                 cluster?.id,
-                cluster?.subscription,
               ],
             });
           },

--- a/src/queries/ClusterDetailsQueries/useFetchCluster.test.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.test.ts
@@ -3,7 +3,9 @@ import axios from 'axios';
 import { waitFor } from '@testing-library/react';
 
 import apiRequest from '~/services/apiRequest';
+import clusterService, * as clusterServiceModule from '~/services/clusterService';
 import { renderHook } from '~/testUtils';
+import { Subscription, SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 
 import { mockedCluster, mockSubscriptionData } from '../__mocks__/queryMockedData';
 
@@ -11,10 +13,23 @@ import { useFetchCluster } from './useFetchCluster';
 
 type MockedJest = jest.Mocked<typeof axios> & jest.Mock;
 const apiRequestMock = apiRequest as unknown as MockedJest;
+const mockGetClusterServiceForRegion = jest.spyOn(
+  clusterServiceModule,
+  'getClusterServiceForRegion',
+);
 
 const MAIN_QUERY_KEY = 'clusterDetails';
 
+const subscriptionWithRegion: Subscription = {
+  ...mockSubscriptionData,
+  rh_region_id: 'us-east-1',
+};
+
 describe('useFetchCluster hook', () => {
+  beforeEach(() => {
+    mockGetClusterServiceForRegion.mockReturnValue(clusterService);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -73,5 +88,36 @@ describe('useFetchCluster hook', () => {
     expect(result.current.isError).toBe(true);
     expect(result.current.error?.name).toEqual(403);
     expect(result.current.error?.message).toEqual('Cluster does not exist');
+  });
+
+  it('does not refetch cluster details when subscription changes but rh_region_id stays the same', async () => {
+    const clusterID = 'mockedClusterID';
+    const isAROCluster = false;
+
+    apiRequestMock.get.mockResolvedValue({ data: mockedCluster });
+
+    const { result, rerender } = renderHook(
+      ({ subscription }: { subscription: Subscription }) =>
+        useFetchCluster(clusterID, subscription, isAROCluster, MAIN_QUERY_KEY),
+      { initialProps: { subscription: subscriptionWithRegion } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+
+    rerender({
+      subscription: {
+        ...subscriptionWithRegion,
+        status: SubscriptionCommonFieldsStatus.Disconnected,
+        display_name: 'Updated subscription',
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/queries/ClusterDetailsQueries/useFetchCluster.test.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.test.ts
@@ -1,15 +1,20 @@
+import React from 'react';
 import axios from 'axios';
 
-import { waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook as rtlRenderHook, waitFor } from '@testing-library/react';
 
+import { queryClient } from '~/components/App/queryClient';
 import apiRequest from '~/services/apiRequest';
 import clusterService, * as clusterServiceModule from '~/services/clusterService';
 import { renderHook } from '~/testUtils';
 import { Subscription, SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 
 import { mockedCluster, mockSubscriptionData } from '../__mocks__/queryMockedData';
+import { queryConstants } from '../queriesConstants';
 
 import { useFetchCluster } from './useFetchCluster';
+import { invalidateClusterDetailsQueries } from './useFetchClusterDetails';
 
 type MockedJest = jest.Mocked<typeof axios> & jest.Mock;
 const apiRequestMock = apiRequest as unknown as MockedJest;
@@ -24,6 +29,9 @@ const subscriptionWithRegion: Subscription = {
   ...mockSubscriptionData,
   rh_region_id: 'us-east-1',
 };
+
+const queryClientWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(QueryClientProvider, { client: queryClient }, children);
 
 describe('useFetchCluster hook', () => {
   beforeEach(() => {
@@ -90,6 +98,26 @@ describe('useFetchCluster hook', () => {
     expect(result.current.error?.message).toEqual('Cluster does not exist');
   });
 
+  it('fetches cluster details using default clusterService when rh_region_id is absent', async () => {
+    const clusterID = 'mockedClusterID';
+    const isAROCluster = false;
+
+    apiRequestMock.get.mockResolvedValueOnce({ data: mockedCluster });
+
+    const { result } = renderHook(() =>
+      useFetchCluster(clusterID, mockSubscriptionData, isAROCluster, MAIN_QUERY_KEY),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetClusterServiceForRegion).not.toHaveBeenCalled();
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data?.data.kind).toEqual(mockedCluster.kind);
+  });
+
   it('does not refetch cluster details when subscription changes but rh_region_id stays the same', async () => {
     const clusterID = 'mockedClusterID';
     const isAROCluster = false;
@@ -119,5 +147,35 @@ describe('useFetchCluster hook', () => {
       expect(result.current.isFetching).toBe(false);
     });
     expect(apiRequest.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('is invalidated by invalidateClusterDetailsQueries', async () => {
+    const clusterID = 'mockedClusterID';
+    const isAROCluster = false;
+
+    queryClient.clear();
+    apiRequestMock.get.mockResolvedValue({ data: mockedCluster });
+
+    const { result } = rtlRenderHook(
+      () =>
+        useFetchCluster(
+          clusterID,
+          subscriptionWithRegion,
+          isAROCluster,
+          queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
+        ),
+      { wrapper: queryClientWrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+
+    invalidateClusterDetailsQueries();
+
+    await waitFor(() => {
+      expect(apiRequest.get).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/queries/ClusterDetailsQueries/useFetchCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.ts
@@ -18,7 +18,7 @@ export const useFetchCluster = (
   mainQueryKey: string,
 ) => {
   const { isLoading, data, isError, error, isFetching } = useQuery({
-    queryKey: [mainQueryKey, 'clusterService', clusterID, subscription],
+    queryKey: [mainQueryKey, 'clusterService', clusterID, subscription?.rh_region_id],
     queryFn: async () => {
       if (subscription?.rh_region_id) {
         const clusterService = getClusterServiceForRegion(subscription?.rh_region_id);

--- a/src/queries/ClusterDetailsQueries/useFetchCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.ts
@@ -18,7 +18,7 @@ export const useFetchCluster = (
   mainQueryKey: string,
 ) => {
   const { isLoading, data, isError, error, isFetching } = useQuery({
-    queryKey: [mainQueryKey, 'fetchCluster', clusterID, subscription?.rh_region_id],
+    queryKey: [mainQueryKey, 'clusterService', clusterID, subscription?.rh_region_id],
     queryFn: async () => {
       if (subscription?.rh_region_id) {
         const clusterService = getClusterServiceForRegion(subscription?.rh_region_id);

--- a/src/queries/ClusterDetailsQueries/useFetchCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchCluster.ts
@@ -18,7 +18,7 @@ export const useFetchCluster = (
   mainQueryKey: string,
 ) => {
   const { isLoading, data, isError, error, isFetching } = useQuery({
-    queryKey: [mainQueryKey, 'clusterService', clusterID, subscription?.rh_region_id],
+    queryKey: [mainQueryKey, 'fetchCluster', clusterID, subscription?.rh_region_id],
     queryFn: async () => {
       if (subscription?.rh_region_id) {
         const clusterService = getClusterServiceForRegion(subscription?.rh_region_id);

--- a/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.test.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.test.ts
@@ -1,0 +1,132 @@
+import axios from 'axios';
+
+import { waitFor } from '@testing-library/react';
+
+import apiRequest from '~/services/apiRequest';
+import clusterService, * as clusterServiceModule from '~/services/clusterService';
+import { renderHook } from '~/testUtils';
+import { SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
+
+import {
+  mockedSubscriptionWithClusterType,
+  mockSubscriptionData,
+} from '../__mocks__/queryMockedData';
+import { queryConstants } from '../queriesConstants';
+import { SubscriptionResponseType } from '../types';
+
+import { useFetchUpgradeGateAgreements } from './useFetchUpgradeGateAgreements';
+
+type MockedJest = jest.Mocked<typeof axios> & jest.Mock;
+const apiRequestMock = apiRequest as unknown as MockedJest;
+const mockGetClusterServiceForRegion = jest.spyOn(
+  clusterServiceModule,
+  'getClusterServiceForRegion',
+);
+
+const MAIN_QUERY_KEY = queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY;
+const clusterID = 'mockedClusterID';
+
+const mockedGateAgreements = {
+  data: {
+    kind: 'VersionGateAgreementList',
+    page: 1,
+    size: 1,
+    total: 1,
+    items: [
+      {
+        kind: 'VersionGateAgreement',
+        id: 'mocked-gate-agreement-id',
+        version_gate: {
+          id: 'mocked-version-gate-id',
+        },
+      },
+    ],
+  },
+};
+
+const subscriptionWithRegion: SubscriptionResponseType = {
+  ...mockedSubscriptionWithClusterType,
+  subscription: {
+    ...mockSubscriptionData,
+    rh_region_id: 'us-east-1',
+  },
+};
+
+describe('useFetchUpgradeGateAgreements', () => {
+  beforeEach(() => {
+    mockGetClusterServiceForRegion.mockReturnValue(clusterService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns gate agreements data on valid response', async () => {
+    apiRequestMock.get.mockResolvedValueOnce(mockedGateAgreements);
+
+    const { result } = renderHook(() =>
+      useFetchUpgradeGateAgreements(clusterID, mockedSubscriptionWithClusterType, MAIN_QUERY_KEY),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBe(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockedGateAgreements);
+    expect(result.current.data?.data.items?.[0]?.id).toEqual('mocked-gate-agreement-id');
+  });
+
+  it('fetches gate agreements using default clusterService when rh_region_id is absent', async () => {
+    apiRequestMock.get.mockResolvedValueOnce(mockedGateAgreements);
+
+    const { result } = renderHook(() =>
+      useFetchUpgradeGateAgreements(clusterID, mockedSubscriptionWithClusterType, MAIN_QUERY_KEY),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockGetClusterServiceForRegion).not.toHaveBeenCalled();
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+    expect(apiRequest.get).toHaveBeenCalledWith(
+      `/api/clusters_mgmt/v1/clusters/${clusterID}/gate_agreements`,
+    );
+    expect(result.current.data).toEqual(mockedGateAgreements);
+  });
+
+  it('does not refetch gate agreements when subscription changes but rh_region_id stays the same', async () => {
+    apiRequestMock.get.mockResolvedValue(mockedGateAgreements);
+
+    const { result, rerender } = renderHook(
+      ({ subscription }: { subscription: SubscriptionResponseType }) =>
+        useFetchUpgradeGateAgreements(clusterID, subscription, MAIN_QUERY_KEY),
+      { initialProps: { subscription: subscriptionWithRegion } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+    expect(mockGetClusterServiceForRegion).toHaveBeenCalledWith('us-east-1');
+
+    rerender({
+      subscription: {
+        ...subscriptionWithRegion,
+        subscription: {
+          ...subscriptionWithRegion.subscription,
+          status: SubscriptionCommonFieldsStatus.Disconnected,
+          display_name: 'Updated subscription',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.test.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.test.ts
@@ -129,4 +129,35 @@ describe('useFetchUpgradeGateAgreements', () => {
     });
     expect(apiRequest.get).toHaveBeenCalledTimes(1);
   });
+
+  it('refetches gate agreements when rh_region_id changes', async () => {
+    apiRequestMock.get.mockResolvedValue(mockedGateAgreements);
+
+    const { result, rerender } = renderHook(
+      ({ subscription }: { subscription: SubscriptionResponseType }) =>
+        useFetchUpgradeGateAgreements(clusterID, subscription, MAIN_QUERY_KEY),
+      { initialProps: { subscription: subscriptionWithRegion } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(apiRequest.get).toHaveBeenCalledTimes(1);
+    expect(mockGetClusterServiceForRegion).toHaveBeenCalledWith('us-east-1');
+
+    rerender({
+      subscription: {
+        ...subscriptionWithRegion,
+        subscription: {
+          ...subscriptionWithRegion.subscription,
+          rh_region_id: 'us-west-2',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(apiRequest.get).toHaveBeenCalledTimes(2);
+    });
+    expect(mockGetClusterServiceForRegion).toHaveBeenCalledWith('us-west-2');
+  });
 });

--- a/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchUpgradeGateAgreements.ts
@@ -4,7 +4,6 @@ import { clusterService } from '~/services';
 import { getClusterServiceForRegion } from '~/services/clusterService';
 import { SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
 
-import { queryConstants } from '../queriesConstants';
 import { SubscriptionResponseType } from '../types';
 
 /**
@@ -21,12 +20,11 @@ export const useFetchUpgradeGateAgreements = (
 ) => {
   const { isLoading, data } = useQuery({
     queryKey: [
-      queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
       mainQueryKey,
-      'upgradeGates',
       'clusterService',
+      'upgradeGates',
       clusterID,
-      subscription,
+      subscription?.subscription.rh_region_id,
     ],
     queryFn: async () => {
       if (subscription?.subscription.rh_region_id) {


### PR DESCRIPTION
# Summary

Change the queryKey on useFetchCluster from the entire subscription object to just the subscription region.  This prevents reloading/caching of data anytime anything on the subscription object changes.  The only thing that will affect our query is the region id.

Also added a unit test to verify additional queries are not made when other parts of the subscription object change.

Update: This similar issue can be found on the upgrade wizard modal where data refreshes can cause the modal to close early.  I have therefore also removed the subscription object from the upgradeGateAgreements call.

AI help write the unit test: cursor/composer-fast-2.5 

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4669](https://issues.redhat.com/browse/OCMUI-4669)

# How to Test

Functionally testing this has proven too difficult to easily reproduce.  Therefore, this test procedure focuses that the changes to the key values has been properly updated.

1. Before switching to this branch locally, use the TRQ tool in the lower right to find the react query cache.
2. Search using the filter for "fetchCluster".  Verify that the key shown has:
```
["fetchClusterDetails","clusterService","2r3j4lenv7hqt3sgnbss00c1li5ehgh5",{"billing_expiration_date":"0001-01-01T00:00:00Z","billing_marketplace_account":"767438687542","capabilities":[{"inherited":false,"name":"capability.cluster.manage_cluster_admin","value":"true"},...
```
3. Repeat for "upgradeGates" and verify key:
```
["fetchClusterDetails","fetchClusterDetails","upgradeGates","clusterService","2r3j4lenv7hqt3sgnbss00c1li5ehgh5",{"isAROCluster":false,"isOSDCluster":false,"isROSACluster":true,"subscription":{"billing_expiration_date":"0001-01-01T00:00:00Z","billing_marketplace_account":"767438687542","capabilities":...
```
3. Now load the PR branch and check the key values. They should be much cleaner and straightforward without the full subscription object:
fetchCluster
```
["fetchClusterDetails","fetchCluster","2r3j4lenv7hqt3sgnbss00c1li5ehgh5",null]
```
UpgradeGates
```
["fetchClusterDetails","clusterService","upgradeGates","2r3j4lenv7hqt3sgnbss00c1li5ehgh5",null]
```
The `null` values maybe different depending on how your cluster is created, but `null` represents the region id

For a final test, this cache is used for cluster details so verify that the cluster details pages work and that the refresh works for cluster details. 

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4669]: https://redhat.atlassian.net/browse/OCMUI-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ