### PR TITLE
OCMUI-3798: Configure MSW

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -139,6 +139,7 @@
         "**/*.stories.ts*",
         "**/*.stories.js*",
         "src/testUtils.tsx",
+        "src/mocks/**/*",
         "cypress.config.js",
         "fec.config.js",
         "*.mjs",

--- a/fec.config.js
+++ b/fec.config.js
@@ -37,8 +37,12 @@ module.exports = {
     '/mockdata': {
       host: 'http://localhost:8010',
     },
+    '/mockServiceWorker.js': {
+      host: 'http://localhost:8003',
+    },
   },
   plugins: [
+    process.env.NODE_ENV !== 'production' && new (require('./src/mocks/MSWPlugin'))(),
     new ForkTsCheckerWebpackPlugin(),
     new webpack.DefinePlugin({
       APP_DEVMODE: process.env.NODE_ENV !== 'production',

--- a/fec.config.js
+++ b/fec.config.js
@@ -37,9 +37,6 @@ module.exports = {
     '/mockdata': {
       host: 'http://localhost:8010',
     },
-    '/mockServiceWorker.js': {
-      host: 'http://localhost:8003',
-    },
   },
   plugins: [
     process.env.NODE_ENV !== 'production' && new (require('./src/mocks/MSWPlugin'))(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,7 @@
         "lint-staged": "^15.0.0",
         "madge": "8.0.0",
         "monaco-editor-webpack-plugin": "^7.1.0",
+        "msw": "^2.14.6",
         "node-fetch": "^3.0.0",
         "nyc": "^17.0.0",
         "openapi-typescript": "^7.5.2",
@@ -3443,6 +3444,15 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
       "version": "3.0.1",
       "dev": true,
@@ -5042,6 +5052,29 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -5099,6 +5132,28 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@openshift-assisted/locales": {
       "version": "2.38.4",
@@ -10119,6 +10174,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
       "dev": true,
@@ -10148,6 +10212,12 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -16404,6 +16474,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.0.6",
       "funding": [
@@ -16417,6 +16502,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
@@ -17423,6 +17517,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "dev": true,
@@ -17698,6 +17801,16 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/history": {
@@ -18932,6 +19045,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -23215,6 +23334,217 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/msw/node_modules/tldts": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.4.tgz",
+      "integrity": "sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^7.4.4"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/msw/node_modules/tldts-core": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "dev": true
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "dev": true,
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -24002,6 +24332,12 @@
       "version": "1.2.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -26376,6 +26712,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
@@ -26869,6 +27211,12 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -27478,6 +27826,12 @@
         "any-promise": "^1.1.0"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "dev": true,
@@ -27812,6 +28166,18 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -28817,6 +29183,15 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/untildify": {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "lint-staged": "^15.0.0",
     "madge": "8.0.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
+    "msw": "^2.14.6",
     "node-fetch": "^3.0.0",
     "nyc": "^17.0.0",
     "openapi-typescript": "^7.5.2",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/chrome-main.test.tsx
+++ b/src/chrome-main.test.tsx
@@ -1,0 +1,90 @@
+// Heavy deps that run code at module load time are mocked so chrome-main can be imported cleanly.
+// The dynamic import('./mocks/browser') is also mocked; the factory survives jest.resetModules()
+// so chrome-main and the test share the same worker instance within each test.
+
+jest.mock('@openshift-assisted/ui-lib/ocm', () => ({
+  Api: { setAuthInterceptor: jest.fn() },
+  Config: { setRouteBasePath: jest.fn() },
+  Services: {
+    APIs: { ClustersAPI: { listBySubscriptionIds: jest.fn(), get: jest.fn() } },
+    NewFeatureSupportLevelsService: { getFeaturesSupportLevel: jest.fn() },
+  },
+}));
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => jest.fn());
+jest.mock('@redhat-cloud-services/frontend-components-notifications', () => ({
+  NotificationsProvider: jest.fn(),
+}));
+jest.mock('@redhat-cloud-services/frontend-components-notifications/NotificationPortal', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('@sentry/browser', () => ({
+  init: jest.fn(),
+  getCurrentScope: jest.fn(() => ({ setUser: jest.fn() })),
+  globalHandlersIntegration: jest.fn(),
+}));
+jest.mock('@sentry/integrations', () => ({ sessionTimingIntegration: jest.fn() }));
+jest.mock('~/queries/featureGates/useFetchFeatureGate', () => ({
+  preFetchAllFeatureGates: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./components/App/App', () => ({ __esModule: true, default: () => null }));
+jest.mock('./hooks/useAnalytics', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('./i18n', () => {});
+jest.mock('./mocks/browser', () => ({ worker: { start: jest.fn() } }));
+
+describe('chrome-main', () => {
+  const originalAppDevMode = (global as any).APP_DEVMODE;
+
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    (global as any).APP_DEVMODE = originalAppDevMode;
+    localStorage.clear();
+    window.history.pushState({}, '', '/');
+  });
+
+  describe('MSW worker initialization', () => {
+    it('starts MSW worker when APP_DEVMODE is true and localStorage contains msw', async () => {
+      (global as any).APP_DEVMODE = true;
+      localStorage.setItem('ocmOverridenEnvironment', 'msw');
+
+      await import('./chrome-main');
+      // flush the microtask queue so the dynamic import's .then() callback runs
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      const { worker } = await import('./mocks/browser');
+      expect(worker.start).toHaveBeenCalledWith({ onUnhandledRequest: 'bypass' });
+    });
+
+    it('starts MSW worker when APP_DEVMODE is true and ?env=msw is in the URL', async () => {
+      (global as any).APP_DEVMODE = true;
+      window.history.pushState({}, '', '?env=msw');
+
+      await import('./chrome-main');
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      const { worker } = await import('./mocks/browser');
+      expect(worker.start).toHaveBeenCalledWith({ onUnhandledRequest: 'bypass' });
+    });
+
+    it('does not start MSW worker when APP_DEVMODE is false', async () => {
+      (global as any).APP_DEVMODE = false;
+      localStorage.setItem('ocmOverridenEnvironment', 'msw');
+
+      await import('./chrome-main');
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      const { worker } = await import('./mocks/browser');
+      expect(worker.start).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/chrome-main.tsx
+++ b/src/chrome-main.tsx
@@ -41,6 +41,10 @@ import './styles/main.scss';
 
 import './i18n';
 
+if (APP_DEVMODE) {
+  import('./mocks/browser').then(({ worker }) => worker.start({ onUnhandledRequest: 'bypass' }));
+}
+
 const { Api, Config } = OCM;
 
 /**

--- a/src/chrome-main.tsx
+++ b/src/chrome-main.tsx
@@ -42,7 +42,12 @@ import './styles/main.scss';
 import './i18n';
 
 if (APP_DEVMODE) {
-  import('./mocks/browser').then(({ worker }) => worker.start({ onUnhandledRequest: 'bypass' }));
+  const isMSW =
+    new URLSearchParams(window.location.search).get('env') === 'msw' ||
+    localStorage.getItem('ocmOverridenEnvironment') === 'msw';
+  if (isMSW) {
+    import('./mocks/browser').then(({ worker }) => worker.start({ onUnhandledRequest: 'bypass' }));
+  }
 }
 
 const { Api, Config } = OCM;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,6 +4,7 @@ import { ENV_OVERRIDE_LOCALSTORAGE_KEY } from './common/localStorageConstants';
 
 describe('config', () => {
   const originalAppDevServer = (global as any).APP_DEV_SERVER;
+  const originalAppDevMode = (global as any).APP_DEVMODE;
   const mockChrome = { isBeta: () => false, getEnvironment: () => 'prod' };
 
   beforeEach(() => {
@@ -13,6 +14,7 @@ describe('config', () => {
 
   afterEach(() => {
     (global as any).APP_DEV_SERVER = originalAppDevServer;
+    (global as any).APP_DEVMODE = originalAppDevMode;
     localStorage.clear();
   });
 
@@ -40,6 +42,57 @@ describe('config', () => {
       expect(config.configData.showOldMetrics).toBeUndefined();
       expect(config.configData.apiGateway).toBe('https://api.openshift.com');
       expect(config.envOverride).toBeUndefined();
+    });
+  });
+
+  describe('MSW env override', () => {
+    afterEach(() => {
+      window.history.pushState({}, '', '/');
+    });
+
+    it('sets envOverride to msw and persists to localStorage when APP_DEVMODE is true and localStorage contains msw', async () => {
+      (global as any).APP_DEVMODE = true;
+      localStorage.setItem(ENV_OVERRIDE_LOCALSTORAGE_KEY, 'msw');
+
+      const { default: config } = await import('./config');
+      await config.fetchConfig(mockChrome as Chrome);
+
+      expect(config.envOverride).toBe('msw');
+      expect(localStorage.getItem(ENV_OVERRIDE_LOCALSTORAGE_KEY)).toBe('msw');
+      expect(config.configData.apiGateway).toBe('https://api.openshift.com');
+    });
+
+    it('falls through to default config and does not set envOverride when APP_DEVMODE is false and localStorage contains msw', async () => {
+      (global as any).APP_DEVMODE = false;
+      localStorage.setItem(ENV_OVERRIDE_LOCALSTORAGE_KEY, 'msw');
+
+      const { default: config } = await import('./config');
+      await config.fetchConfig(mockChrome as Chrome);
+
+      expect(config.envOverride).toBeUndefined();
+      expect(config.configData.apiGateway).toBe('https://api.openshift.com');
+    });
+
+    it('sets envOverride to msw and persists to localStorage when APP_DEVMODE is true and ?env=msw is in the URL', async () => {
+      (global as any).APP_DEVMODE = true;
+      window.history.pushState({}, '', '?env=msw');
+
+      const { default: config } = await import('./config');
+      await config.fetchConfig(mockChrome as Chrome);
+
+      expect(config.envOverride).toBe('msw');
+      expect(localStorage.getItem(ENV_OVERRIDE_LOCALSTORAGE_KEY)).toBe('msw');
+    });
+
+    it('ignores ?env=msw in the URL and uses default config when APP_DEVMODE is false', async () => {
+      (global as any).APP_DEVMODE = false;
+      window.history.pushState({}, '', '?env=msw');
+
+      const { default: config } = await import('./config');
+      await config.fetchConfig(mockChrome as Chrome);
+
+      expect(config.envOverride).toBeUndefined();
+      expect(localStorage.getItem(ENV_OVERRIDE_LOCALSTORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,8 @@ const parseEnvQueryParam = (): string | undefined => {
         ret = val;
       } else if (key === 'env' && val === 'mockserver' && configs.mockdata) {
         ret = 'mockdata';
+      } else if (key === 'env' && val === 'msw') {
+        ret = 'msw';
       }
     });
   return ret;
@@ -162,7 +164,14 @@ const config = {
       }
 
       const queryEnv = parseEnvQueryParam() || localStorage.getItem(ENV_OVERRIDE_LOCALSTORAGE_KEY);
-      if (queryEnv && configs[queryEnv]) {
+      if (queryEnv === 'msw') {
+        configs.default?.then((data) => {
+          this.loadConfig(data, chrome);
+          that.envOverride = 'msw';
+          localStorage.setItem(ENV_OVERRIDE_LOCALSTORAGE_KEY, 'msw');
+          resolve();
+        });
+      } else if (queryEnv && configs[queryEnv]) {
         configs[queryEnv]!.then((data) => {
           this.loadConfig(data, chrome);
           // eslint-disable-next-line no-console

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ const parseEnvQueryParam = (): string | undefined => {
         ret = val;
       } else if (key === 'env' && val === 'mockserver' && configs.mockdata) {
         ret = 'mockdata';
-      } else if (key === 'env' && val === 'msw') {
+      } else if (key === 'env' && val === 'msw' && APP_DEVMODE) {
         ret = 'msw';
       }
     });
@@ -164,7 +164,7 @@ const config = {
       }
 
       const queryEnv = parseEnvQueryParam() || localStorage.getItem(ENV_OVERRIDE_LOCALSTORAGE_KEY);
-      if (queryEnv === 'msw') {
+      if (queryEnv === 'msw' && APP_DEVMODE) {
         configs.default?.then((data) => {
           this.loadConfig(data, chrome);
           that.envOverride = 'msw';

--- a/src/mocks/MSWPlugin.js
+++ b/src/mocks/MSWPlugin.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Webpack plugin that emits mockServiceWorker.js into the build output.
+ * The dev server serves the output directory at /, so the file becomes
+ * available at /mockServiceWorker.js without touching the mockdata server.
+ * Only used in development — excluded from production builds via fec.config.js.
+ */
+class MSWPlugin {
+  apply(compiler) {
+    compiler.hooks.emit.tapAsync('MSWPlugin', (compilation, callback) => {
+      const content = fs.readFileSync(path.resolve(__dirname, '../../public/mockServiceWorker.js'));
+      compilation.emitAsset(
+        'mockServiceWorker.js',
+        new compiler.webpack.sources.RawSource(content),
+      );
+      callback();
+    });
+  }
+}
+
+module.exports = MSWPlugin;

--- a/src/mocks/MSWPlugin.js
+++ b/src/mocks/MSWPlugin.js
@@ -4,10 +4,11 @@ const fs = require('fs');
 /**
  * Webpack plugin that emits mockServiceWorker.js into the build output.
  * The dev server serves the output directory at /, so the file becomes
- * available at /mockServiceWorker.js without touching the mockdata server.
+ * available at /mockServiceWorker.js.
  * Only used in development — excluded from production builds via fec.config.js.
  */
 class MSWPlugin {
+  // eslint-disable-next-line class-methods-use-this -- Webpack plugin interface requires apply() to be an instance method; it intentionally does not use `this`
   apply(compiler) {
     compiler.hooks.emit.tapAsync('MSWPlugin', (compilation, callback) => {
       const content = fs.readFileSync(path.resolve(__dirname, '../../public/mockServiceWorker.js'));

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from 'msw/browser';
+
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.post('*/api/authorizations/v1/self_access_review', () => {
+    return HttpResponse.json({
+      account_id: '2K89szemF25dKqb0w16cdfucF92',
+      action: 'create',
+      allowed: false,
+      cluster_id: '',
+      cluster_uuid: '',
+      organization_id: '',
+      reason: '',
+      resource_type: 'Cluster',
+      subscription_id: '',
+    });
+  }),
+];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,8 +1,8 @@
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  http.post('*/api/authorizations/v1/self_access_review', () => {
-    return HttpResponse.json({
+  http.post('*/api/authorizations/v1/self_access_review', () =>
+    HttpResponse.json({
       account_id: '2K89szemF25dKqb0w16cdfucF92',
       action: 'create',
       allowed: false,
@@ -12,6 +12,6 @@ export const handlers = [
       reason: '',
       resource_type: 'Cluster',
       subscription_id: '',
-    });
-  }),
+    }),
+  ),
 ];


### PR DESCRIPTION
# Summary

Integrates [Mock Service Worker (MSW)](https://mswjs.io/) into the dev environment as an opt-in request interception layer. This enables local development against mocked API responses without requiring backend or proxy access.

**What was added:**
- `MSWPlugin` — a custom Webpack plugin that emits `mockServiceWorker.js` into the build output at `/`, making it available for service worker registration. Active in dev only (`NODE_ENV !== 'production'`).
- `src/mocks/handlers.ts` — MSW request handlers (currently mocks `POST /api/authorizations/v1/self_access_review` → `allowed: false` as a proof of concept).
- `src/mocks/browser.ts` — sets up the MSW browser worker with the defined handlers.
- MSW is activated via the existing `?env=msw` query param (or `localStorage`), consistent with the `mockdata` env toggle pattern.

**Config changes:**
- `fec.config.js`: registers `MSWPlugin` and adds a `/mockServiceWorker.js` proxy route.
- `src/config.ts`: handles the `msw` env value in `parseEnvQueryParam` and persists it to `localStorage`.
- `src/chrome-main.tsx`: starts the MSW worker on app init when the `msw` env is active.

Assisted by: Claude Sonnet 4.6

### Future work:

- Integrate with Storybook
- Integrate with unit tests
- Handlers structure: This PR contains only one api mock response for the POC. As we will be adding many other mocks, we will need to come up with a maintainable structure for the handlers files. 
Suggestions:  1. Group them by domain - ROSA, HCP, GCP, Wizard (?) , Permissions (?) . 2. Group by UI areas - Cluster list, Cluster Details, OSD Wizard, ROSA wizard etc

# Jira

https://redhat.atlassian.net/browse/OCMUI-3798

# Additional information

- MSW is completely tree-shaken from production builds — `MSWPlugin` is guarded by `NODE_ENV !== 'production'` and `src/mocks/` files are only imported under the `APP_DEVMODE` guard.
- The `msw` env toggle follows the same pattern as the existing `mockdata` toggle (`?env=mockdata`) so it integrates naturally with the existing env-override mechanism.
- The MSW handler must use a `*/api/...` wildcard prefix (not a relative path) because `authInterceptor` prepends an absolute base URL before requests are dispatched.

# How to Test

**Prerequisites — trust the Caddy local CA **

The FEC dev proxy runs behind a container-based reverse proxy with a self-signed local CA. Browsers require a trusted TLS certificate to register a service worker — there is no click-through bypass. Without this setup, MSW will silently fail to register.

**Step 1 — extract the cert from the running container** (same on all platforms, requires `npm run start` to be running):
```bash
podman exec frontend-development-proxy find / -name "root.crt" 2>/dev/null
podman exec frontend-development-proxy cat <path-from-above> > caddy-root.crt
```

**Step 2 — trust the cert (platform-specific):**

_macOS:_
```bash
sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain caddy-root.crt
```

_Linux (Fedora/RHEL):_
```bash
certutil -d ~/.pki/nssdb -A -n "Caddy Local Authority" -t "CT,," -i caddy-root.crt
```

**Step 3 — fully restart the browser** — the cert store is read at startup; a tab refresh is not enough.

**Step 4 — clear Chrome's stored HSTS policy** for `prod.foo.redhat.com`:
- Go to `chrome://net-internals/#hsts`
- Under "Delete domain security policies", enter `prod.foo.redhat.com` and delete
- This is needed because the proxy sets a `Strict-Transport-Security` header; if Chrome stored it from a previous session, any cert issue becomes an unbypassable hard error

**Steps:**

1. Open the app and append `?env=msw` to the URL.
3. Open DevTools → Application → Service Workers — confirm `mockServiceWorker.js` is registered.
4. Navigate to the Overview page — the **Create cluster** buttons for ROSA and OSD should be **disabled**, because the mocked `self_access_review` returns `allowed: false`, simulating a state where the user doesn't have enough permissions to create a cluster.
5. Remove `?env=msw` (or clear `localStorage`) to restore normal behavior.

# Screen Captures

| Before | After |
|---|---|
| <img width="1622" height="698" alt="image" src="https://github.com/user-attachments/assets/ddb98817-361a-4f8d-b137-d7ddba249af9" /> | <img width="1627" height="768" alt="image" src="https://github.com/user-attachments/assets/34f2bfe5-a06b-4fc8-8509-0aa41bc3a059" /> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation