### PR TITLE
OCMUI-4728 : Playwright -Reduce parallel workers for playwright e2e smoke workflow from 4 to 2

### DIFF
--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -46,7 +46,7 @@ on:
       workers:
         description: 'Number of parallel workers'
         required: false
-        default: '4'
+        default: '2'
         type: string
 
 jobs:
@@ -312,7 +312,7 @@ jobs:
           export TEST_WITHQUOTA_PASSWORD=$(jq -r '.QE_ORGADMIN_PASSWORD // empty' playwright.env.json)
 
           GREP_PATTERN="${{ inputs.grep_tags || '@smoke' }}"
-          WORKERS="${{ inputs.workers || '4' }}"
+          WORKERS="${{ inputs.workers || '2' }}"
           EUT="${{ inputs.EUT || 'staging' }}"
 
           echo "Running tests with pattern: $GREP_PATTERN"
@@ -427,7 +427,7 @@ jobs:
                     },
                     {
                       "title": "Workers",
-                      "value": "${{ inputs.workers || '4' }}",
+                      "value": "${{ inputs.workers || '2' }}",
                       "short": true
                     },
                     {


### PR DESCRIPTION
# Summary
Reduce parallel workers for playwright e2e smoke workflow from 4 to 2

# Jira
Fixes [OCMUI-4728](https://issues.redhat.com/browse/OCMUI-4728) 

# Additional information
The Playwright smoke daily execution is failing or being blocked by Akamai with Access Denied before requests reach the application(refer failing jobs [here](https://github.com/RedHatInsights/uhc-portal/actions/workflows/e2e-smoke-playwright.yml) ). Reducing default parallel workers from 4 to 2 to bypass the rate-limit failures temporarily until we get a full clarity on the infrastructure issues


# How to Test

This change is applicable only for playwright smoke github workflow and could be only tested after merge.

Manual triggers with smoke workflow with 1 and 2 workers are successful.
Reference report for playwright execution with 1 worker is [here](https://redhat-internal.slack.com/archives/C09RJF2E4TE/p1782105827642139)
Reference report for playwright execution with 2 workers is [here](https://redhat-internal.slack.com/archives/C09RJF2E4TE/p1782121888896029)
 
# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4728]: https://redhat.atlassian.net/browse/OCMUI-4728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ