### PR TITLE
OCMUI-1492: Add OSD hibernating cluster documentation link and update related components

### DIFF
--- a/src/common/docLinks.mjs
+++ b/src/common/docLinks.mjs
@@ -127,6 +127,7 @@ const docLinks = {
   AWS_SPOT_INSTANCES: `${OCP_DOCS_BASE}/machine_management/managing-compute-machines-with-the-machine-api#machineset-non-guaranteed-instance_creating-machineset-aws`,
   COSTMGMT_ADDING_OCP: `${COSTMGMT_DOCS_BASE}/integrating_openshift_container_platform_data_into_cost_management/index`,
   UPDATING_CLUSTER: `${OCP_DOCS_BASE}/updating_clusters/performing-a-cluster-update#updating-cluster-web-console`,
+  OCP_HIBERNATING_CLUSTER: `${OCP_DOCS_BASE}/backup_and_restore/hibernating-cluster`,
 
   // AWS
   AWS_CLI: 'https://aws.amazon.com/cli/',

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropDownItems.test.jsx
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropDownItems.test.jsx
@@ -81,6 +81,28 @@ describe('Cluster Actions Dropdown Items', () => {
       });
     });
 
+    it('passes isROSA when opening hibernate cluster modal for ROSA cluster', async () => {
+      const rosaClusterProps = {
+        ...Fixtures.managedReadyProps,
+        cluster: {
+          ...Fixtures.managedReadyProps.cluster,
+          product: { id: 'ROSA' },
+          subscription: { id: 'subscription-id', plan: { type: 'ROSA' } },
+        },
+      };
+      const { user } = render(<DropDownItemsRenderHelper {...rosaClusterProps} />);
+
+      await user.click(screen.getByRole('menuitem', { name: 'Hibernate cluster' }));
+
+      expect(Fixtures.managedReadyProps.openModal).toHaveBeenCalledWith('hibernate-cluster', {
+        clusterID: Fixtures.managedReadyProps.cluster.id,
+        clusterName: Fixtures.managedReadyProps.cluster.name,
+        subscriptionID: 'subscription-id',
+        isROSA: true,
+        shouldDisplayClusterName: false,
+      });
+    });
+
     it('should open delete modal', async () => {
       const { user } = render(<DropDownItemsRenderHelper {...Fixtures.managedReadyProps} />);
       expect(Fixtures.managedReadyProps.openModal).toHaveBeenCalledTimes(0);
@@ -183,6 +205,20 @@ describe('Cluster Actions Dropdown Items', () => {
         <DropDownItemsRenderHelper {...Fixtures.clusterHibernatingProps} />,
       );
       await checkAccessibility(container);
+    });
+
+    it('passes isROSA when opening resume cluster modal', async () => {
+      const { user } = render(<DropDownItemsRenderHelper {...Fixtures.clusterHibernatingProps} />);
+
+      await user.click(screen.getByRole('menuitem', { name: 'Resume from Hibernation' }));
+
+      expect(Fixtures.clusterHibernatingProps.openModal).toHaveBeenCalledWith('resume-cluster', {
+        clusterID: Fixtures.clusterHibernatingProps.cluster.id,
+        clusterName: Fixtures.clusterHibernatingProps.cluster.name,
+        subscriptionID: Fixtures.clusterHibernatingProps.cluster.subscription.id,
+        isROSA: false,
+        shouldDisplayClusterName: false,
+      });
     });
 
     it.each([

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdown.fixtures.js
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdown.fixtures.js
@@ -64,6 +64,7 @@ const hibernateClusterModalData = {
   clusterID: cluster.id,
   clusterName: cluster.name,
   subscriptionID: cluster.subscription.id,
+  isROSA: false,
 };
 
 const deleteModalData = {

--- a/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
+++ b/src/components/clusters/common/ClusterActionsDropdown/ClusterActionsDropdownItems.jsx
@@ -10,7 +10,7 @@ import getClusterName from '../../../../common/getClusterName';
 import { isAssistedInstallCluster } from '../../../../common/isAssistedInstallerCluster';
 import { normalizedProducts } from '../../../../common/subscriptionTypes';
 import modals from '../../../common/Modal/modals';
-import clusterStates, { isHibernating, isHypershiftCluster } from '../clusterStates';
+import clusterStates, { isHibernating, isHypershiftCluster, isROSA } from '../clusterStates';
 
 /**
  * Helper using reason message why it's disabled as source-of-truth
@@ -120,6 +120,7 @@ function actionResolver(
       clusterName,
       subscriptionID: cluster.subscription ? cluster.subscription.id : '',
       shouldDisplayClusterName: inClusterList,
+      isROSA: isROSA(cluster),
     };
     const hibernateClusterProps = {
       ...hibernateClusterBaseProps,

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterContent.test.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterContent.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import docLinks from '~/common/docLinks.mjs';
+import supportLinks from '~/common/supportLinks.mjs';
+import { render, screen } from '~/testUtils';
+
+import HibernateClusterContent from './HibernateClusterContent';
+
+describe('HibernateClusterContent', () => {
+  const clusterName = 'test-cluster';
+  const linkText = /Learn more about cluster hibernation/;
+
+  it.each([
+    [false, false, docLinks.OCP_HIBERNATING_CLUSTER],
+    [false, true, docLinks.OCP_HIBERNATING_CLUSTER],
+    [true, false, supportLinks.HIBERNATING_CLUSTER],
+    [true, true, supportLinks.HIBERNATING_CLUSTER],
+  ])(
+    'renders expected doc link when isROSA is %s and isHibernating is %s',
+    (isROSA, isHibernating, expectedHref) => {
+      render(
+        <HibernateClusterContent
+          clusterName={clusterName}
+          isHibernating={isHibernating}
+          isROSA={isROSA}
+        />,
+      );
+
+      expect(screen.getByText(linkText)).toHaveAttribute('href', expectedHref);
+    },
+  );
+});

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterContent.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterContent.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 import { Content, List, ListItem } from '@patternfly/react-core';
 
+import docLinks from '~/common/docLinks.mjs';
 import supportLinks from '~/common/supportLinks.mjs';
 import ExternalLink from '~/components/common/ExternalLink';
 
-const HibernateInfoLink = () => (
-  <ExternalLink href={supportLinks.HIBERNATING_CLUSTER}>
+const HibernateInfoLink = ({ isROSA }: { isROSA: boolean }) => (
+  <ExternalLink href={isROSA ? supportLinks.HIBERNATING_CLUSTER : docLinks.OCP_HIBERNATING_CLUSTER}>
     Learn more about cluster hibernation
   </ExternalLink>
 );
@@ -14,9 +15,11 @@ const HibernateInfoLink = () => (
 const HibernateClusterContent = ({
   clusterName,
   isHibernating,
+  isROSA,
 }: {
   clusterName: string;
   isHibernating: boolean;
+  isROSA: boolean;
 }) =>
   isHibernating ? (
     <Content>
@@ -24,7 +27,7 @@ const HibernateClusterContent = ({
         Cluster <strong>{clusterName}</strong> will move out of Hibernating state and all cluster
         operations will be resumed.
       </Content>
-      <HibernateInfoLink />
+      <HibernateInfoLink isROSA={isROSA} />
     </Content>
   ) : (
     <>
@@ -37,7 +40,7 @@ const HibernateClusterContent = ({
           It&apos;s recommended to hibernate only clusters that run recoverable workloads.
         </ListItem>
       </List>
-      <HibernateInfoLink />
+      <HibernateInfoLink isROSA={isROSA} />
       <Content>
         <Content component="p">
           Are you sure you want to hibernate <strong>{clusterName}</strong>?

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.test.jsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import * as reactRedux from 'react-redux';
 
+import docLinks from '~/common/docLinks.mjs';
+import supportLinks from '~/common/supportLinks.mjs';
 import * as useHibernateCluster from '~/queries/ClusterActionsQueries/useHibernateCluster';
 import * as useGetSchedules from '~/queries/ClusterDetailsQueries/ClusterSettingsTab/useGetSchedules';
 import { checkAccessibility, screen, withState } from '~/testUtils';
@@ -195,6 +197,35 @@ describe('<HibernateClusterModal />', () => {
       expect(
         screen.getByRole('button', { name: 'Change cluster upgrade policy' }),
       ).toBeInTheDocument();
+    });
+
+    it('renders OCP hibernation doc link when cluster is not ROSA', () => {
+      mockedUseGetSchedules.mockReturnValue(useGetSchedulesReturnData);
+      mockedUseHibernateCluster.mockReturnValue(useHibernateClusterReturnData);
+      withState(defaultReduxState).render(<HibernateClusterModal {...defaultProps} />);
+
+      expect(screen.getByText(/Learn more about cluster hibernation/)).toHaveAttribute(
+        'href',
+        docLinks.OCP_HIBERNATING_CLUSTER,
+      );
+    });
+
+    it('renders ROSA hibernation support link when cluster is ROSA', () => {
+      mockedUseGetSchedules.mockReturnValue(useGetSchedulesReturnData);
+      mockedUseHibernateCluster.mockReturnValue(useHibernateClusterReturnData);
+      withState({
+        modal: {
+          data: {
+            ...defaultReduxState.modal.data,
+            isROSA: true,
+          },
+        },
+      }).render(<HibernateClusterModal {...defaultProps} />);
+
+      expect(screen.getByText(/Learn more about cluster hibernation/)).toHaveAttribute(
+        'href',
+        supportLinks.HIBERNATING_CLUSTER,
+      );
     });
   });
 });

--- a/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
+++ b/src/components/clusters/common/HibernateClusterModal/HibernateClusterModal.tsx
@@ -32,6 +32,7 @@ const HibernateClusterModal = ({ onClose }: HibernateClusterModalProps) => {
   const clusterName = modalData.clusterName || '';
   const subscriptionID = modalData.subscriptionID || '';
   const shouldDisplayClusterName = !!modalData.shouldDisplayClusterName;
+  const isROSA = !!modalData.isROSA;
 
   const isHypershift = isHypershiftCluster(modalData);
 
@@ -98,7 +99,7 @@ const HibernateClusterModal = ({ onClose }: HibernateClusterModalProps) => {
   } else {
     isHibernateEnabled = true;
     hibernateFormContent = (
-      <HibernateClusterContent clusterName={clusterName} isHibernating={false} />
+      <HibernateClusterContent clusterName={clusterName} isHibernating={false} isROSA={isROSA} />
     );
   }
 

--- a/src/components/clusters/common/HibernatingClusterCard/HibernatingClusterCard.jsx
+++ b/src/components/clusters/common/HibernatingClusterCard/HibernatingClusterCard.jsx
@@ -18,7 +18,7 @@ import { modalActions } from '~/components/common/Modal/ModalActions';
 
 import ButtonWithTooltip from '../../../common/ButtonWithTooltip';
 import modals from '../../../common/Modal/modals';
-import clusterStates from '../clusterStates';
+import clusterStates, { isROSA } from '../clusterStates';
 
 function HibernatingClusterCard({ cluster }) {
   const dispatch = useDispatch();
@@ -33,6 +33,7 @@ function HibernatingClusterCard({ cluster }) {
       clusterID: cluster.id,
       clusterName: cluster.name,
       subscriptionID: cluster.subscription.id,
+      isROSA: isROSA(cluster),
     };
     dispatch(modalActions.openModal(modals.RESUME_CLUSTER, clusterData));
   };

--- a/src/components/clusters/common/HibernatingClusterCard/HibernatingClusterCard.test.jsx
+++ b/src/components/clusters/common/HibernatingClusterCard/HibernatingClusterCard.test.jsx
@@ -1,24 +1,34 @@
 import React from 'react';
+import * as reactRedux from 'react-redux';
 
+import { openModal } from '~/components/common/Modal/ModalActions';
+import modals from '~/components/common/Modal/modals';
 import { checkAccessibility, render, screen } from '~/testUtils';
 
 import clusterStates from '../clusterStates';
 
 import HibernatingClusterCard from './HibernatingClusterCard';
 
-describe('<HibernateClusterModal />', () => {
-  const openModal = jest.fn();
+jest.mock('react-redux', () => {
+  const config = {
+    __esModule: true,
+    ...jest.requireActual('react-redux'),
+  };
+  return config;
+});
+
+describe('<HibernatingClusterCard />', () => {
+  const mockedDispatch = jest.fn();
+  jest.spyOn(reactRedux, 'useDispatch').mockReturnValue(mockedDispatch);
+
   const cluster = {
     id: 'test-id',
     name: 'test-cluster',
+    canEdit: true,
     subscription: {
       id: 'subscription-id',
     },
     state: clusterStates.hibernating,
-  };
-  const defaultProps = {
-    cluster,
-    openModal,
   };
 
   afterEach(() => {
@@ -26,9 +36,46 @@ describe('<HibernateClusterModal />', () => {
   });
 
   it('is accessible', async () => {
-    const { container } = render(<HibernatingClusterCard {...defaultProps} />);
+    const { container } = render(<HibernatingClusterCard cluster={cluster} />);
 
     expect(screen.getByText('Cluster is currently hibernating')).toBeInTheDocument();
     await checkAccessibility(container);
+  });
+
+  it('opens resume cluster modal with isROSA when cluster is ROSA', async () => {
+    const rosaCluster = {
+      ...cluster,
+      product: { id: 'ROSA' },
+      subscription: {
+        id: 'subscription-id',
+        plan: { type: 'ROSA' },
+      },
+    };
+
+    const { user } = render(<HibernatingClusterCard cluster={rosaCluster} />);
+    await user.click(screen.getByRole('button', { name: 'Resume from Hibernation' }));
+
+    expect(mockedDispatch).toHaveBeenCalledWith(
+      openModal(modals.RESUME_CLUSTER, {
+        clusterID: 'test-id',
+        clusterName: 'test-cluster',
+        subscriptionID: 'subscription-id',
+        isROSA: true,
+      }),
+    );
+  });
+
+  it('opens resume cluster modal with isROSA false for non-ROSA cluster', async () => {
+    const { user } = render(<HibernatingClusterCard cluster={cluster} />);
+    await user.click(screen.getByRole('button', { name: 'Resume from Hibernation' }));
+
+    expect(mockedDispatch).toHaveBeenCalledWith(
+      openModal(modals.RESUME_CLUSTER, {
+        clusterID: 'test-id',
+        clusterName: 'test-cluster',
+        subscriptionID: 'subscription-id',
+        isROSA: false,
+      }),
+    );
   });
 });

--- a/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.test.tsx
+++ b/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import * as reactRedux from 'react-redux';
 
+import docLinks from '~/common/docLinks.mjs';
+import supportLinks from '~/common/supportLinks.mjs';
 import * as useResumeCluster from '~/queries/ClusterActionsQueries/useResumeCluster';
 import { checkAccessibility, screen, withState } from '~/testUtils';
 
@@ -135,6 +137,33 @@ describe('<ResumeClusterModal />', () => {
       expect(mockedDispatch.mock.calls[0][0].type).toEqual('CLOSE_MODAL');
       expect(resetResponse).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
+    });
+
+    it('renders OCP hibernation doc link when cluster is not ROSA', () => {
+      mockedUseResumeCluster.mockReturnValue(useResumeClusterReturnData);
+      withState(defaultReduxState).render(<ResumeClusterModal {...defaultProps} />);
+
+      expect(screen.getByText(/Learn more about cluster hibernation/)).toHaveAttribute(
+        'href',
+        docLinks.OCP_HIBERNATING_CLUSTER,
+      );
+    });
+
+    it('renders ROSA hibernation support link when cluster is ROSA', () => {
+      mockedUseResumeCluster.mockReturnValue(useResumeClusterReturnData);
+      withState({
+        modal: {
+          data: {
+            ...defaultReduxState.modal.data,
+            isROSA: true,
+          },
+        },
+      }).render(<ResumeClusterModal {...defaultProps} />);
+
+      expect(screen.getByText(/Learn more about cluster hibernation/)).toHaveAttribute(
+        'href',
+        supportLinks.HIBERNATING_CLUSTER,
+      );
     });
   });
 });

--- a/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
+++ b/src/components/clusters/common/ResumeClusterModal/ResumeClusterModal.tsx
@@ -22,6 +22,7 @@ const ResumeClusterModal = ({ onClose }: ResumeClusterModalProps) => {
   const clusterID = modalData.clusterID || '';
   const clusterName = modalData.clusterName || '';
   const shouldDisplayClusterName = !!modalData.shouldDisplayClusterName;
+  const isROSA = !!modalData.isROSA;
   const region = modalData.rh_region_id;
 
   const {
@@ -63,7 +64,7 @@ const ResumeClusterModal = ({ onClose }: ResumeClusterModalProps) => {
         {resumeClusterIsError ? (
           <ErrorBox message="Error hibernating cluster" response={resumeClusterError || {}} />
         ) : null}
-        <HibernateClusterContent clusterName={clusterName} isHibernating />
+        <HibernateClusterContent clusterName={clusterName} isHibernating isROSA={isROSA} />
       </Form>
     </Modal>
   );


### PR DESCRIPTION
# Summary

- Added a new documentation link for hibernating clusters in docLinks.mjs.
- Updated hibernateClusterModal and related components to include isROSA prop for conditional rendering.
- Modified ClusterActionsDropdown and HibernatingClusterCard to pass isROSA information.
- Ensured HibernateClusterContent uses the correct link based on the isROSA flag.

# Jira

Fixes [OCMUI-1492](https://issues.redhat.com/browse/OCMUI-1492)

# Additional information

<!-- any additional information reviewers should know for example:
  - how the fix was made if not clear in the code
  - things for the reviewer to pay close attention to
  - any other approaches taken that failed
  - requests for any exceptions
 -->

# How to Test

1. Create and OSD-GCP Cluster and hibernate it when it is ready.  (You do not need to actual hibernate it to see the updated link)
2. The hibernate modal will have the updated link at the bottom

# Screen Captures
<img width="771" height="346" alt="Screenshot From 2026-07-01 13-43-21" src="https://github.com/user-attachments/assets/1d1b513b-9f79-4942-9957-1de57a6ef33a" />

# Note: OUT OF SCOPE
I cannot update the links in this alert as they are sent from the back end.
<img width="1463" height="299" alt="Screenshot From 2026-07-01 13-27-16" src="https://github.com/user-attachments/assets/8ca2ca6a-ca32-4e11-9c45-1a79138eb84b" />

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-1492]: https://redhat.atlassian.net/browse/OCMUI-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ