### PR TITLE
OCMUI-4729: Fix default billing model values to match available quota

### DIFF
--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
@@ -9,6 +9,7 @@ import { FieldId, initialValues } from '../constants';
 
 import { BillingModel } from './BillingModel';
 import { useGetBillingQuotas } from './useGetBillingQuotas';
+import { BillingQuotas, getDefaultBillingModel, getDefaultByoc } from './utils';
 
 // Mock hooks
 jest.mock('~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud');
@@ -17,31 +18,38 @@ jest.mock('~/components/clusters/wizards/osd/BillingModel/useGetBillingQuotas');
 const mockUseIsOSDFromGoogleCloud = useIsOSDFromGoogleCloud as jest.Mock;
 const mockUseGetBillingQuotas = useGetBillingQuotas as jest.Mock;
 
-const defaultQuotas = {
+const defaultQuotas: BillingQuotas = {
   osdTrial: true,
   standardOsd: true,
   marketplace: true,
   gcpResources: true,
+  awsResources: true,
   rhInfra: true,
   byoc: true,
   marketplaceRhInfra: true,
   marketplaceByoc: true,
 };
 
-const buildTestComponent = (isOSDFromGoogleCloud = false) => (
-  <Formik
-    initialValues={{
-      ...initialValues,
-      ...(isOSDFromGoogleCloud && {
-        [FieldId.BillingModel]: SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp,
-      }),
-    }}
-    initialTouched={{}}
-    onSubmit={() => {}}
-  >
-    <BillingModel />
-  </Formik>
-);
+const buildTestComponent = (isOSDFromGoogleCloud = false, quotas = defaultQuotas) => {
+  const billingModel = isOSDFromGoogleCloud
+    ? SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp
+    : getDefaultBillingModel(quotas);
+  const byoc = isOSDFromGoogleCloud ? 'true' : getDefaultByoc(quotas, billingModel);
+
+  return (
+    <Formik
+      initialValues={{
+        ...initialValues,
+        [FieldId.BillingModel]: billingModel,
+        [FieldId.Byoc]: byoc,
+      }}
+      initialTouched={{}}
+      onSubmit={() => {}}
+    >
+      <BillingModel />
+    </Formik>
+  );
+};
 
 describe('<BillingModel />', () => {
   beforeEach(() => {
@@ -93,6 +101,36 @@ describe('<BillingModel />', () => {
       expect(byocRadioCCSOption).toBeInTheDocument();
       expect(byocRadioCCSOption).toBeChecked();
     });
+
+    it('defaults to Red Hat cloud account when there is no BYOC quota', () => {
+      mockUseGetBillingQuotas.mockReturnValue({
+        ...defaultQuotas,
+        byoc: false,
+      });
+
+      render(buildTestComponent(false, { ...defaultQuotas, byoc: false }));
+
+      const rhInfraRadioOption = screen.getByRole('radio', {
+        name: /red hat cloud account/i,
+      });
+
+      expect(rhInfraRadioOption).toBeChecked();
+    });
+
+    it('defaults to On-Demand when there is no standard OSD quota', () => {
+      mockUseGetBillingQuotas.mockReturnValue({
+        ...defaultQuotas,
+        standardOsd: false,
+      });
+
+      render(buildTestComponent(false, { ...defaultQuotas, standardOsd: false }));
+
+      const onDemandRadioOption = screen.getByRole('radio', {
+        name: /On-Demand: Flexible usage billed through/i,
+      });
+
+      expect(onDemandRadioOption).toBeChecked();
+    });
   });
 
   describe('When creating a cluster coming from google cloud console', () => {
@@ -123,18 +161,14 @@ describe('<BillingModel />', () => {
       expect(screen.getByText(/On-Demand: Flexible usage billed through/i)).toBeInTheDocument();
     });
 
-    it('has On-Demand selected by default', async () => {
+    it('has On-Demand selected by default', () => {
       render(buildTestComponent(true));
 
       const onDemandRadioOption = screen.getByRole('radio', {
         name: /On-Demand: Flexible usage billed through/i,
       });
       expect(onDemandRadioOption).toBeInTheDocument();
-
-      // Wait for the useEffect to update the billing model
-      await waitFor(() => {
-        expect(onDemandRadioOption).toBeChecked();
-      });
+      expect(onDemandRadioOption).toBeChecked();
     });
 
     it('displays only customer cloud subscription infrastructure option', () => {

--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Formik } from 'formik';
 
 import { useIsOSDFromGoogleCloud } from '~/components/clusters/wizards/osd/useIsOSDFromGoogleCloud';
-import { checkAccessibility, render, screen, waitFor } from '~/testUtils';
+import { checkAccessibility, render, screen } from '~/testUtils';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
 import { FieldId, initialValues } from '../constants';

--- a/src/components/clusters/wizards/osd/BillingModel/BillingModel.tsx
+++ b/src/components/clusters/wizards/osd/BillingModel/BillingModel.tsx
@@ -35,6 +35,7 @@ import CreateOSDWizardIntro from '~/styles/images/CreateOSDWizard-intro.png';
 import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
 
 import { useGetBillingQuotas } from './useGetBillingQuotas';
+import { getDefaultByoc } from './utils';
 
 import './BillingModel.scss';
 
@@ -147,25 +148,13 @@ export const BillingModel = () => {
       }
     }
 
-    // Select marketplace billing if user only has marketplace quota
-    // Also, if the selected default billing model is disabled
-    // Default to marketplace
-    if (
-      (!showOsdTrial || billingModel === SubscriptionCommonFieldsClusterBillingModel.standard) &&
-      quotas.marketplace &&
-      !quotas.standardOsd &&
-      !billingModel.startsWith(SubscriptionCommonFieldsClusterBillingModel.marketplace)
-    ) {
-      setFieldValue(FieldId.BillingModel, SubscriptionCommonFieldsClusterBillingModel.marketplace);
-    }
-
     clearPreviousVersionsReponse();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     product,
     billingModel,
     showOsdTrial,
-    quotas.marketplace,
+    quotas.gcpResources,
     quotas.standardOsd,
     selectedMarketplace,
   ]);
@@ -209,10 +198,6 @@ export const BillingModel = () => {
   const onBillingModelChange = (_event: React.FormEvent<HTMLDivElement>, value: string) => {
     let selectedProduct = normalizedProducts.OSD;
 
-    if (value !== SubscriptionCommonFieldsClusterBillingModel.standard) {
-      setFieldValue(FieldId.Byoc, 'true');
-    }
-
     if (value === STANDARD_TRIAL_BILLING_MODEL_TYPE) {
       selectedProduct = normalizedProducts.OSDTrial;
     }
@@ -222,6 +207,7 @@ export const BillingModel = () => {
       setFieldValue(FieldId.CloudProvider, CloudProviderType.Gcp, false);
     }
 
+    setFieldValue(FieldId.Byoc, getDefaultByoc(quotas, value));
     setFieldValue(FieldId.Product, selectedProduct);
   };
 

--- a/src/components/clusters/wizards/osd/BillingModel/utils.ts
+++ b/src/components/clusters/wizards/osd/BillingModel/utils.ts
@@ -1,0 +1,29 @@
+import { SubscriptionCommonFieldsCluster_billing_model as SubscriptionCommonFieldsClusterBillingModel } from '~/types/accounts_mgmt.v1';
+
+import type { useGetBillingQuotas } from './useGetBillingQuotas';
+
+export type BillingQuotas = ReturnType<typeof useGetBillingQuotas>;
+
+export const getDefaultBillingModel = (
+  quotas: BillingQuotas,
+): SubscriptionCommonFieldsClusterBillingModel => {
+  if (!quotas.standardOsd) {
+    return SubscriptionCommonFieldsClusterBillingModel.marketplace_gcp;
+  }
+
+  return SubscriptionCommonFieldsClusterBillingModel.standard;
+};
+
+export const getDefaultByoc = (quotas: BillingQuotas, billingModel: string): 'true' | 'false' => {
+  const isMarketplace = billingModel.startsWith(
+    SubscriptionCommonFieldsClusterBillingModel.marketplace,
+  );
+  const isByocQuotaDisabled = isMarketplace ? !quotas.marketplaceByoc : !quotas.byoc;
+  const isRhInfraQuotaDisabled = isMarketplace ? !quotas.marketplaceRhInfra : !quotas.rhInfra;
+
+  if (isByocQuotaDisabled && !isRhInfraQuotaDisabled) {
+    return 'false';
+  }
+
+  return 'true';
+};

--- a/src/components/clusters/wizards/osd/CreateOsdWizard.tsx
+++ b/src/components/clusters/wizards/osd/CreateOsdWizard.tsx
@@ -47,6 +47,8 @@ import { ErrorState } from '~/types/types';
 import { QuotaTypes } from '../../common/quotaModel';
 import { useClusterWizardResetStepsHook } from '../hooks/useClusterWizardResetStepsHook';
 
+import { useGetBillingQuotas } from './BillingModel/useGetBillingQuotas';
+import { getDefaultBillingModel, getDefaultByoc } from './BillingModel/utils';
 import { CloudProviderType } from './ClusterSettings/CloudProvider/types';
 import { BillingModel } from './BillingModel';
 import {
@@ -294,6 +296,8 @@ export const CreateOsdWizard = ({
   const persistentStorageValues = useGlobalState((state) => state.persistentStorageValues);
   const loadBalancerValues = useGlobalState((state) => state.loadBalancerValues);
   const organization = useGlobalState((state) => state.userProfile.organization);
+  const billingQuotas = useGetBillingQuotas({ product: product || initialValues[FieldId.Product] });
+  const billingModel = getDefaultBillingModel(billingQuotas);
 
   usePreventBrowserNav();
 
@@ -338,6 +342,10 @@ export const CreateOsdWizard = ({
   const defaultInitialValues = {
     ...initialValues,
     ...(product && { product }),
+    ...(organization.fulfilled && {
+      [FieldId.BillingModel]: billingModel,
+      [FieldId.Byoc]: getDefaultByoc(billingQuotas, billingModel),
+    }),
     // WIF is now unconditionally the default auth type (set in initialValues)
     ...(isOSDFromGoogleCloud && {
       [FieldId.InstallToVpc]: true,
@@ -345,12 +353,14 @@ export const CreateOsdWizard = ({
       [FieldId.Byoc]: 'true',
     }),
   };
+
   const contextValue = useMemo(() => ({ isOSDFromGoogleCloud }), [isOSDFromGoogleCloud]);
   return (
     <AppPage title={documentTitle}>
       <OsdWizardContext.Provider value={contextValue}>
         <Formik
           initialValues={defaultInitialValues}
+          enableReinitialize
           initialTouched={initialTouched}
           validate={osdWizardFormValidator}
           validateOnChange={false}


### PR DESCRIPTION
# Summary

The OSD wizard used static `initialValues` for billing model and byoc with no quota based correction, so defaults could disagree with what the org actually has. That caused disabled subscription/infra options to appear selected or non selected and next enabled. 
This PR sets billing model and byoc based on quota when the wizard loads.
# Jira

Fixes [OCMUI-4729](https://redhat.atlassian.net/browse/OCMUI-4729)

# Additional information

This fix sets the default values when the wizard renders (once quota is loaded) according to quota.


# How to Test

** When testing make sure in review and create screen subscription and byoc matches the chosen options.

**Subscription type:**

1. Use the [myquota](https://gitlab.cee.redhat.com/openshift-group-I/myquota) tool to remove OSD quota (cluster|general-purpose|single|rhinfra|osd|any)
2. Open the OSD wizard 
3. On the billing model page, on-demand subscription should be chosen
4. Follow the wizard steps and on the overview page observe the billing model is on-demand

**Infrastructure type:**

1. Add back the OSD quota
2. Use the [myquota](https://gitlab.cee.redhat.com/openshift-group-I/myquota) tool to remove CCS quota (MW01371 cluster|byoc|osd)
3. Open the OSD wizard 
4. In the infra type section, 'Red Hat cloud account' should be chosen


# Screen Captures

**Subscription type:**

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="1305" height="752" alt="image" src="https://github.com/user-attachments/assets/7acbb0d0-e34e-486a-8e77-f42c4bde1aac" /> | <img width="1305" height="752" alt="image" src="https://github.com/user-attachments/assets/5d4f572b-7135-45bd-bc7c-d2f47182b8af" /> |

**Infrastructure type:**

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
|<img width="1380" height="879" alt="image" src="https://github.com/user-attachments/assets/d3698e12-6473-44d1-a629-865c97f5d03e" />| <img width="1380" height="879" alt="image" src="https://github.com/user-attachments/assets/0b8319ab-cc1b-40a1-af9d-659c8c275995" />|

# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4729]: https://redhat.atlassian.net/browse/OCMUI-4729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ