### PR TITLE
[OCMUI-4309] Playwright integration with Currents.dev

### DIFF
--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -188,6 +188,12 @@ spec:
         " 2>/dev/null || true
       fi
 
+      # Print Currents.dev dashboard link if reporting was enabled
+      if [ -n "${CURRENTS_RECORD_KEY:-}" ]; then
+        echo ""
+        echo "  Currents.dev: https://app.currents.dev/projects/AFvdNQ/runs"
+      fi
+
       echo "============================================"
       echo "  Exit code: $TEST_EXIT_CODE"
       echo "============================================"

--- a/.tekton/uhc-portal-pull-request.yaml
+++ b/.tekton/uhc-portal-pull-request.yaml
@@ -78,6 +78,13 @@ spec:
         exit 1
       fi
 
+      # Currents.dev integration — uploads screenshots, traces, and videos
+      if [ -n "${CURRENTS_RECORD_KEY:-}" ]; then
+        export CURRENTS_CI_BUILD_ID="${PIPELINE_RUN_NAME:-$RANDOM}"
+        export CURRENTS_TAG="pr-{{pull_request_number}}"
+        echo "Currents.dev reporting enabled (build: $CURRENTS_CI_BUILD_ID)"
+      fi
+
       # Wait for dev server to be ready (probe the app route, not just /)
       timeout 120s bash -c 'until curl -kf https://prod.foo.redhat.com:1337/apps/openshift/fed-mods.json > /dev/null 2>&1; do
         echo "Waiting for dev server to be ready"
@@ -226,6 +233,13 @@ spec:
     - pipelineTaskName: run-e2e-tests
       stepSpecs:
         - name: e2e-tests
+          env:
+            - name: CURRENTS_RECORD_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ocm-ui-credentials-secret
+                  key: CURRENTS_RECORD_KEY
+                  optional: true
           computeResources:
             requests:
               memory: "10Gi"

--- a/currents.config.ts
+++ b/currents.config.ts
@@ -1,0 +1,8 @@
+import { CurrentsConfig } from '@currents/playwright';
+
+const config: CurrentsConfig = {
+  projectId: 'AFvdNQ',
+  recordKey: process.env.CURRENTS_RECORD_KEY!,
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "@babel/preset-env": "^7.23.9",
         "@babel/preset-react": "^7.23.3",
         "@chromatic-com/storybook": "3.2.2",
+        "@currents/playwright": "^2.3.0",
         "@cypress/code-coverage": "^3.12.39",
         "@cypress/grep": "^4.0.1",
         "@playwright/test": "1.60.0",
@@ -704,7 +705,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2413,6 +2416,16 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
+      "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~13.1.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "dev": true,
@@ -2516,6 +2529,479 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@currents/commit-info": {
+      "version": "1.0.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@currents/commit-info/-/commit-info-1.0.1-beta.0.tgz",
+      "integrity": "sha512-gkn8E3UC+F4/fCla7QAGMGgGPzxZUL9bU9+4I+KZf9PtCU3DdQCdy7a+er2eg4ewfUzZ2Ic1HcfnHuPkuLPKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "3.5.5",
+        "check-more-types": "2.24.0",
+        "debug": "4.3.4",
+        "execa": "1.0.0",
+        "lazy-ass": "1.6.0",
+        "ramda": "0.26.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/bluebird": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@currents/commit-info/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@currents/commit-info/node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@currents/commit-info/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/@currents/playwright": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-2.3.0.tgz",
+      "integrity": "sha512-Va89jYmhSPcKXisgc/0fBjLnZJRpj6PnuKDReDDtHc4CMpp2B7Zd0ttkaJUqSQyRKQK0vA7kHxxUwuf9B8FHLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@commander-js/extra-typings": "^13.1.0",
+        "@currents/commit-info": "1.0.1-beta.0",
+        "async-retry": "^1.3.3",
+        "chalk": "^4.1.2",
+        "commander": "^13.1.0",
+        "date-fns": "^4.3.0",
+        "debug": "^4.4.3",
+        "dotenv": "^17.4.2",
+        "execa": "^9.6.0",
+        "getos": "^3.2.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "jiti": "2.7.0",
+        "json-stringify-safe": "^5.0.1",
+        "lil-http-terminator": "^1.2.3",
+        "lodash": "^4.18.1",
+        "nanoid": "^3.3.8",
+        "object-sizeof": "^2.6.5",
+        "p-debounce": "^2.1.0",
+        "p-map": "^4.0.0",
+        "p-queue": "6.6.2",
+        "pluralize": "^8.0.0",
+        "pretty-ms": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "regexp.escape": "^2.0.1",
+        "safe-regex2": "^5.1.1",
+        "source-map-support": "^0.5.21",
+        "stack-utils": "^2.0.6",
+        "tmp": "^0.2.7",
+        "tmp-promise": "^3.0.3",
+        "ts-pattern": "^5.8.0",
+        "undici": "^6.23.0",
+        "ws": "^8.21.0"
+      },
+      "bin": {
+        "pwc": "dist/bin/pwc.js",
+        "pwc-p": "dist/bin/pwc-p.js"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/execa/node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@currents/playwright/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@cypress/code-coverage": {
@@ -4343,14 +4829,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@jest/transform/node_modules/@babel/helper-validator-option": {
@@ -6769,23 +7247,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/nanoid": {
-      "version": "3.3.11",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/ora": {
       "version": "5.4.1",
       "dev": true,
@@ -7419,6 +7880,13 @@
         "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
         "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "10.53.1",
@@ -8078,6 +8546,19 @@
       "version": "0.27.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -10797,14 +11278,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-core/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@vue/compiler-core/node_modules/@babel/parser": {
       "version": "7.28.3",
       "dev": true,
@@ -10856,14 +11329,6 @@
         "source-map-js": "^1.2.1"
       }
     },
-    "node_modules/@vue/compiler-sfc/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
       "version": "7.28.3",
       "dev": true,
@@ -10896,23 +11361,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/nanoid": {
-      "version": "3.3.11",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@vue/compiler-sfc/node_modules/postcss": {
@@ -11857,6 +12305,16 @@
       "version": "3.2.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -19751,14 +20209,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/jest-config/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/jest-config/node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
       "dev": true,
@@ -20156,14 +20606,6 @@
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -20585,14 +21027,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
       "dev": true,
@@ -20812,6 +21246,16 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/joi": {
@@ -21342,6 +21786,16 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lil-http-terminator": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/lil-http-terminator/-/lil-http-terminator-1.2.3.tgz",
+      "integrity": "sha512-vQcHSwAFq/kTR2cG6peOVS7SjgksGgSPeH0G2lkw+buue33thE/FCHdn10wJXXshc5RswFy0Iaz48qA2Busw5Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lilconfig": {
@@ -23242,7 +23696,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -23288,6 +23744,13 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -23375,14 +23838,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/node-source-walk/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/node-source-walk/node_modules/@babel/parser": {
@@ -23578,6 +24033,41 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/object-sizeof": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-2.6.5.tgz",
+      "integrity": "sha512-Mu3udRqIsKpneKjIEJ2U/s1KmEgpl+N6cEX1o+dDl2aZ+VW5piHqNgomqAk5YMsDoSkpcA8HnIKx1eqGTKzdfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/object-sizeof/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/object.assign": {
       "version": "4.1.5",
       "license": "MIT",
@@ -23771,14 +24261,6 @@
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/openapi-typescript/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -24003,6 +24485,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/p-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-debounce/-/p-debounce-2.1.0.tgz",
+      "integrity": "sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "dev": true,
@@ -24053,6 +24555,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-retry": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
@@ -24069,6 +24595,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -24826,23 +25365,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/precinct/node_modules/nanoid": {
-      "version": "3.3.11",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/precinct/node_modules/postcss": {
       "version": "8.5.6",
       "dev": true,
@@ -25191,6 +25713,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "dev": true,
@@ -25442,14 +25971,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/react-docgen/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/react-docgen/node_modules/@babel/helper-validator-option": {
@@ -26054,6 +26575,27 @@
         "@babel/runtime": "^7.8.4"
       }
     },
+    "node_modules/regexp.escape": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexp.escape/-/regexp.escape-2.0.1.tgz",
+      "integrity": "sha512-JItRb4rmyTzmERBkAf6J87LjDPy/RscIwmaJQ3gsFlAzrmZbZU8LwBw5IydFZXW9hqpgbPlGbMhtpqtuAhMgtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "for-each": "^0.3.3",
+        "safe-regex-test": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "license": "MIT",
@@ -26366,6 +26908,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -26510,6 +27062,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safer-buffer": {
@@ -27670,6 +28245,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "dev": true,
@@ -28056,11 +28641,23 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
       }
     },
     "node_modules/tmpl": {
@@ -28369,6 +28966,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "dev": true,
@@ -28614,6 +29218,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "dev": true,
@@ -28648,6 +29262,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {
@@ -30282,7 +30909,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -30398,6 +31027,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.23.3",
     "@chromatic-com/storybook": "3.2.2",
+    "@currents/playwright": "^2.3.0",
     "@cypress/code-coverage": "^3.12.39",
     "@cypress/grep": "^4.0.1",
     "@playwright/test": "1.60.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -83,7 +83,10 @@ export default defineConfig({
     /* Take screenshot on failure */
     screenshot: 'only-on-failure',
 
-    /* Record video on failure */
+    /* Context-level video fallback for non-Currents runs (GitHub Actions, local).
+       Note: with our worker-scoped shared context this is a no-op in practice.
+       Per-test video for Currents.dev uses the page.screencast API via the
+       _currentsScreencast auto-fixture in fixtures/pages.ts. */
     video: 'retain-on-failure',
 
     /* Default timeout for each action */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { currentsReporter } from '@currents/playwright';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -55,6 +56,7 @@ export default defineConfig({
   reporter: [
     ['html', { outputFolder: REPORTS_DIR, open: 'never' }],
     ['json', { outputFile: path.join(RESULTS_DIR, 'test-results.json') }],
+    ...(process.env.CURRENTS_RECORD_KEY ? [currentsReporter()] : []),
   ],
   outputDir: RESULTS_DIR, // For traces, videos, screenshots
   /* Increase default timeout for all expectations */
@@ -72,10 +74,11 @@ export default defineConfig({
     /* Ignore HTTPS certificate errors globally */
     ignoreHTTPSErrors: true,
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace:
-      (process.env.PLAYWRIGHT_TRACE as 'on' | 'off' | 'on-first-retry' | 'retain-on-failure') ||
-      'off',
+    /* Collect trace: always-on when uploading to Currents, otherwise configurable */
+    trace: process.env.CURRENTS_RECORD_KEY
+      ? 'on'
+      : ((process.env.PLAYWRIGHT_TRACE as 'on' | 'off' | 'on-first-retry' | 'retain-on-failure') ||
+          'off'),
 
     /* Take screenshot on failure */
     screenshot: 'only-on-failure',

--- a/playwright/fixtures/pages.ts
+++ b/playwright/fixtures/pages.ts
@@ -67,6 +67,8 @@ type WorkerFixtures = {
  * Test-scoped fixtures - created fresh for each test
  */
 type TestFixtures = {
+  /** Screencast auto-fixture — starts/stops page.screencast per test when Currents is enabled */
+  _currentsScreencast: void;
   navigateTo: (
     url: string,
     options?: { waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit' },
@@ -121,6 +123,32 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   page: async ({ authenticatedPage }, use) => {
     await use(authenticatedPage);
   },
+
+  // Auto-fixture: per-test screencast recording when Currents.dev is enabled.
+  // Uses the page.screencast API (Playwright 1.59+) which works independently of
+  // context lifecycle — critical for our worker-scoped shared context architecture.
+  _currentsScreencast: [
+    async ({ page }, use, testInfo) => {
+      if (!process.env.CURRENTS_RECORD_KEY) {
+        await use();
+        return;
+      }
+
+      const videoPath = testInfo.outputPath('screencast.webm');
+      const size = page.viewportSize() ?? { width: 1280, height: 720 };
+      await page.screencast.start({ path: videoPath, size });
+      await use();
+      await page.screencast.stop();
+
+      if (testInfo.status !== testInfo.expectedStatus) {
+        await testInfo.attach('video', {
+          path: videoPath,
+          contentType: 'video/webm',
+        });
+      }
+    },
+    { auto: true },
+  ],
 
   // Test-scoped: navigateTo - Navigate to a URL with a clean state
   navigateTo: async ({ page }, use) => {


### PR DESCRIPTION
# Summary

Integrate [Currents.dev](https://currents.dev) with our Playwright E2E tests to get real-time test reporting, failure screenshots, traces, and videos from Konflux PR pipeline runs.

Today, Playwright artifacts (screenshots, videos, traces) captured during Konflux E2E runs are lost when the ephemeral pod is destroyed. Currents streams results to an external dashboard during test execution, so artifacts survive regardless of pod lifecycle.

The integration is conditional — it only activates when `CURRENTS_RECORD_KEY` is present in the environment, so local development, GitHub Actions workflows, and existing CI behavior are unaffected.

Assisted by: Cursor/claude-4.6-opus

# Jira

https://redhat.atlassian.net/browse/OCMUI-4309

### Related work

This follows the pattern established by the platform-ui team:
- [konflux-pipelines #223](https://github.com/RedHatInsights/konflux-pipelines/pull/223) — v2 pipeline with flexible secret management
- [frontend-starter-app #760](https://github.com/RedHatInsights/frontend-starter-app/pull/760) — Currents POC for starter-app

# Additional information

### What changed

| File | Change |
|------|--------|
| `package.json` / `package-lock.json` | Added `@currents/playwright` devDependency |
| `currents.config.ts` | New config file with project ID and record key from env |
| `playwright.config.ts` | Conditionally adds Currents reporter when `CURRENTS_RECORD_KEY` is set; enables traces when Currents is active |
| `.tekton/uhc-portal-pull-request.yaml` | Exports `CURRENTS_CI_BUILD_ID` and `CURRENTS_TAG` env vars; injects `CURRENTS_RECORD_KEY` from `ocm-ui-credentials-secret` via `secretKeyRef` (with `optional: true`) |

### How it works

- The `@currents/playwright` reporter is added to the Playwright reporter array **only** when `CURRENTS_RECORD_KEY` is set
- In Konflux, the record key is injected from `ocm-ui-credentials-secret` via an explicit `secretKeyRef` in `stepSpecs`
- Traces are set to `'on'` when Currents is active (so artifacts are uploaded), otherwise the existing configurable behavior is preserved
- `optional: true` on the `secretKeyRef` ensures the pipeline doesn't break if the secret key is missing

### Prerequisites (completed)

The `CURRENTS_RECORD_KEY` has been added to `ocm-ui-credentials-secret` in the `ocm-ui-tenant` namespace via the Konflux Secrets UI.

# How to Test

**Automated (this PR):** The Konflux PR pipeline should run E2E tests and stream results to [app.currents.dev](https://app.currents.dev) under the OCM-UI project. Check the Tekton pod logs for a Currents dashboard link:
<img width="1407" height="875" alt="CleanShot 2026-06-24 at 12 43 57" src="https://github.com/user-attachments/assets/f3ef9a30-5747-45d1-a39c-a5da0f8070ac" />

1. Goto the Dashboard on https://app.currents.dev
2. Click on failed red vertical bar, this loads the Runs view
3. Find a failed test, click on the footer failed test icon:

<img width="382" height="220" alt="CleanShot 2026-06-23 at 15 35 21" src="https://github.com/user-attachments/assets/bb3d2809-f1e1-4d1f-a56d-b175a7f5a5fb" />

4. Click on the failed test's title, until side panel "Attempts" tab is shown, then click on Screenshots (see 'After' image below). 

# Screen Captures

| Before | After |
| --- | --- |
| E2E failures in Konflux produce only pod log output; screenshots/traces are lost with the pod | <img width="1339" height="847" alt="CleanShot 2026-06-23 at 15 21 13" src="https://github.com/user-attachments/assets/88baf39a-59f5-48ea-a4bc-d7ea4037bf2b" />|

# Video support:
<img width="837" height="755" alt="CleanShot 2026-06-24 at 10 37 15" src="https://github.com/user-attachments/assets/57745a6e-f2f1-4b3c-b4c8-fc5d5d2f662d" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).