### PR TITLE
OCMUI-4579: Update documentation link in AddGrantModal

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 
 import { Form, FormGroup, Radio, TextInput } from '@patternfly/react-core';
 
-import installLinks from '~/common/installLinks.mjs';
+import docLinks from '~/common/docLinks.mjs';
 import { validateUserOrGroupARN } from '~/common/validators';
 import ErrorBox from '~/components/common/ErrorBox';
 import { FormGroupHelperText } from '~/components/common/FormGroupHelperText';
@@ -131,11 +131,7 @@ const AddGrantModal = ({
                   hint={
                     <div>
                       <p>Need help configuring ARNs?</p>
-                      <a
-                        href={installLinks.AWS_ARN_CONFIG}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                      >
+                      <a href={docLinks.AWS_ARN_CONFIG} target="_blank" rel="noreferrer noopener">
                         Check the AWS documentation.
                       </a>
                     </div>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/AccessControl/NetworkSelfServiceSection/AddGrantModal/AddGrantModal.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import * as reactRedux from 'react-redux';
+
+import docLinks from '~/common/docLinks.mjs';
+import { useGlobalState } from '~/redux/hooks';
+import { render, screen } from '~/testUtils';
+
+import AddGrantModal from './AddGrantModal';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('~/redux/hooks', () => ({
+  useGlobalState: jest.fn(),
+}));
+
+describe('<AddGrantModal />', () => {
+  const useDispatchMock = jest.spyOn(reactRedux, 'useDispatch');
+  const useGlobalStateMock = useGlobalState;
+
+  const defaultProps = {
+    addGrantsMutate: jest.fn(),
+    roles: [
+      {
+        id: 'network-mgmt',
+        displayName: 'Network Management',
+        description: 'Manage network resources',
+      },
+    ],
+    isAddGrantsPending: false,
+    isAddGrantsError: false,
+    addGrantsError: null,
+    resetAddGrantsMutate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    useDispatchMock.mockReturnValue(jest.fn());
+    useGlobalStateMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the AWS ARN documentation link in the help popover', async () => {
+    const { user } = render(<AddGrantModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: 'More information' }));
+
+    const link = screen.getByRole('link', { name: 'Check the AWS documentation.' });
+    expect(link).toHaveAttribute('href', docLinks.AWS_ARN_CONFIG);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer noopener');
+  });
+});


### PR DESCRIPTION
# Summary
The link broke on Grant AWS infrastructure role modal when we refactor the link files.  No big deal, just needed to update which link file was being imported and referenced.

- Replaced the import of installLinks with docLinks in AddGrantModal component.
- Updated the help popover to use the new documentation link.
- Added unit tests for AddGrantModal to ensure the documentation link renders correctly.


Assisted by: Cursor/composer-fast

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-4579](https://issues.redhat.com/browse/OCMUI-4579)

# How to Test

1. Build an OSD AWS nonCCS cluster using the OSD wizard
2. From Cluster List, Go to [Create cluster-> Create osd cluster](https://prod.foo.redhat.com:1337/openshift/create/osd) 
3. Select Annual and Red Hat cloud account for Infrastructure type
4.  From there, select all default values and create the cluster
5. Cluster will take a long time to build - like an hour.  Go get coffee or a snack and come back here when the cluster is ready
6. When it is ready, go to the cluster details page and then select "Access control" tab
7. On the lower left, select "AWS infrastructure access". Click "Grant role"
8. Next to the sub title "AWS IAM ARN" is a ? pop over.  Click that ?
9. The pop over text will have a link "[Check the AWS documentation.](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)"
10. Verify that link works when click

# Screen Captures
<img width="785" height="688" alt="Screenshot From 2026-06-30 13-05-56" src="https://github.com/user-attachments/assets/0f7685fe-3b33-4255-9e87-d0872345ae40" />


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4579]: https://redhat.atlassian.net/browse/OCMUI-4579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ