### PR TITLE
[OCMUI-4806] Reduce parallel workers for playwright from 2 to 1

### DIFF
--- a/.github/workflows/e2e-smoke-playwright.yml
+++ b/.github/workflows/e2e-smoke-playwright.yml
@@ -46,7 +46,7 @@ on:
       workers:
         description: 'Number of parallel workers'
         required: false
-        default: '2'
+        default: '1'
         type: string
 
 jobs:
@@ -312,7 +312,7 @@ jobs:
           export TEST_WITHQUOTA_PASSWORD=$(jq -r '.QE_ORGADMIN_PASSWORD // empty' playwright.env.json)
 
           GREP_PATTERN="${{ inputs.grep_tags || '@smoke' }}"
-          WORKERS="${{ inputs.workers || '2' }}"
+          WORKERS="${{ inputs.workers || '1' }}"
           EUT="${{ inputs.EUT || 'staging' }}"
 
           echo "Running tests with pattern: $GREP_PATTERN"
@@ -427,7 +427,7 @@ jobs:
                     },
                     {
                       "title": "Workers",
-                      "value": "${{ inputs.workers || '2' }}",
+                      "value": "${{ inputs.workers || '1' }}",
                       "short": true
                     },
                     {


### PR DESCRIPTION
# Summary
When GHA runs Playwright smoke, requests come from GitHub’s runner IP pools, not Konflux. Those IPs change and are not on Akamai’s allowlist today which is causing the smoke test to fail. We are looking into workarounds to reduce parallel workers for playwright e2e smoke workflow from 2 to 1

# Jira
Fixes [OCMUI-4806](https://issues.redhat.com/browse/OCMUI-4806) 

# Additional information
GHA smoke hits staging directly → burst of POST/navigation → Akamai “Non-GET-HEAD Requests” lockouts
Refer failing jobs [here](https://github.com/RedHatInsights/uhc-portal/actions/runs/28926318842). This ticket is a follow up of OCMUI-4728 to further reduce default parallel workers from 2 to 1 to bypass the rate-limit failures temporarily until we get a full clarity on the infrastructure issues


# How to Test

This change is applicable only for playwright smoke github workflow and could be only tested after merge.

Reference report for playwright execution with 1 worker is [here](https://github.com/RedHatInsights/uhc-portal/actions/runs/28976439378)


# Review process

Please review and follow the [PR process](https://github.com/RedHatInsights/uhc-portal/blob/main/docs/pull-request-process.md).

## QE Reviewer

- [ ] _Pre-merge testing : Verified change locally in a browser (downloaded and ran code using reviewx tool)_
- [ ] Updated/created Polarion test cases which were peer QE reviewed
- [ ] Confirmed 'tc-approved' label was added by dev to the linked JIRA ticket
- [ ] (optional) Updated/created Cypress e2e tests
- [ ] Closed threads I started after the author made changes or added an explanation


[OCMUI-4806]: https://redhat.atlassian.net/browse/OCMUI-4806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ