### PR TITLE
[NO-JIRA]: Fix formatting inside AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Some parts of the application are legacy code, using JavaScript and Redux for gl
 
 All documents are located inside `/docs`. Read the relevant file before writing or reviewing code.
 
+```text
 root: docs/
 
 UI-components:              code-guide.md
@@ -15,10 +16,9 @@ contributing:               contributing.md
 unit-testing:               unit-testing.md
 e2e-testing:                Playwright-e2e-test-automation-guidelines.md
 e2e-testing FAQ:            Playwright-e2e-test-automation-faq.md
+```
 
-root: openapi/
-
-API types and generation:   README.md
+For information about the generation of TS models from OpenAPI specs, check the `/openapi/README.md` doc.
 
 ## Project structure
 


### PR DESCRIPTION
# Summary

Just fixing the formatting to make it easier to read docs links.

# Jira

no jira

# Additional information

NA

# How to Test

Nothing to test besides checking that when opening AGENTS.md within github, the docs are easier to read.

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <!-- attach a "before" screenshot or video here --> | <!-- attach an "after" capture here --> |

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation
