### PR TITLE
OCMUI-3288: Enhance HTPasswd username validation logic

### DIFF
--- a/playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts
+++ b/playwright/e2e/access-control/identity-provider-htpasswd-manual.spec.ts
@@ -12,6 +12,7 @@ const manualProfile = htpasswdProfile.Htpasswd.Manual;
 // Short suffix makes each run's IDP names unique, preventing collisions on retries or shared clusters.
 const runId = Math.random().toString(36).slice(2, 5);
 const htpasswdIdpNames = [`HtpasswdSingleUser-${runId}`, `HtpasswdMultipleUsers-${runId}`];
+const singleUserUsername = manualProfile.Usernames.ValidUsernameWithSpaces;
 // >10 users required to exercise per-page-10 pagination; +1 extra reserved for the add-user edit modal test
 const BULK_USER_COUNT = 15;
 const bulkUsers = Array.from({ length: BULK_USER_COUNT + 1 }, (_, i) => `ocmplaywright${i + 1}`);
@@ -85,6 +86,12 @@ test.describe.serial(
         clusterIdentityProviderPage.getByText(manualProfile.Usernames.InValidUserNameError),
       ).toBeVisible();
 
+      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(singleUserUsername);
+      await clusterIdentityProviderPage.htpasswdUsernameInput().blur();
+      await expect(
+        clusterIdentityProviderPage.getByText(manualProfile.Usernames.InValidUserNameError),
+      ).not.toBeVisible();
+
       for (const info of manualProfile.Password.DefaultPasswordInformation) {
         await expect(clusterIdentityProviderPage.getByText(info)).toBeVisible();
       }
@@ -102,7 +109,7 @@ test.describe.serial(
       await clusterIdentityProviderPage.openHtpasswdForm();
 
       await clusterIdentityProviderPage.htpasswdNameInput().fill(htpasswdIdpNames[0]);
-      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(bulkUsers[1]);
+      await clusterIdentityProviderPage.htpasswdUsernameInput().fill(singleUserUsername);
       await clusterIdentityProviderPage.fillSuggestedPassword();
       await clusterIdentityProviderPage.fillSuggestedConfirmPassword();
 

--- a/playwright/fixtures/access-control/identity-provider-htpasswd.json
+++ b/playwright/fixtures/access-control/identity-provider-htpasswd.json
@@ -12,7 +12,8 @@
       "Usernames": {
         "EmptyUserNameError": "Username is required",
         "InvalidUserNameInput": ["Osd%Rosa:asd", "1234567890"],
-        "InValidUserNameError": "Username must not contain /, :, %, or empty spaces.",
+        "InValidUserNameError": "Username must not contain /, :, or %.",
+        "ValidUsernameWithSpaces": " playwright user ",
         "DefaultUsernameInformation": "Unique name of the user within the cluster.",
         "NoMatchingUserName": "No results found"
       },

--- a/src/common/__tests__/validators.test.ts
+++ b/src/common/__tests__/validators.test.ts
@@ -1320,14 +1320,17 @@ describe('HTPasswd password', () => {
 });
 
 describe('HTPasswd username', () => {
-  const validationErrorMessage = 'Username must not contain /, :, %, or empty spaces.';
   it.each([
     ['username1234', undefined],
-    ['username%', validationErrorMessage],
-    ['username:', validationErrorMessage],
-    ['username/', validationErrorMessage],
-    ['username1  ', validationErrorMessage],
-    [' ', validationErrorMessage],
+    ['user name', undefined],
+    ['username1  ', undefined],
+    ['     ', undefined],
+    ['username%', 'Username must not contain /, :, or %.'],
+    ['username:', 'Username must not contain /, :, or %.'],
+    ['username/', 'Username must not contain /, :, or %.'],
+    ['', 'Username is required.'],
+    ['a'.repeat(255), undefined],
+    ['a'.repeat(256), 'Username may not exceed 255 characters.'],
   ])('value %p to be %p', (value: string, expected: string | undefined) => {
     expect(validateHTPasswdUsername(value)).toBe(expected);
   });

--- a/src/common/validators.ts
+++ b/src/common/validators.ts
@@ -1663,15 +1663,25 @@ const validateUniqueHTPasswdUsername = (fields: { name: string }[]) => {
   return undefined;
 };
 
+const MAX_HTPASSWD_USERNAME_LENGTH = 255;
+
 const validateHTPasswdUsername = (username: string): string | undefined => {
+  if (!username) {
+    return 'Username is required.';
+  }
+
   if (
     indexOf(username, '%') !== -1 ||
     indexOf(username, ':') !== -1 ||
-    indexOf(username, '/') !== -1 ||
-    indexOf(username, ' ') !== -1
+    indexOf(username, '/') !== -1
   ) {
-    return 'Username must not contain /, :, %, or empty spaces.';
+    return 'Username must not contain /, :, or %.';
   }
+
+  if (username.length > MAX_HTPASSWD_USERNAME_LENGTH) {
+    return `Username may not exceed ${MAX_HTPASSWD_USERNAME_LENGTH} characters.`;
+  }
+
   return undefined;
 };
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.test.ts
@@ -63,6 +63,23 @@ describe('htpasswdFileParser', () => {
       expect(result.errors[0]).toBe('Line 1: Password cannot be empty.');
     });
 
+    it('accepts usernames up to 255 characters', () => {
+      const username = 'a'.repeat(255);
+      const content = `${username}:$2y$05$hash123`;
+      const result = parseHTPasswdFile(content);
+      expect(result.users).toEqual([{ username, password: '$2y$05$hash123' }]);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('reports error for usernames longer than 255 characters', () => {
+      const username = 'a'.repeat(256);
+      const content = `${username}:$2y$05$hash123`;
+      const result = parseHTPasswdFile(content);
+      expect(result.users).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBe('Line 1: Username may not exceed 255 characters.');
+    });
+
     it('reports error for duplicate usernames', () => {
       const content = 'admin:$2y$05$hash1\nuser:$apr1$salt$hash2\nadmin:$2y$05$hash3';
       const result = parseHTPasswdFile(content);
@@ -106,10 +123,17 @@ describe('htpasswdFileParser', () => {
       expect(result.errors).toHaveLength(0);
     });
 
-    it('trims whitespace from lines, usernames, and passwords', () => {
+    it('trims whitespace from passwords but preserves username spacing', () => {
       const content = '  user1 : $2y$05$hash1  ';
       const result = parseHTPasswdFile(content);
-      expect(result.users[0]).toEqual({ username: 'user1', password: '$2y$05$hash1' });
+      expect(result.users[0]).toEqual({ username: '  user1 ', password: '$2y$05$hash1' });
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('preserves leading and trailing spaces in usernames', () => {
+      const content = ' user name :$2y$05$hash123';
+      const result = parseHTPasswdFile(content);
+      expect(result.users).toEqual([{ username: ' user name ', password: '$2y$05$hash123' }]);
       expect(result.errors).toHaveLength(0);
     });
 

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.test.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.test.ts
@@ -137,6 +137,13 @@ describe('htpasswdFileParser', () => {
       expect(result.errors).toHaveLength(0);
     });
 
+    it('accepts usernames containing only spaces', () => {
+      const content = '   :$2y$05$hash123';
+      const result = parseHTPasswdFile(content);
+      expect(result.users).toEqual([{ username: '   ', password: '$2y$05$hash123' }]);
+      expect(result.errors).toHaveLength(0);
+    });
+
     it('reports error for plain text passwords', () => {
       const content = 'test:JKN@#$123';
       const result = parseHTPasswdFile(content);

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.ts
@@ -35,7 +35,7 @@ export const parseHTPasswdFile = (content: string): HTPasswdParseResult => {
     const username = rawLine.substring(0, colonIndex);
     const password = rawLine.substring(colonIndex + 1).trim();
 
-    if (!username.trim()) {
+    if (username.length === 0) {
       errors.push(`Line ${index + 1}: Username cannot be empty.`);
       return;
     }

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.ts
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/IdentityProvidersPage/components/ProvidersForms/htpasswdFileParser.ts
@@ -1,3 +1,5 @@
+import { validateHTPasswdUsername } from '~/common/validators';
+
 export type ParsedHTPasswdUser = {
   username: string;
   password: string;
@@ -19,22 +21,28 @@ export const parseHTPasswdFile = (content: string): HTPasswdParseResult => {
   const seenUsernames = new Set<string>();
 
   lines.forEach((rawLine, index) => {
-    const line = rawLine.trim();
-    if (line === '' || line.startsWith('#')) {
+    const trimmedLine = rawLine.trim();
+    if (trimmedLine === '' || trimmedLine.startsWith('#')) {
       return;
     }
 
-    const colonIndex = line.indexOf(':');
+    const colonIndex = rawLine.indexOf(':');
     if (colonIndex === -1) {
       errors.push(`Line ${index + 1}: Invalid format. Expected "username:password".`);
       return;
     }
 
-    const username = line.substring(0, colonIndex).trim();
-    const password = line.substring(colonIndex + 1).trim();
+    const username = rawLine.substring(0, colonIndex);
+    const password = rawLine.substring(colonIndex + 1).trim();
 
-    if (!username) {
+    if (!username.trim()) {
       errors.push(`Line ${index + 1}: Username cannot be empty.`);
+      return;
+    }
+
+    const usernameError = validateHTPasswdUsername(username);
+    if (usernameError) {
+      errors.push(`Line ${index + 1}: ${usernameError}`);
       return;
     }
 


### PR DESCRIPTION
# Summary
The UI and CLI did not match for htpasswd usernames.  Based on the htpasswd standards, spaces should be allowed so I have updated the code to allow spaces in the username or as a username - i.e. "     " (valid by standards)

- Added a maximum length check for HTPasswd usernames (255 characters).
- Updated validation messages for empty usernames and invalid characters.
- Adjusted unit tests to reflect new validation rules and edge cases.



<!-- add a summarized description of the PR content -->

<!-- add information about AI usage if substantial contributions are generated/assisted by AI tools -->
<!-- for example: Assisted by: Cursor/gemini-2.5-pro -->

# Jira

<!-- link to the corresponding Jira item -->
Fixes [OCMUI-3288](https://issues.redhat.com/browse/OCMUI-3288)

# Additional information

Refer to the jira ticket to see the CLI commands if you want to test the CLI

# How to Test

1.  Build an HCP cluster
2. When ready, go to cluster details-> "Access control" tab
3. On the sub menu "Identity providers", Add a htpasswd IDP
4. Validate that the username can be spaces or have some like "test user 1".  Please realize that in an ASCII file " " (1 space_ is different thn "  " (2 spaces).  So you could have a real fun list of usernames.
5. Validate the username cannot be left empty
6. If you are bored, validate that you cannot have more than 255 characters.

# Screen shots
Valid usernames (2 spaces, 3 spaces, 4 spaces):
<img width="1114" height="542" alt="Screenshot From 2026-06-30 15-51-22" src="https://github.com/user-attachments/assets/25a7f294-7531-419d-90d6-a06c16941ecf" />

Username with spaces:
<img width="1110" height="311" alt="Screenshot From 2026-06-30 15-53-30" src="https://github.com/user-attachments/assets/cb8d5e7b-fb1c-4bab-ae95-127901665292" />

Username
<img width="1110" height="311" alt="Screenshot From 2026-06-30 15-53-50" src="https://github.com/user-attachments/assets/b1bb8511-6005-41e2-9ffa-d39cd9090824" />
 with more than 255 chars:



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-3288]: https://redhat.atlassian.net/browse/OCMUI-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ