### PR TITLE
OCMUI-4195: Fix infinite spinner for AI clusters with non-404 errors

### DIFF
--- a/src/queries/ClusterDetailsQueries/useFetchAiCluster.test.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchAiCluster.test.ts
@@ -1,0 +1,124 @@
+import { waitFor } from '@testing-library/react';
+
+import * as normalizeModule from '~/common/normalize';
+import { assistedService } from '~/services';
+import { renderHook } from '~/testUtils';
+import { Subscription, SubscriptionCommonFieldsStatus } from '~/types/accounts_mgmt.v1';
+
+import { useFetchAiCluster } from './useFetchAiCluster';
+
+jest.mock('~/common/normalize');
+
+const CLUSTER_ID = 'test-cluster-id';
+const MAIN_QUERY_KEY = 'clusterDetails';
+
+const aiSubscription: Subscription = {
+  cluster_id: CLUSTER_ID,
+  plan: { id: 'OCP-AssistedInstall', type: 'OCP-AssistedInstall' },
+  status: SubscriptionCommonFieldsStatus.Active,
+  managed: false,
+};
+
+const nonAiSubscription: Subscription = {
+  cluster_id: CLUSTER_ID,
+  plan: { id: 'ROSA', type: 'ROSA' },
+  status: SubscriptionCommonFieldsStatus.Active,
+  managed: true,
+};
+
+const fakeBaseCluster = { id: CLUSTER_ID } as any;
+
+describe('useFetchAiCluster', () => {
+  const getAIClusterSpy = jest.spyOn(assistedService, 'getAICluster');
+  const getAIFeatureSupportLevelsSpy = jest.spyOn(assistedService, 'getAIFeatureSupportLevels');
+  const fakeClusterFromAISubscriptionMock =
+    normalizeModule.fakeClusterFromAISubscription as jest.Mock;
+  const fakeClusterFromSubscriptionMock = normalizeModule.fakeClusterFromSubscription as jest.Mock;
+
+  beforeEach(() => {
+    fakeClusterFromAISubscriptionMock.mockReturnValue({ ...fakeBaseCluster });
+    fakeClusterFromSubscriptionMock.mockReturnValue({ ...fakeBaseCluster });
+    getAIFeatureSupportLevelsSpy.mockResolvedValue(undefined as any);
+  });
+
+  it('returns cluster data with aiCluster populated when getAICluster succeeds', async () => {
+    const mockAiCluster = { id: CLUSTER_ID, status: 'installed' };
+    getAIClusterSpy.mockResolvedValueOnce({ data: mockAiCluster } as any);
+
+    const { result } = renderHook(() =>
+      useFetchAiCluster(CLUSTER_ID, MAIN_QUERY_KEY, aiSubscription),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data?.aiCluster).toEqual(mockAiCluster);
+    expect(fakeClusterFromAISubscriptionMock).toHaveBeenCalledWith(aiSubscription, mockAiCluster);
+    expect(fakeClusterFromSubscriptionMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to fakeClusterFromSubscription and does not surface an error when getAICluster returns 403', async () => {
+    const error403 = Object.assign(new Error('Request failed with status code 403'), {
+      isAxiosError: true,
+      response: {
+        status: 403,
+        statusText: 'Forbidden',
+        data: { code: 403, message: 'Unauthorized to access route (access review failed)' },
+      },
+    });
+    getAIClusterSpy.mockRejectedValueOnce(error403);
+
+    const { result } = renderHook(() =>
+      useFetchAiCluster(CLUSTER_ID, MAIN_QUERY_KEY, aiSubscription),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data?.aiCluster).toBeUndefined();
+    expect(fakeClusterFromAISubscriptionMock).not.toHaveBeenCalled();
+    expect(fakeClusterFromSubscriptionMock).toHaveBeenCalledWith(aiSubscription);
+  });
+
+  it('falls back to fakeClusterFromSubscription and does not surface an error when getAICluster returns a non-404 error', async () => {
+    const error500 = Object.assign(new Error('Internal Server Error'), {
+      isAxiosError: true,
+      response: { status: 500, statusText: 'Internal Server Error' },
+    });
+    getAIClusterSpy.mockRejectedValueOnce(error500);
+
+    const { result } = renderHook(() =>
+      useFetchAiCluster(CLUSTER_ID, MAIN_QUERY_KEY, aiSubscription),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data?.aiCluster).toBeUndefined();
+    expect(fakeClusterFromAISubscriptionMock).not.toHaveBeenCalled();
+    expect(fakeClusterFromSubscriptionMock).toHaveBeenCalledWith(aiSubscription);
+  });
+
+  it('returns a fake cluster without calling getAICluster when subscription is not an AI subscription', async () => {
+    const { result } = renderHook(() =>
+      useFetchAiCluster(CLUSTER_ID, MAIN_QUERY_KEY, nonAiSubscription),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getAIClusterSpy).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toBeDefined();
+    expect(fakeClusterFromSubscriptionMock).toHaveBeenCalledWith(nonAiSubscription);
+  });
+
+  it('is disabled and returns no data when subscription is undefined', () => {
+    const { result } = renderHook(() => useFetchAiCluster(CLUSTER_ID, MAIN_QUERY_KEY, undefined));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(getAIClusterSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/queries/ClusterDetailsQueries/useFetchAiCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchAiCluster.ts
@@ -23,14 +23,9 @@ const getAIClusterDetails = async (clusterID: string, subscription: Subscription
       cluster = fakeClusterFromAISubscription(subscription, aiCluster?.data || null);
       cluster.aiCluster = aiCluster.data;
     } catch (e) {
-      if (axios.isAxiosError(e) && e.response?.status === 404) {
-        // The cluster is garbage collected or the user does not have privileges
-        // eslint-disable-next-line no-console
-        console.info('Failed to query assisted-installer cluster id: ', clusterID);
-        cluster = fakeClusterFromSubscription(subscription);
-      } else {
-        throw e;
-      }
+      // eslint-disable-next-line no-console
+      console.info('Failed to query assisted-installer cluster id: ', clusterID);
+      cluster = fakeClusterFromSubscription(subscription);
     }
     try {
       const featureSupportLevels = await assistedService.getAIFeatureSupportLevels(

--- a/src/queries/ClusterDetailsQueries/useFetchAiCluster.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchAiCluster.ts
@@ -49,11 +49,11 @@ const getAIClusterDetails = async (clusterID: string, subscription: Subscription
 };
 
 /**
- * Query responsible for fetching actions and permissions
- * @param subscriptionID subscription ID to pass into api call
+ * Query responsible for fetching AI cluster details
+ * @param clusterID cluster ID to pass into api call
  * @param mainQueryKey used for invalidation of the query (refetch)
- * @param subscriptionStatus status of the subscription for query enablement
- * @returns cloud providers array
+ * @param subscription subscription object used for query enablement and building fake cluster
+ * @returns AI cluster details or fake cluster assembled from subscription
  */
 export const useFetchAiCluster = (
   clusterID: string,

--- a/src/queries/ClusterDetailsQueries/useFetchClusterDetails.ts
+++ b/src/queries/ClusterDetailsQueries/useFetchClusterDetails.ts
@@ -107,7 +107,11 @@ export const useFetchClusterDetails = (subscriptionID: string) => {
     subscription?.subscription.rh_region_id,
   );
 
-  const { isLoading: isAIClusterLoading, data: aiClusterResponse } = useFetchAiCluster(
+  const {
+    isLoading: isAIClusterLoading,
+    data: aiClusterResponse,
+    isError: isAIClusterError,
+  } = useFetchAiCluster(
     subscription?.subscription.cluster_id as string,
     queryConstants.FETCH_CLUSTER_DETAILS_QUERY_KEY,
     subscription?.subscription,
@@ -135,18 +139,21 @@ export const useFetchClusterDetails = (subscriptionID: string) => {
       isSubscriptionError ||
       isClusterDetailsError ||
       isActionsError ||
-      isCanDeleteAccessReviewError
+      isCanDeleteAccessReviewError ||
+      isAIClusterError
     ) {
       const isError =
         isSubscriptionError ||
         isClusterDetailsError ||
         isActionsError ||
-        isCanDeleteAccessReviewError;
+        isCanDeleteAccessReviewError ||
+        isAIClusterError;
       const isLoading =
         subscriptionLoading ||
         isClusterDetailsLoading ||
         isActionQueriesLoading ||
-        isCanDeleteAccessReviewLoading;
+        isCanDeleteAccessReviewLoading ||
+        isAIClusterLoading;
       const error =
         subscriptionError || clusterDetailsError || actionsError || canDeleteAccessReviewError;
 


### PR DESCRIPTION
# Summary

Fix an infinite loading spinner on the cluster details page for AI (Assisted Installer) clusters that return a non-404 error from the assisted-installer API.

Unfortunately we don't have clear steps to reproduce the issue, and our mock data env cannot mock responses from Assisted-Installer service, so the only way to test is to tweak the code to return 403 error.  

Assisted by: Claude Code / claude-sonnet-4-6

# Jira

Fixes [OCMUI-4195](https://issues.redhat.com/browse/OCMUI-4195)

# Additional information

**Root cause:** `useFetchAiCluster` only caught 404 errors and re-threw everything else. Any other error (e.g. 500) propagated up to `useFetchClusterDetails`, which fell through to the `return { isLoading: true }` fallback — causing an infinite spinner with no error state.

**Fix 1 — `useFetchAiCluster.ts`:** Replaced the 404-only catch with a catch-all that always falls back to `fakeClusterFromSubscription`. This matches the existing intent for 404 and extends it to cover other transient or server errors.

**Fix 2 — `useFetchClusterDetails.ts`:** Destructure `isError` from `useFetchAiCluster` and include it in both the error-guard condition and the inner `isLoading` calculation, so an AI cluster error surfaces as an error state rather than a perpetual loading state.

# How to Test

1. To simulate the bug, temporarily modify `src/services/assistedService.ts` — replace these two lines:
   ```ts
   const getAIClustersBySubscription = ClustersAPI.listBySubscriptionIds;
   const getAICluster = ClustersAPI.get;
   ```
   with:
   ```ts
   const mock403 = (): Promise<any> => Promise.reject(
     Object.assign(new Error('Request failed with status code 403'),
       { isAxiosError: true, response: { status: 403, statusText: 'Forbidden',
         data: { code: 403, message: 'Unauthorized to access route (access review failed)' } } })
   );
   const getAIClustersBySubscription = (..._args: any[]): Promise<any> => mock403();
   const getAICluster = (..._args: any[]): Promise<any> => mock403();
   ```

2. Navigate to an AI (Assisted Installer) cluster's details page in the mock data env (https://prod.foo.redhat.com:1337/openshift/?env=mockdata).
3. **Before fix:** the cluster details page spins indefinitely with no error state.
4. **After fix:** the cluster details page renders an error state instead of spinning.

# Screen Captures

Before - infinite spinner

<img width="1915" height="733" alt="image" src="https://github.com/user-attachments/assets/5f964076-8714-47c4-84ea-85b8c27ca545" />


After - page renders correctly (with data from OCM only) 


<img width="1866" height="979" alt="image" src="https://github.com/user-attachments/assets/19107d3f-6405-4ad3-8186-a6a6200f245e" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation

[OCMUI-4195]: https://redhat.atlassian.net/browse/OCMUI-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ