### PR TITLE
OCMUI-4727 - Autonode field is shown when viewing a deleted cluster

### DIFF
--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -488,7 +488,7 @@ function DetailsRight({
         </DescriptionListGroup>
       )}
       {/* Autonode */}
-      {isAutoNodeAllowed && (
+      {isAutoNodeAllowed && !isArchivedSubscription(cluster) && (
         <>
           {isEditAutoNodeModalOpen && (
             <EditAutoNodeModal cluster={cluster} region={region} onClose={closeEditAutoNodeModal} />

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.jsx
@@ -187,6 +187,8 @@ function DetailsRight({
   const infraDesiredNodes = get(cluster, 'nodes.infra', '-');
   const cloudProviderId = get(cluster, 'cloud_provider.id', '-');
   const autoNodeCount = cluster?.auto_node?.status?.node_count;
+  const showAutoNodeCount =
+    isAutoNodeAllowed && !isArchivedSubscription(cluster) && autoNodeCount != null;
 
   const workerActualNodes = totalActualNodes === false ? '-' : totalActualNodes;
   const workerDesiredNodes = totalDesiredComputeNodes || '-';
@@ -351,9 +353,7 @@ function DetailsRight({
                       : 'N/A'}
                   </dd>
                 </Flex>
-                {isAutoNodeAllowed && autoNodeCount != null && (
-                  <AutoNodeKarpenterCount count={autoNodeCount} />
-                )}
+                {showAutoNodeCount && <AutoNodeKarpenterCount count={autoNodeCount} />}
               </dl>
             </DescriptionListDescription>
           </DescriptionListGroup>
@@ -378,9 +378,7 @@ function DetailsRight({
                   <dt>Compute: </dt>
                   <dd>{totalActualNodes || 'N/A'}</dd>
                 </Flex>
-                {isAutoNodeAllowed && autoNodeCount != null && (
-                  <AutoNodeKarpenterCount count={autoNodeCount} />
-                )}
+                {showAutoNodeCount && <AutoNodeKarpenterCount count={autoNodeCount} />}
               </dl>
             </DescriptionListDescription>
           </DescriptionListGroup>

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -1050,6 +1050,50 @@ describe('<DetailsRight />', () => {
           expect(screen.queryByTestId('autoNodeKarpenterCountContainer')).not.toBeInTheDocument();
         });
 
+        it('hides Autonode Karpenter count when cluster subscription is archived', () => {
+          mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
+          const clusterFixture = defaultProps.cluster;
+          const newProps = {
+            ...defaultProps,
+            cluster: {
+              ...clusterFixture,
+              managed: true,
+              hypershift: { enabled: true },
+              auto_node: { mode: 'enabled', status: { node_count: 5 } },
+              subscription: {
+                ...clusterFixture.subscription,
+                status: SubscriptionCommonFieldsStatus.Archived,
+              },
+            },
+          };
+          useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+          render(<DetailsRight {...newProps} />);
+
+          expect(screen.queryByTestId('autoNodeKarpenterCountContainer')).not.toBeInTheDocument();
+        });
+
+        it('hides Autonode Karpenter count when cluster subscription is deprovisioned', () => {
+          mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
+          const clusterFixture = defaultProps.cluster;
+          const newProps = {
+            ...defaultProps,
+            cluster: {
+              ...clusterFixture,
+              managed: true,
+              hypershift: { enabled: true },
+              auto_node: { mode: 'enabled', status: { node_count: 5 } },
+              subscription: {
+                ...clusterFixture.subscription,
+                status: SubscriptionCommonFieldsStatus.Deprovisioned,
+              },
+            },
+          };
+          useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+          render(<DetailsRight {...newProps} />);
+
+          expect(screen.queryByTestId('autoNodeKarpenterCountContainer')).not.toBeInTheDocument();
+        });
+
         it('shows Autonode Karpenter count in autoscaled nodes view', () => {
           mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
           const clusterFixture = defaultProps.cluster;

--- a/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
+++ b/src/components/clusters/ClusterDetailsMultiRegion/components/Overview/DetailsRight/DetailsRight.test.jsx
@@ -1798,6 +1798,48 @@ describe('<DetailsRight />', () => {
       expect(screen.queryByTestId('autoNodeStatus')).not.toBeInTheDocument();
     });
 
+    it('hides Autonode section when cluster subscription is archived', () => {
+      mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
+      const clusterFixture = defaultProps.cluster;
+      const newProps = {
+        ...defaultProps,
+        cluster: {
+          ...clusterFixture,
+          hypershift: { enabled: true },
+          auto_node: { mode: 'enabled' },
+          subscription: {
+            ...clusterFixture.subscription,
+            status: SubscriptionCommonFieldsStatus.Archived,
+          },
+        },
+      };
+      useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.queryByTestId('autoNodeStatus')).not.toBeInTheDocument();
+    });
+
+    it('hides Autonode section when cluster subscription is deprovisioned', () => {
+      mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
+      const clusterFixture = defaultProps.cluster;
+      const newProps = {
+        ...defaultProps,
+        cluster: {
+          ...clusterFixture,
+          hypershift: { enabled: true },
+          auto_node: { mode: 'enabled' },
+          subscription: {
+            ...clusterFixture.subscription,
+            status: SubscriptionCommonFieldsStatus.Deprovisioned,
+          },
+        },
+      };
+      useFetchMachineOrNodePools.mockReturnValue({ data: [] });
+      render(<DetailsRight {...newProps} />);
+
+      expect(screen.queryByTestId('autoNodeStatus')).not.toBeInTheDocument();
+    });
+
     it('shows "Disabled" when auto_node is undefined', () => {
       mockUseFeatureGate([[ENABLE_AUTO_NODE, true]]);
       const clusterFixture = defaultProps.cluster;


### PR DESCRIPTION
# Summary

This PR adds a small fix to hide the Autonode field or archived or deprovisioned clusters 

# Jira


Fixes [OCMUI-4727](https://issues.redhat.com/browse/OCMUI-4727)



# How to Test

1. From the Clusters list page `/openshift/clusters/list` click the "View cluster archives" option in the toolbar
2. Find any archived Rosa HCP cluster and go to the cluster's cluster details
3. On the cluster overview page, check that the "Red Hat Build of Karpenter (Autonode)" field is not shown

# Screen Captures

| Before                                              | After                                   |
| --------------------------------------------------- | --------------------------------------- |
| <img width="451" height="729" alt="ocmui4727_before" src="https://github.com/user-attachments/assets/ee906f7f-ac0e-4ced-9567-17ec32a48394" /> | <img width="511" height="694" alt="ocmui4727_after" src="https://github.com/user-attachments/assets/5ac83fee-cd0b-475c-ba0e-b2d3c8ae521a" /> |



# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4727]: https://redhat.atlassian.net/browse/OCMUI-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ