### PR TITLE
OCMUI-4315: Refactor CreateOsdWizardFooter and CreateRosaWizardFooter to repositi…

### DIFF
--- a/src/components/clusters/wizards/osd/CreateOsdWizardFooter.tsx
+++ b/src/components/clusters/wizards/osd/CreateOsdWizardFooter.tsx
@@ -120,9 +120,6 @@ export const CreateOsdWizardFooter = ({
     <WizardFooterWrapper>
       <ActionList>
         <ActionListGroup>
-          <CreateManagedClusterButtonWithTooltip wrap>
-            {primaryBtn}
-          </CreateManagedClusterButtonWithTooltip>
           <ActionListItem>
             <Button
               variant="secondary"
@@ -133,6 +130,9 @@ export const CreateOsdWizardFooter = ({
               Back
             </Button>
           </ActionListItem>
+          <CreateManagedClusterButtonWithTooltip wrap>
+            {primaryBtn}
+          </CreateManagedClusterButtonWithTooltip>
         </ActionListGroup>
         <ActionListGroup>
           <ActionListItem>

--- a/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.jsx
+++ b/src/components/clusters/wizards/rosa/CreateRosaWizardFooter.jsx
@@ -170,10 +170,6 @@ const CreateRosaWizardFooter = ({
     <WizardFooterWrapper>
       <ActionList>
         <ActionListGroup>
-          <CreateManagedClusterButtonWithTooltip wrap>
-            {primaryBtn}
-          </CreateManagedClusterButtonWithTooltip>
-
           <ActionListItem>
             <Button
               variant="secondary"
@@ -184,6 +180,9 @@ const CreateRosaWizardFooter = ({
               Back
             </Button>
           </ActionListItem>
+          <CreateManagedClusterButtonWithTooltip wrap>
+            {primaryBtn}
+          </CreateManagedClusterButtonWithTooltip>
         </ActionListGroup>
         <ActionListGroup>
           <ActionListItem>


### PR DESCRIPTION
# Summary

Refactor CreateOsdWizardFooter and CreateRosaWizardFooter to reposition Back and Next button for improved layout consistency.

This order matches the [PF6 guidelines for wizards](https://www.patternfly.org/components/wizard)

# Jira

Fixes [OCMUI-4315](https://issues.redhat.com/browse/OCMUI-4315) 


# How to Test

1. Go to the OSD wizard.  Verify that back is first and Next is second on the butons
2. Go to the ROSA wizard. Verify that back is first and Next is second on the butons

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1114" height="542" alt="osd-before-fix" src="https://github.com/user-attachments/assets/2ed44f2a-db27-4154-a0ee-9c06dd86f0ad" /> | <img width="1114" height="542" alt="osd-after-fix" src="https://github.com/user-attachments/assets/dd8a6b15-d1c6-49af-98d7-65a3a5e40a46" /> |
| <img width="1114" height="542" alt="rosa-before-fix" src="https://github.com/user-attachments/assets/201d029e-b511-46cb-987f-e0fc4ad88b61" /> | <img width="1114" height="542" alt="rosa-after-fix" src="https://github.com/user-attachments/assets/5c3b54de-8a4d-4b75-a1c8-b7b1f89628bc" /> |



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4315]: https://redhat.atlassian.net/browse/OCMUI-4315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ